### PR TITLE
ADIF 3.1.7 support (v1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2026-05-16
+
+### Added
+
+* **ADIF 3.1.7 specification support**. Full official 3.1.7 JSON resources from [adif.org.uk](https://adif.org.uk/317/) installed alongside the sealed 3.1.6 set. New enum entries (pure additive — no breaking changes):
+  - New Mode: **OFDM** (Orthogonal Frequency-Division Multiplexing including COFDM)
+  - New Submode: **FT2** (Mode MFSK)
+  - New Submode: **FREEDATA** (Mode DYNAMIC)
+  - New Submode: **RIBBIT_PIX** (Mode OFDM — Images transmitted using Ribbit)
+  - New Submode: **RIBBIT_SMS** (Mode OFDM)
+* `src/adif_mcp/resources/spec/317/` — full 30-file canonical 3.1.7 JSON set (29 official from upstream ZIP + project-internal `enumerations_country.json` carried forward).
+* Test corpus `test/data/ADIF_317_test_QSOs_2026_03_22.adi` (6,197 records, +6 over 3.1.6) — official G3ZOD-generated file from upstream `ADIF_317_resources_2026_03_22.zip`.
+* New tests covering the 5 new enum entries (`test_317_new_mode_ofdm`, `test_317_new_submode_ft2`, `test_317_new_submode_freedata`, `test_317_new_submode_ribbit_pix`, `test_317_new_submode_ribbit_sms`, `test_317_submode_count`).
+
+### Changed
+
+* Default spec set switched to **3.1.7** (`__adif_spec__`, `[tool.adif] spec_version`, `[tool.adif_mcp] spec`, `get_spec_text(version=...)` default).
+* `test_list_enumerations_has_mode` — Mode record count expectation 90 → 91. Import-only count stays 42 (OFDM is not import-only).
+* `test_official_adif_test_file_zero_errors` — switched to the 3.1.7 corpus, record count 6191 → 6197.
+* `test_pkg_meta_exposed` — accepted `__adif_spec__` set now includes "3.1.7".
+* Docstrings, README, and project URLs updated to reference 3.1.7.
+
+### Preserved
+
+* `src/adif_mcp/resources/spec/316/` — sealed and untouched. Callers explicitly pinning to 3.1.6 continue to work via `get_spec_text(filename, version="316")`.
+* `test/data/ADIF_316_test_QSOs_2025_09_15.adi` — sealed for regression reference.
+
+### Reference
+
+* Upstream spec changes: https://adif.org.uk/317/ADIF_317_annotated.htm
+* Tracks fleet rollout pattern from IONIS-AI/ionis-devel#49 (also bumps `get_version_info`'s reported `adif_spec_version` from `3.1.6` to `3.1.7`).
+
 ## [0.4.4] - 2025-12-28
 
 ### **Added**

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <!-- mcp-name: io.github.qso-graph/adif-mcp -->
 # adif-mcp
 
-Core [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for **Amateur Radio Logging**, built on the [ADIF 3.1.6 specification](https://adif.org.uk/316/ADIF_316.htm).
+Core [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for **Amateur Radio Logging**, built on the [ADIF 3.1.7 specification](https://adif.org.uk/317/ADIF_317.htm).
 
 ## Overview
 
-adif-mcp gives AI agents safe, typed access to Amateur Radio logging data. It validates and parses ADIF records, searches the full ADIF 3.1.6 specification (fields, enumerations, data types), and provides geospatial utilities for Maidenhead locators.
+adif-mcp gives AI agents safe, typed access to Amateur Radio logging data. It validates and parses ADIF records, searches the full ADIF 3.1.7 specification (fields, enumerations, data types), and provides geospatial utilities for Maidenhead locators.
 
 [![Made with Python](https://img.shields.io/badge/Made%20with-Python-blue)](https://www.python.org/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](LICENSE)
-[![ADIF 3.1.6](https://img.shields.io/badge/ADIF-3.1.6-blue)](https://adif.org.uk/316/ADIF_316.htm)
+[![ADIF 3.1.7](https://img.shields.io/badge/ADIF-3.1.7-blue)](https://adif.org.uk/317/ADIF_317.htm)
 [![PyPI](https://img.shields.io/pypi/v/adif-mcp)](https://pypi.org/project/adif-mcp/)
 [![CI](https://github.com/qso-graph/adif-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/qso-graph/adif-mcp/actions/workflows/ci.yml)
 [![Docs](https://img.shields.io/badge/docs-qso--graph.io-blue)](https://qso-graph.io/)
@@ -114,7 +114,7 @@ adif-mcp exposes **8 tools** via the Model Context Protocol:
 
 | Category | Tool | Description |
 |----------|------|-------------|
-| **Validation** | `validate_adif_record` | Validate a raw ADIF string against the 3.1.6 spec |
+| **Validation** | `validate_adif_record` | Validate a raw ADIF string against the 3.1.7 spec |
 | **Validation** | `parse_adif` | Streaming parser for large ADIF files with pagination |
 | **Spec** | `read_specification_resource` | Retrieve raw JSON for any spec module (band, mode, fields) |
 | **Spec** | `list_enumerations` | List all ADIF enumerations with entry counts |
@@ -130,7 +130,7 @@ adif-mcp is the **ADIF specification package** -- validation, parsing, and geosp
 | Package | PyPI | What It Does |
 |---------|------|-------------|
 | [`qso-graph-auth`](https://pypi.org/project/qso-graph-auth/) | v0.1.1 | OS keyring credential management, persona CRUD |
-| [`adif-mcp`](https://pypi.org/project/adif-mcp/) | v1.0.5 | ADIF 3.1.6 spec tools, validation, parsing, geospatial |
+| [`adif-mcp`](https://pypi.org/project/adif-mcp/) | v1.1.0 | ADIF 3.1.7 spec tools, validation, parsing, geospatial |
 | [`eqsl-mcp`](https://pypi.org/project/eqsl-mcp/) | v0.3.1 | eQSL inbox, verification, AG status, last upload |
 | [`qrz-mcp`](https://pypi.org/project/qrz-mcp/) | v0.3.1 | Callsign lookup, DXCC, logbook status/fetch |
 | [`lotw-mcp`](https://pypi.org/project/lotw-mcp/) | v0.3.1 | LoTW confirmations, QSOs, DXCC credits, user activity |
@@ -148,7 +148,7 @@ Authenticated servers use [qso-graph-auth](https://pypi.org/project/qso-graph-au
 
 ## Compliance & Provenance
 
-adif-mcp follows the [ADIF Specification](https://adif.org.uk) (currently 3.1.6) and uses **registered Program IDs** to identify all exports:
+adif-mcp follows the [ADIF Specification](https://adif.org.uk) (currently 3.1.7) and uses **registered Program IDs** to identify all exports:
 
 - `ADIF-MCP` -- Core engine
 - `ADIF-MCP-LOTW` -- LoTW server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adif-mcp"
-version = "1.0.5"
+version = "1.1.0"
 description = "ADIF MCP server — spec parsing, validation, and field enumeration tools"
 readme = "README.md"
 license = { text = "GPL-3.0-or-later" }
@@ -84,7 +84,7 @@ Homepage = "https://qso-graph.io"
 Documentation = "https://qso-graph.io"
 Repository = "https://github.com/qso-graph/adif-mcp"
 Issues = "https://github.com/qso-graph/adif-mcp/issues"
-"ADIF Specification" = "https://adif.org.uk/316/ADIF_316.htm"
+"ADIF Specification" = "https://adif.org.uk/317/ADIF_317.htm"
 
 [project.scripts]
 adif-mcp = "adif_mcp.cli.__main__:main"
@@ -93,7 +93,7 @@ adif-mcp = "adif_mcp.cli.__main__:main"
 # ADIF tool config (OS-agnostic & SSOT-ish; helpers interpret it)
 # --------------------------------------------------------------------
 [tool.adif]
-spec_version = "3.1.6"
+spec_version = "3.1.7"
 features = ["core QSO model", "band/mode/QSL_RCVD enums"]
 
 [tool.adif_mcp]
@@ -103,7 +103,7 @@ meta_output = "adif_meta.json"
 personas_index = "personas.json"
 providers_dir = "providers"
 schemas = "adif_catalog.json"
-spec = "ADIF_316"
+spec = "ADIF_317"
 
 [tool.pytest.ini_options]
 testpaths = ["test"]

--- a/src/adif_mcp/__init__.py
+++ b/src/adif_mcp/__init__.py
@@ -11,4 +11,4 @@ except PackageNotFoundError:  # local dev / editable installs without dist metad
     _pkg_version = "0.0.0"
 
 __version__: Final[str] = _pkg_version
-__adif_spec__: Final[str] = "3.1.6"
+__adif_spec__: Final[str] = "3.1.7"

--- a/src/adif_mcp/adif_meta.json
+++ b/src/adif_mcp/adif_meta.json
@@ -4,5 +4,5 @@
     "core QSO model",
     "band/mode/QSL_RCVD enums"
   ],
-  "spec_version": "3.1.6"
+  "spec_version": "3.1.7"
 }

--- a/src/adif_mcp/cli/__init__.py
+++ b/src/adif_mcp/cli/__init__.py
@@ -20,7 +20,7 @@ except PackageNotFoundError:  # local dev / editable installs without dist metad
     _pkg_version = "0.0.0"
 
 __version__: Final[str] = _pkg_version
-__adif_spec__: Final[str] = "3.1.6"
+__adif_spec__: Final[str] = "3.1.7"
 
 __all__: list[str] = []
 

--- a/src/adif_mcp/dev/build_hooks.py
+++ b/src/adif_mcp/dev/build_hooks.py
@@ -5,7 +5,7 @@ Hatch build hook: writes ADIF metadata from pyproject.toml into the package.
 During `uv build` / `hatchling` builds, this hook reads:
 
   [tool.adif]
-  spec_version = "3.1.6"
+  spec_version = "3.1.7"
   features = ["core QSO model", "band/mode/QSL_RCVD enums"]
 
 …and emits `src/adif_mcp/adif_meta.json` so the wheel/sdist contains a

--- a/src/adif_mcp/mcp/server.py
+++ b/src/adif_mcp/mcp/server.py
@@ -1,5 +1,5 @@
 """
-ADIF-MCP Server: Authoritative 3.1.6 Specification Server.
+ADIF-MCP Server: Authoritative 3.1.7 Specification Server.
 
 Provides tools for parsing, streaming, and validating ADIF data.
 """
@@ -412,8 +412,8 @@ def _validate_time(field_name: str, value: str) -> List[str]:
 # --- Spec File Loader ---
 
 
-def get_spec_text(filename: str, version: str = "316") -> str:
-    """Retrieve raw text of a 3.1.6 specification JSON file."""
+def get_spec_text(filename: str, version: str = "317") -> str:
+    """Retrieve raw text of a 3.1.7 specification JSON file."""
     current_dir = os.path.dirname(os.path.abspath(__file__))
     json_dir = os.path.abspath(
         os.path.join(current_dir, "..", "resources", "spec", version)
@@ -539,13 +539,13 @@ async def parse_adif(
 
 @mcp.tool()
 def read_specification_resource(resource_name: str) -> str:
-    """Reads an ADIF 3.1.6 specification resource (e.g., 'mode')."""
+    """Reads an ADIF 3.1.7 specification resource (e.g., 'mode')."""
     return get_spec_text(resource_name)
 
 
 @mcp.tool()
 def list_enumerations() -> Dict[str, Any]:
-    """Lists all 25 ADIF 3.1.6 enumerations with record counts and fields."""
+    """Lists all 25 ADIF 3.1.7 enumerations with record counts and fields."""
     result: Dict[str, Any] = {}
     for enum_name, fields in ENUMERATION_FIELDS.items():
         records = _load_enum_records(enum_name)
@@ -566,7 +566,7 @@ def search_enumerations(
     search_term: str,
     enumeration: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Searches ADIF 3.1.6 enumerations. Optionally filter by enumeration name."""
+    """Searches ADIF 3.1.7 enumerations. Optionally filter by enumeration name."""
     term = search_term.upper().strip()
     if not term:
         return {"error": "Search term must not be empty."}
@@ -619,7 +619,7 @@ def search_enumerations(
 
 @mcp.tool()
 def validate_adif_record(adif_string: str) -> Dict[str, Any]:
-    """Validates an ADIF record against 3.1.6 rules including enum membership."""
+    """Validates an ADIF record against 3.1.7 rules including enum membership."""
     parsed = parse_adif_internal(adif_string)
 
     try:

--- a/src/adif_mcp/models/qso.py
+++ b/src/adif_mcp/models/qso.py
@@ -1,4 +1,4 @@
-"""ADIF 3.1.6 QSO Model definition."""
+"""ADIF 3.1.7 QSO Model definition."""
 
 from datetime import date, time
 from typing import Optional
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, field_validator
 
 class QSO(BaseModel):
     """
-    Represents a single ADIF 3.1.6 QSO record.
+    Represents a single ADIF 3.1.7 QSO record.
 
     Strictly typed to prevent hallucinations and ensure protocol integrity.
     """

--- a/src/adif_mcp/resources/schemas/__init__.py
+++ b/src/adif_mcp/resources/schemas/__init__.py
@@ -1,0 +1,6 @@
+"""JSON Schemas bundled with adif-mcp.
+
+Currently contains:
+  - manifest.v1.json — schema for src/adif_mcp/mcp/manifest.json validation
+    (consumed by the `adif-mcp validate-manifest` CLI command).
+"""

--- a/src/adif_mcp/resources/schemas/manifest.v1.json
+++ b/src/adif_mcp/resources/schemas/manifest.v1.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://qso-graph.io/schemas/adif-mcp/manifest.v1.json",
+  "title": "adif-mcp manifest schema (v1)",
+  "description": "JSON Schema validating src/adif_mcp/mcp/manifest.json — the declarative description of the adif-mcp MCP server, its tool surface, and the shared QSO record schema.",
+  "type": "object",
+  "required": ["schema_version", "name", "version", "description", "tools"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Manifest schema major version (e.g. '1.0'). Bumped when the manifest contract changes incompatibly.",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "name": {
+      "type": "string",
+      "description": "MCP server name (matches PyPI package name).",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "description": "Manifest content version — semver-shaped.",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "description": "One-line description of the server.",
+      "minLength": 1
+    },
+    "components": {
+      "type": "object",
+      "description": "Reusable shared schemas referenced by tool input/output definitions.",
+      "additionalProperties": true,
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "description": "Map of schema name → JSON Schema. Referenced from tools via $ref: '#/components/schemas/<Name>'.",
+          "additionalProperties": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "tools": {
+      "type": "array",
+      "description": "MCP tools exposed by this server. Each entry declares its input/output contract.",
+      "items": {
+        "type": "object",
+        "required": ["name", "description"],
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Fully-qualified tool name (e.g. 'eqsl.fetch_inbox').",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable description of what the tool does.",
+            "minLength": 1
+          },
+          "input_schema": {
+            "type": "object",
+            "description": "JSON Schema describing the tool's expected input arguments."
+          },
+          "output_schema": {
+            "type": "object",
+            "description": "JSON Schema describing the tool's response shape."
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/adif_mcp/resources/spec/317/all.json
+++ b/src/adif_mcp/resources/spec/317/all.json
@@ -1,0 +1,22525 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:31Z",
+    "DataTypes": {
+      "Header": [
+        "Data Type Name",
+        "Data Type Indicator",
+        "Description",
+        "Minimum Value",
+        "Maximum Value",
+        "Import-only",
+        "Comments"
+      ],
+      "Records": {
+        "AwardList": {
+          "Data Type Name": "AwardList",
+          "Description": "a comma-delimited list of members of the Award enumeration",
+          "Import-only": "true"
+        },
+        "CreditList": {
+          "Data Type Name": "CreditList",
+          "Description": "a comma-delimited list where each list item is either: A member of the Credit enumeration. A member of the Credit enumeration followed by a colon and an ampersand-delimited list of members of the QSL_Medium enumeration. For example IOTA,WAS:LOTW\u0026CARD,DXCC:CARD"
+        },
+        "SponsoredAwardList": {
+          "Data Type Name": "SponsoredAwardList",
+          "Description": "a comma-delimited list of members of the Sponsored_Award enumeration"
+        },
+        "Boolean": {
+          "Data Type Name": "Boolean",
+          "Data Type Indicator": "B",
+          "Description": "if True, the single ASCII character Y or y if False, the single ASCII character N or n"
+        },
+        "Digit": {
+          "Data Type Name": "Digit",
+          "Description": "an ASCII character whose code lies in the range of 48 through 57, inclusive"
+        },
+        "Integer": {
+          "Data Type Name": "Integer",
+          "Description": "a sequence of one or more Digits representing a decimal integer, optionally preceded by a minus sign (ASCII code 45). Leading zeroes are allowed."
+        },
+        "Number": {
+          "Data Type Name": "Number",
+          "Data Type Indicator": "N",
+          "Description": "a sequence of one or more Digits representing a decimal number, optionally preceded by a minus sign (ASCII code 45) and optionally including a single decimal point (ASCII code 46)"
+        },
+        "PositiveInteger": {
+          "Data Type Name": "PositiveInteger",
+          "Description": "an unsigned sequence of one or more Digits representing a decimal integer that has a value greater than 0. Leading zeroes are allowed.",
+          "Minimum Value": "1"
+        },
+        "Character": {
+          "Data Type Name": "Character",
+          "Description": "an ASCII character whose code lies in the range of 32 through 126, inclusive"
+        },
+        "IntlCharacter": {
+          "Data Type Name": "IntlCharacter",
+          "Description": "a Unicode character (encoded with UTF-8) excluding line break CR (code 13) and LF (code 10) characters"
+        },
+        "Date": {
+          "Data Type Name": "Date",
+          "Data Type Indicator": "D",
+          "Description": "8 Digits representing a UTC date in YYYYMMDD format, where YYYY is a 4-Digit year specifier, where 1930 \u003C= YYYY MM is a 2-Digit month specifier, where 1 \u003C= MM \u003C= 12 [use leading zeroes] DD is a 2-Digit day specifier, where 1 \u003C= DD \u003C= DaysInMonth(MM) [use leading zeroes]"
+        },
+        "Time": {
+          "Data Type Name": "Time",
+          "Data Type Indicator": "T",
+          "Description": "6 Digits representing a UTC time in HHMMSS format or 4 Digits representing a time in HHMM format, where HH is a 2-Digit hour specifier, where 0 \u003C= HH \u003C= 23 [use leading zeroes] MM is a 2-Digit minute specifier, where 0 \u003C= MM \u003C= 59 [use leading zeroes] SS is a 2-Digit second specifier, where 0 \u003C= SS \u003C= 59 [use leading zeroes]"
+        },
+        "IOTARefNo": {
+          "Data Type Name": "IOTARefNo",
+          "Description": "IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "String": {
+          "Data Type Name": "String",
+          "Data Type Indicator": "S",
+          "Description": "a sequence of Characters"
+        },
+        "IntlString": {
+          "Data Type Name": "IntlString",
+          "Data Type Indicator": "I",
+          "Description": "a sequence of International Characters. Fields of type IntlString must only be used in ADX files"
+        },
+        "MultilineString": {
+          "Data Type Name": "MultilineString",
+          "Data Type Indicator": "M",
+          "Description": "a sequence of Characters and line-breaks, where a line break is an ASCII CR (code 13) followed immediately by an ASCII LF (code 10)"
+        },
+        "IntlMultilineString": {
+          "Data Type Name": "IntlMultilineString",
+          "Data Type Indicator": "G",
+          "Description": "a sequence of International Characters and line breaks. Fields of type IntlMultilineString must only be used in ADX files"
+        },
+        "Enumeration": {
+          "Data Type Name": "Enumeration",
+          "Data Type Indicator": "E",
+          "Description": "an explicit list of legal case-insensitive values represented in ASCII set forth in set notation, e.g. {A, B, C, D}, or defined in a table, from which a single value may be selected."
+        },
+        "GridSquare": {
+          "Data Type Name": "GridSquare",
+          "Description": "a case-insensitive 2-character, 4-character, 6-character, or 8-character Maidenhead locator. Specific fields impose additional restrictions on the number of characters; see the field descriptions for the allowed numbers of characters."
+        },
+        "GridSquareExt": {
+          "Data Type Name": "GridSquareExt",
+          "Description": "For a 10-character Maidenhead locator, contains characters 9 and 10. For a 12-character Maidenhead locator, contains characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0-9."
+        },
+        "GridSquareList": {
+          "Data Type Name": "GridSquareList",
+          "Description": "a comma-delimited list of GridSquare items"
+        },
+        "Location": {
+          "Data Type Name": "Location",
+          "Data Type Indicator": "L",
+          "Description": "a sequence of 11 characters representing a latitude or longitude in XDDD MM.MMM format, where X is a directional Character from the set {E, W, N, S} DDD is a 3-Digit degrees specifier, where 0 \u003C= DDD \u003C= 180 [use leading zeroes] There is a single space character in between DDD and MM.MMM MM.MMM is an unsigned Number minutes specifier with its decimal point in the third position, where 00.000 \u003C= MM.MMM \u003C= 59.999 [use leading and trailing zeroes]"
+        },
+        "POTARef": {
+          "Data Type Name": "POTARef",
+          "Description": "a sequence of case-insensitive Characters representing a Parks on the Air park reference in the form xxxx-nnnnn[@yyyyyy] comprising 6 to 17 characters where: xxxx is the POTA national program and is 1 to 4 characters in length, typically the default callsign prefix of the national program (rather than the DX entity) nnnnn represents the unique number within the national program and is either 4 or 5 characters in length (use the exact format listed on the POTA website) yyyyyy **Optional** is the 4 to 6 character ISO 3166-2 code to differentiate which state/province/prefecture/primary administration location the contact represents, in the case that the park reference spans more than one location (such as a trail). Examples of the POTARef Data Type: ReferenceLocation K-5033Golden Hill State Forest K-10000 5-digit park numbers are reserved for future use VE-5082@CA-ABThe Great Trail of Canada (the Canadian Trailway) National Scenic Trail, within Alberta, Canada 8P-0012Chancery Lane Swamp National Park VK-0556Pieman River State Reserve K-4562@US-CAPacific Crest Trail, within California, USA Additional Notes on POTARef: A browsable and searchable list of all park references is available. A complete CSV file is available (generated nightly). For more information, visit the Parks on the Air documentation website."
+        },
+        "POTARefList": {
+          "Data Type Name": "POTARefList",
+          "Description": "a comma-delimited list of one or more POTARef items."
+        },
+        "SecondarySubdivisionList": {
+          "Data Type Name": "SecondarySubdivisionList",
+          "Description": "a colon-delimited list of two or more members of the Secondary_Administrative_Subdivision enumeration. E.g.: MA,Franklin:MA,Hampshire"
+        },
+        "SecondaryAdministrativeSubdivisionListAlt": {
+          "Data Type Name": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of one or more members of a Secondary_Administrative_Subdivision_Alt enumeration in the form: enumeration-name:enumeration-code Where there is more than one locality represented by the enumeration-code, they are separated by slash (/) characters. Only one of each enumeration-name valid for the DXCC entity concerned can appear in the list. Examples: \u003CCNTY_ALT:28\u003ENZ_Regions:Hawkes Bay/Wairoa \u003CMY_CNTY_ALT:52\u003ENZ_Islands:North Island;NZ_Regions:Hawkes Bay/Wairoa The first example shows the enumeration-name NZ_Regions with the region Hawkes Bay and the district Wairoa. For the purposes of illustration, the second example includes a non-existent subdivision with two available enumeration-codes, NZ_Islands:North Island and NZ_Islands:South Island. The example shows: the enumeration-name NZ_Islands with the island North Island the enumeration-name NZ_Regions with the region Hawkes Bay and the district Wairoa"
+        },
+        "SOTARef": {
+          "Data Type Name": "SOTARef",
+          "Description": "a sequence of Characters representing an International SOTA Reference. The sequence comprises: an ITU prefix if applicable, a SOTA subdivision a / Character a SOTA Reference Number Examples: W2/WE-003 G/LD-003"
+        },
+        "WWFFRef": {
+          "Data Type Name": "WWFFRef",
+          "Description": "a sequence of case-insensitive Characters representing an International WWFF (World Wildlife Flora \u0026 Fauna) reference in the form xxFF-nnnn comprising 8 to 11 characters where: xx is the WWFF national program and is 1 to 4 characters in length. FF- is two F characters followed by a dash character. nnnn represents the unique number within the national program and is 4 characters in length with leading zeros. Examples: KFF-4655 3DAFF-0002"
+        }
+      }
+    },
+    "Enumerations": {
+      "Ant_Path": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "G": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "G",
+            "Meaning": "grayline"
+          },
+          "O": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "O",
+            "Meaning": "other"
+          },
+          "S": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "S",
+            "Meaning": "short path"
+          },
+          "L": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "L",
+            "Meaning": "long path"
+          }
+        }
+      },
+      "ARRL_Section": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Section Name",
+          "DXCC Entity Code",
+          "From Date",
+          "Deleted Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AL",
+            "Section Name": "Alabama",
+            "DXCC Entity Code": "291"
+          },
+          "AK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AK",
+            "Section Name": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AB",
+            "Section Name": "Alberta",
+            "DXCC Entity Code": "1"
+          },
+          "AR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AR",
+            "Section Name": "Arkansas",
+            "DXCC Entity Code": "291"
+          },
+          "AZ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AZ",
+            "Section Name": "Arizona",
+            "DXCC Entity Code": "291"
+          },
+          "BC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "BC",
+            "Section Name": "British Columbia",
+            "DXCC Entity Code": "1"
+          },
+          "CO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CO",
+            "Section Name": "Colorado",
+            "DXCC Entity Code": "291"
+          },
+          "CT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CT",
+            "Section Name": "Connecticut",
+            "DXCC Entity Code": "291"
+          },
+          "DE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "DE",
+            "Section Name": "Delaware",
+            "DXCC Entity Code": "291"
+          },
+          "EB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EB",
+            "Section Name": "East Bay",
+            "DXCC Entity Code": "291"
+          },
+          "EMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EMA",
+            "Section Name": "Eastern Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "ENY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ENY",
+            "Section Name": "Eastern New York",
+            "DXCC Entity Code": "291"
+          },
+          "EPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EPA",
+            "Section Name": "Eastern Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "EWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EWA",
+            "Section Name": "Eastern Washington",
+            "DXCC Entity Code": "291"
+          },
+          "GA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GA",
+            "Section Name": "Georgia",
+            "DXCC Entity Code": "291"
+          },
+          "GH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GH",
+            "Section Name": "Golden Horseshoe",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "GTA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GTA",
+            "Section Name": "Greater Toronto Area",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by GH"
+          },
+          "ID": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ID",
+            "Section Name": "Idaho",
+            "DXCC Entity Code": "291"
+          },
+          "IL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IL",
+            "Section Name": "Illinois",
+            "DXCC Entity Code": "291"
+          },
+          "IN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IN",
+            "Section Name": "Indiana",
+            "DXCC Entity Code": "291"
+          },
+          "IA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IA",
+            "Section Name": "Iowa",
+            "DXCC Entity Code": "291"
+          },
+          "KS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KS",
+            "Section Name": "Kansas",
+            "DXCC Entity Code": "291"
+          },
+          "KY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KY",
+            "Section Name": "Kentucky",
+            "DXCC Entity Code": "291"
+          },
+          "LAX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LAX",
+            "Section Name": "Los Angeles",
+            "DXCC Entity Code": "291"
+          },
+          "LA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LA",
+            "Section Name": "Louisiana",
+            "DXCC Entity Code": "291"
+          },
+          "ME": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ME",
+            "Section Name": "Maine",
+            "DXCC Entity Code": "291"
+          },
+          "MB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MB",
+            "Section Name": "Manitoba",
+            "DXCC Entity Code": "1"
+          },
+          "MAR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MAR",
+            "Section Name": "Maritime",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by NB and NS"
+          },
+          "MDC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MDC",
+            "Section Name": "Maryland-DC",
+            "DXCC Entity Code": "291"
+          },
+          "MI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MI",
+            "Section Name": "Michigan",
+            "DXCC Entity Code": "291"
+          },
+          "MN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MN",
+            "Section Name": "Minnesota",
+            "DXCC Entity Code": "291"
+          },
+          "MS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MS",
+            "Section Name": "Mississippi",
+            "DXCC Entity Code": "291"
+          },
+          "MO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MO",
+            "Section Name": "Missouri",
+            "DXCC Entity Code": "291"
+          },
+          "MT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MT",
+            "Section Name": "Montana",
+            "DXCC Entity Code": "291"
+          },
+          "NE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NE",
+            "Section Name": "Nebraska",
+            "DXCC Entity Code": "291"
+          },
+          "NV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NV",
+            "Section Name": "Nevada",
+            "DXCC Entity Code": "291"
+          },
+          "NB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NB",
+            "Section Name": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "NH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NH",
+            "Section Name": "New Hampshire",
+            "DXCC Entity Code": "291"
+          },
+          "NM": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NM",
+            "Section Name": "New Mexico",
+            "DXCC Entity Code": "291"
+          },
+          "NLI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NLI",
+            "Section Name": "New York City-Long Island",
+            "DXCC Entity Code": "291"
+          },
+          "NL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NL",
+            "Section Name": "Newfoundland/Labrador",
+            "DXCC Entity Code": "1"
+          },
+          "NC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NC",
+            "Section Name": "North Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "ND": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ND",
+            "Section Name": "North Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "NTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NTX",
+            "Section Name": "North Texas",
+            "DXCC Entity Code": "291"
+          },
+          "NFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NFL",
+            "Section Name": "Northern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "NNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNJ",
+            "Section Name": "Northern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "NNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNY",
+            "Section Name": "Northern New York",
+            "DXCC Entity Code": "291"
+          },
+          "NT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "From Date": "2003-11-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by TER"
+          },
+          "NWT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NWT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2003-11-01T00:00:00Z",
+            "Comments": "replaced by NT"
+          },
+          "NS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NS",
+            "Section Name": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "OH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OH",
+            "Section Name": "Ohio",
+            "DXCC Entity Code": "291"
+          },
+          "OK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OK",
+            "Section Name": "Oklahoma",
+            "DXCC Entity Code": "291"
+          },
+          "ON": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ON",
+            "Section Name": "Ontario",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2012-09-01T00:00:00Z",
+            "Comments": "replaced by GTA, ONE, ONN, and ONS"
+          },
+          "ONE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONE",
+            "Section Name": "Ontario East",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONN",
+            "Section Name": "Ontario North",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONS",
+            "Section Name": "Ontario South",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ORG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ORG",
+            "Section Name": "Orange",
+            "DXCC Entity Code": "291"
+          },
+          "OR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OR",
+            "Section Name": "Oregon",
+            "DXCC Entity Code": "291"
+          },
+          "PAC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PAC",
+            "Section Name": "Pacific",
+            "DXCC Entity Code": "9,20,103,110,123,138,166,174,197,297,515"
+          },
+          "PE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PE",
+            "Section Name": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "From Date": "2020-04-01T00:00:00Z"
+          },
+          "PR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PR",
+            "Section Name": "Puerto Rico",
+            "DXCC Entity Code": "43,202"
+          },
+          "QC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "QC",
+            "Section Name": "Quebec",
+            "DXCC Entity Code": "1"
+          },
+          "RI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "RI",
+            "Section Name": "Rhode Island",
+            "DXCC Entity Code": "291"
+          },
+          "SV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SV",
+            "Section Name": "Sacramento Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SDG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SDG",
+            "Section Name": "San Diego",
+            "DXCC Entity Code": "291"
+          },
+          "SF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SF",
+            "Section Name": "San Francisco",
+            "DXCC Entity Code": "291"
+          },
+          "SJV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SJV",
+            "Section Name": "San Joaquin Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SB",
+            "Section Name": "Santa Barbara",
+            "DXCC Entity Code": "291"
+          },
+          "SCV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SCV",
+            "Section Name": "Santa Clara Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SK",
+            "Section Name": "Saskatchewan",
+            "DXCC Entity Code": "1"
+          },
+          "SC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SC",
+            "Section Name": "South Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "SD": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SD",
+            "Section Name": "South Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "STX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "STX",
+            "Section Name": "South Texas",
+            "DXCC Entity Code": "291"
+          },
+          "SFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SFL",
+            "Section Name": "Southern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "SNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SNJ",
+            "Section Name": "Southern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "TN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TN",
+            "Section Name": "Tennessee",
+            "DXCC Entity Code": "291"
+          },
+          "TER": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TER",
+            "Section Name": "Territories",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "VI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VI",
+            "Section Name": "US Virgin Islands",
+            "DXCC Entity Code": "105,182,285"
+          },
+          "UT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "UT",
+            "Section Name": "Utah",
+            "DXCC Entity Code": "291"
+          },
+          "VT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VT",
+            "Section Name": "Vermont",
+            "DXCC Entity Code": "291"
+          },
+          "VA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VA",
+            "Section Name": "Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WCF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WCF",
+            "Section Name": "West Central Florida",
+            "DXCC Entity Code": "291"
+          },
+          "WTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WTX",
+            "Section Name": "West Texas",
+            "DXCC Entity Code": "291"
+          },
+          "WV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WV",
+            "Section Name": "West Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WMA",
+            "Section Name": "Western Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "WNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WNY",
+            "Section Name": "Western New York",
+            "DXCC Entity Code": "291"
+          },
+          "WPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WPA",
+            "Section Name": "Western Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "WWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WWA",
+            "Section Name": "Western Washington",
+            "DXCC Entity Code": "291"
+          },
+          "WI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WI",
+            "Section Name": "Wisconsin",
+            "DXCC Entity Code": "291"
+          },
+          "WY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WY",
+            "Section Name": "Wyoming",
+            "DXCC Entity Code": "291"
+          }
+        }
+      },
+      "Award": {
+        "Header": [
+          "Enumeration Name",
+          "Award",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AJA": {
+            "Enumeration Name": "Award",
+            "Award": "AJA",
+            "Import-only": "true"
+          },
+          "CQDX": {
+            "Enumeration Name": "Award",
+            "Award": "CQDX",
+            "Import-only": "true"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Award",
+            "Award": "CQDXFIELD",
+            "Import-only": "true"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_MIXED",
+            "Import-only": "true"
+          },
+          "CQWAZ_CW": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_CW",
+            "Import-only": "true"
+          },
+          "CQWAZ_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_PHONE",
+            "Import-only": "true"
+          },
+          "CQWAZ_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_RTTY",
+            "Import-only": "true"
+          },
+          "CQWAZ_160m": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_160m",
+            "Import-only": "true"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Award",
+            "Award": "CQWPX",
+            "Import-only": "true"
+          },
+          "DARC_DOK": {
+            "Enumeration Name": "Award",
+            "Award": "DARC_DOK",
+            "Import-only": "true"
+          },
+          "DXCC": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC",
+            "Import-only": "true"
+          },
+          "DXCC_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_MIXED",
+            "Import-only": "true"
+          },
+          "DXCC_CW": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_CW",
+            "Import-only": "true"
+          },
+          "DXCC_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_PHONE",
+            "Import-only": "true"
+          },
+          "DXCC_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_RTTY",
+            "Import-only": "true"
+          },
+          "IOTA": {
+            "Enumeration Name": "Award",
+            "Award": "IOTA",
+            "Import-only": "true"
+          },
+          "JCC": {
+            "Enumeration Name": "Award",
+            "Award": "JCC",
+            "Import-only": "true"
+          },
+          "JCG": {
+            "Enumeration Name": "Award",
+            "Award": "JCG",
+            "Import-only": "true"
+          },
+          "MARATHON": {
+            "Enumeration Name": "Award",
+            "Award": "MARATHON",
+            "Import-only": "true"
+          },
+          "RDA": {
+            "Enumeration Name": "Award",
+            "Award": "RDA",
+            "Import-only": "true"
+          },
+          "WAB": {
+            "Enumeration Name": "Award",
+            "Award": "WAB",
+            "Import-only": "true"
+          },
+          "WAC": {
+            "Enumeration Name": "Award",
+            "Award": "WAC",
+            "Import-only": "true"
+          },
+          "WAE": {
+            "Enumeration Name": "Award",
+            "Award": "WAE",
+            "Import-only": "true"
+          },
+          "WAIP": {
+            "Enumeration Name": "Award",
+            "Award": "WAIP",
+            "Import-only": "true"
+          },
+          "WAJA": {
+            "Enumeration Name": "Award",
+            "Award": "WAJA",
+            "Import-only": "true"
+          },
+          "WAS": {
+            "Enumeration Name": "Award",
+            "Award": "WAS",
+            "Import-only": "true"
+          },
+          "WAZ": {
+            "Enumeration Name": "Award",
+            "Award": "WAZ",
+            "Import-only": "true"
+          },
+          "USACA": {
+            "Enumeration Name": "Award",
+            "Award": "USACA",
+            "Import-only": "true"
+          },
+          "VUCC": {
+            "Enumeration Name": "Award",
+            "Award": "VUCC",
+            "Import-only": "true"
+          }
+        }
+      },
+      "Award_Sponsor": {
+        "Header": [
+          "Enumeration Name",
+          "Sponsor",
+          "Sponsoring Organization",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "ADIF_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ADIF_",
+            "Sponsoring Organization": "ADIF Development Group"
+          },
+          "ARI_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARI_",
+            "Sponsoring Organization": "ARI - l\u0027Associazione Radioamatori Italiani"
+          },
+          "ARRL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARRL_",
+            "Sponsoring Organization": "ARRL - American Radio Relay League"
+          },
+          "CQ_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "CQ_",
+            "Sponsoring Organization": "CQ Magazine"
+          },
+          "DARC_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "DARC_",
+            "Sponsoring Organization": "DARC - Deutscher Amateur-Radio-Club e.V."
+          },
+          "EQSL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "EQSL_",
+            "Sponsoring Organization": "eQSL"
+          },
+          "IARU_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "IARU_",
+            "Sponsoring Organization": "IARU - International Amateur Radio Union"
+          },
+          "JARL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "JARL_",
+            "Sponsoring Organization": "JARL - Japan Amateur Radio League"
+          },
+          "RSGB_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "RSGB_",
+            "Sponsoring Organization": "RSGB - Radio Society of Great Britain"
+          },
+          "TAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "TAG_",
+            "Sponsoring Organization": "TAG - Tambov award group"
+          },
+          "WABAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "WABAG_",
+            "Sponsoring Organization": "WAB - Worked all Britain"
+          }
+        }
+      },
+      "Band": {
+        "Header": [
+          "Enumeration Name",
+          "Band",
+          "Lower Freq (MHz)",
+          "Upper Freq (MHz)",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "2190m": {
+            "Enumeration Name": "Band",
+            "Band": "2190m",
+            "Lower Freq (MHz)": ".1357",
+            "Upper Freq (MHz)": ".1378"
+          },
+          "630m": {
+            "Enumeration Name": "Band",
+            "Band": "630m",
+            "Lower Freq (MHz)": ".472",
+            "Upper Freq (MHz)": ".479"
+          },
+          "560m": {
+            "Enumeration Name": "Band",
+            "Band": "560m",
+            "Lower Freq (MHz)": ".501",
+            "Upper Freq (MHz)": ".504"
+          },
+          "160m": {
+            "Enumeration Name": "Band",
+            "Band": "160m",
+            "Lower Freq (MHz)": "1.8",
+            "Upper Freq (MHz)": "2.0"
+          },
+          "80m": {
+            "Enumeration Name": "Band",
+            "Band": "80m",
+            "Lower Freq (MHz)": "3.5",
+            "Upper Freq (MHz)": "4.0"
+          },
+          "60m": {
+            "Enumeration Name": "Band",
+            "Band": "60m",
+            "Lower Freq (MHz)": "5.06",
+            "Upper Freq (MHz)": "5.45"
+          },
+          "40m": {
+            "Enumeration Name": "Band",
+            "Band": "40m",
+            "Lower Freq (MHz)": "7.0",
+            "Upper Freq (MHz)": "7.3"
+          },
+          "30m": {
+            "Enumeration Name": "Band",
+            "Band": "30m",
+            "Lower Freq (MHz)": "10.1",
+            "Upper Freq (MHz)": "10.15"
+          },
+          "20m": {
+            "Enumeration Name": "Band",
+            "Band": "20m",
+            "Lower Freq (MHz)": "14.0",
+            "Upper Freq (MHz)": "14.35"
+          },
+          "17m": {
+            "Enumeration Name": "Band",
+            "Band": "17m",
+            "Lower Freq (MHz)": "18.068",
+            "Upper Freq (MHz)": "18.168"
+          },
+          "15m": {
+            "Enumeration Name": "Band",
+            "Band": "15m",
+            "Lower Freq (MHz)": "21.0",
+            "Upper Freq (MHz)": "21.45"
+          },
+          "12m": {
+            "Enumeration Name": "Band",
+            "Band": "12m",
+            "Lower Freq (MHz)": "24.890",
+            "Upper Freq (MHz)": "24.99"
+          },
+          "10m": {
+            "Enumeration Name": "Band",
+            "Band": "10m",
+            "Lower Freq (MHz)": "28.0",
+            "Upper Freq (MHz)": "29.7"
+          },
+          "8m": {
+            "Enumeration Name": "Band",
+            "Band": "8m",
+            "Lower Freq (MHz)": "40",
+            "Upper Freq (MHz)": "45"
+          },
+          "6m": {
+            "Enumeration Name": "Band",
+            "Band": "6m",
+            "Lower Freq (MHz)": "50",
+            "Upper Freq (MHz)": "54"
+          },
+          "5m": {
+            "Enumeration Name": "Band",
+            "Band": "5m",
+            "Lower Freq (MHz)": "54.000001",
+            "Upper Freq (MHz)": "69.9"
+          },
+          "4m": {
+            "Enumeration Name": "Band",
+            "Band": "4m",
+            "Lower Freq (MHz)": "70",
+            "Upper Freq (MHz)": "71"
+          },
+          "2m": {
+            "Enumeration Name": "Band",
+            "Band": "2m",
+            "Lower Freq (MHz)": "144",
+            "Upper Freq (MHz)": "148"
+          },
+          "1.25m": {
+            "Enumeration Name": "Band",
+            "Band": "1.25m",
+            "Lower Freq (MHz)": "222",
+            "Upper Freq (MHz)": "225"
+          },
+          "70cm": {
+            "Enumeration Name": "Band",
+            "Band": "70cm",
+            "Lower Freq (MHz)": "420",
+            "Upper Freq (MHz)": "450"
+          },
+          "33cm": {
+            "Enumeration Name": "Band",
+            "Band": "33cm",
+            "Lower Freq (MHz)": "902",
+            "Upper Freq (MHz)": "928"
+          },
+          "23cm": {
+            "Enumeration Name": "Band",
+            "Band": "23cm",
+            "Lower Freq (MHz)": "1240",
+            "Upper Freq (MHz)": "1300"
+          },
+          "13cm": {
+            "Enumeration Name": "Band",
+            "Band": "13cm",
+            "Lower Freq (MHz)": "2300",
+            "Upper Freq (MHz)": "2450"
+          },
+          "9cm": {
+            "Enumeration Name": "Band",
+            "Band": "9cm",
+            "Lower Freq (MHz)": "3300",
+            "Upper Freq (MHz)": "3500"
+          },
+          "6cm": {
+            "Enumeration Name": "Band",
+            "Band": "6cm",
+            "Lower Freq (MHz)": "5650",
+            "Upper Freq (MHz)": "5925"
+          },
+          "3cm": {
+            "Enumeration Name": "Band",
+            "Band": "3cm",
+            "Lower Freq (MHz)": "10000",
+            "Upper Freq (MHz)": "10500"
+          },
+          "1.25cm": {
+            "Enumeration Name": "Band",
+            "Band": "1.25cm",
+            "Lower Freq (MHz)": "24000",
+            "Upper Freq (MHz)": "24250"
+          },
+          "6mm": {
+            "Enumeration Name": "Band",
+            "Band": "6mm",
+            "Lower Freq (MHz)": "47000",
+            "Upper Freq (MHz)": "47200"
+          },
+          "4mm": {
+            "Enumeration Name": "Band",
+            "Band": "4mm",
+            "Lower Freq (MHz)": "75500",
+            "Upper Freq (MHz)": "81000"
+          },
+          "2.5mm": {
+            "Enumeration Name": "Band",
+            "Band": "2.5mm",
+            "Lower Freq (MHz)": "119980",
+            "Upper Freq (MHz)": "123000"
+          },
+          "2mm": {
+            "Enumeration Name": "Band",
+            "Band": "2mm",
+            "Lower Freq (MHz)": "134000",
+            "Upper Freq (MHz)": "149000"
+          },
+          "1mm": {
+            "Enumeration Name": "Band",
+            "Band": "1mm",
+            "Lower Freq (MHz)": "241000",
+            "Upper Freq (MHz)": "250000"
+          },
+          "submm": {
+            "Enumeration Name": "Band",
+            "Band": "submm",
+            "Lower Freq (MHz)": "300000",
+            "Upper Freq (MHz)": "7500000"
+          }
+        }
+      },
+      "Contest_ID": {
+        "Header": [
+          "Enumeration Name",
+          "Contest-ID",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "070-160M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-160M-SPRINT",
+            "Description": "PODXS Great Pumpkin Sprint"
+          },
+          "070-3-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-3-DAY",
+            "Description": "PODXS Three Day Weekend"
+          },
+          "070-31-FLAVORS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-31-FLAVORS",
+            "Description": "PODXS 31 Flavors"
+          },
+          "070-40M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-40M-SPRINT",
+            "Description": "PODXS 40m Firecracker Sprint"
+          },
+          "070-80M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-80M-SPRINT",
+            "Description": "PODXS 80m Jay Hudak Memorial Sprint"
+          },
+          "070-PSKFEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-PSKFEST",
+            "Description": "PODXS PSKFest"
+          },
+          "070-ST-PATS-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-ST-PATS-DAY",
+            "Description": "PODXS St. Patricks Day"
+          },
+          "070-VALENTINE-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-VALENTINE-SPRINT",
+            "Description": "PODXS Valentine Sprint"
+          },
+          "10-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "10-RTTY",
+            "Description": "Ten-Meter RTTY Contest (2011 onwards)"
+          },
+          "1010-OPEN-SEASON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "1010-OPEN-SEASON",
+            "Description": "Open Season Ten Meter QSO Party"
+          },
+          "7QP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "7QP",
+            "Description": "7th-Area QSO Party"
+          },
+          "AL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AL-QSO-PARTY",
+            "Description": "Alabama QSO Party"
+          },
+          "ALL-ASIAN-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-CW",
+            "Description": "JARL All Asian DX Contest (CW)"
+          },
+          "ALL-ASIAN-DX-PHONE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-PHONE",
+            "Description": "JARL All Asian DX Contest (PHONE)"
+          },
+          "ANARTS-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANARTS-RTTY",
+            "Description": "ANARTS WW RTTY"
+          },
+          "ANATOLIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANATOLIAN-RTTY",
+            "Description": "Anatolian WW RTTY"
+          },
+          "AP-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AP-SPRINT",
+            "Description": "Asia - Pacific Sprint"
+          },
+          "AR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AR-QSO-PARTY",
+            "Description": "Arkansas QSO Party"
+          },
+          "ARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-DX",
+            "Description": "ARI DX Contest"
+          },
+          "ARI-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-EME",
+            "Description": "ARI Italian EME Trophy"
+          },
+          "ARI-IAC-13CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-13CM",
+            "Description": "ARI Italian Activity Contest (13cm\u002B)"
+          },
+          "ARI-IAC-23CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-23CM",
+            "Description": "ARI Italian Activity Contest (23cm)"
+          },
+          "ARI-IAC-6M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-6M",
+            "Description": "ARI Italian Activity Contest (6m)"
+          },
+          "ARI-IAC-UHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-UHF",
+            "Description": "ARI Italian Activity Contest (UHF)"
+          },
+          "ARI-IAC-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-VHF",
+            "Description": "ARI Italian Activity Contest (VHF)"
+          },
+          "ARRL-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10",
+            "Description": "ARRL 10 Meter Contest"
+          },
+          "ARRL-10-GHZ": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10-GHZ",
+            "Description": "ARRL 10 GHz and Up Contest"
+          },
+          "ARRL-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-160",
+            "Description": "ARRL 160 Meter Contest"
+          },
+          "ARRL-222": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-222",
+            "Description": "ARRL 222 MHz and Up Distance Contest"
+          },
+          "ARRL-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DIGI",
+            "Description": "ARRL International Digital Contest"
+          },
+          "ARRL-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-CW",
+            "Description": "ARRL International DX Contest (CW)"
+          },
+          "ARRL-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-SSB",
+            "Description": "ARRL International DX Contest (Phone)"
+          },
+          "ARRL-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-EME",
+            "Description": "ARRL EME contest"
+          },
+          "ARRL-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-FIELD-DAY",
+            "Description": "ARRL Field Day"
+          },
+          "ARRL-RR-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-CW",
+            "Description": "ARRL Rookie Roundup (CW)"
+          },
+          "ARRL-RR-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-RTTY",
+            "Description": "ARRL Rookie Roundup (RTTY)"
+          },
+          "ARRL-RR-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-SSB",
+            "Description": "ARRL Rookie Roundup (Phone)"
+          },
+          "ARRL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RTTY",
+            "Description": "ARRL RTTY Round-Up"
+          },
+          "ARRL-SCR": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SCR",
+            "Description": "ARRL School Club Roundup"
+          },
+          "ARRL-SS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-CW",
+            "Description": "ARRL November Sweepstakes (CW)"
+          },
+          "ARRL-SS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-SSB",
+            "Description": "ARRL November Sweepstakes (Phone)"
+          },
+          "ARRL-UHF-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-UHF-AUG",
+            "Description": "ARRL August UHF Contest"
+          },
+          "ARRL-VHF-JAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JAN",
+            "Description": "ARRL January VHF Sweepstakes"
+          },
+          "ARRL-VHF-JUN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JUN",
+            "Description": "ARRL June VHF QSO Party"
+          },
+          "ARRL-VHF-SEP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-SEP",
+            "Description": "ARRL September VHF QSO Party"
+          },
+          "AZ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AZ-QSO-PARTY",
+            "Description": "Arizona QSO Party"
+          },
+          "BANGGAI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BANGGAI-DX",
+            "Description": "ORARI Banggai DX Contest"
+          },
+          "BARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-RTTY",
+            "Description": "BARTG Spring RTTY Contest"
+          },
+          "BARTG-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-SPRINT",
+            "Description": "BARTG Sprint Contest"
+          },
+          "BC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BC-QSO-PARTY",
+            "Description": "British Columbia QSO Party"
+          },
+          "BEKASI-MERDEKA-CONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BEKASI-MERDEKA-CONTEST",
+            "Description": "ORARI Bekasi Merdeka Contest"
+          },
+          "CA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CA-QSO-PARTY",
+            "Description": "California QSO Party"
+          },
+          "CIS-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CIS-DX",
+            "Description": "CIS DX Contest"
+          },
+          "CO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CO-QSO-PARTY",
+            "Description": "Colorado QSO Party"
+          },
+          "CQ-160-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-CW",
+            "Description": "CQ WW 160 Meter DX Contest (CW)"
+          },
+          "CQ-160-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-SSB",
+            "Description": "CQ WW 160 Meter DX Contest (SSB)"
+          },
+          "CQ-M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-M",
+            "Description": "CQ-M International DX Contest"
+          },
+          "CQ-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-VHF",
+            "Description": "CQ World-Wide VHF Contest"
+          },
+          "CQ-WPX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-CW",
+            "Description": "CQ WW WPX Contest (CW)"
+          },
+          "CQ-WPX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-RTTY",
+            "Description": "CQ/RJ WW RTTY WPX Contest"
+          },
+          "CQ-WPX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-SSB",
+            "Description": "CQ WW WPX Contest (SSB)"
+          },
+          "CQ-WW-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-CW",
+            "Description": "CQ WW DX Contest (CW)"
+          },
+          "CQ-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-RTTY",
+            "Description": "CQ/RJ WW RTTY DX Contest"
+          },
+          "CQ-WW-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-SSB",
+            "Description": "CQ WW DX Contest (SSB)"
+          },
+          "CT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CT-QSO-PARTY",
+            "Description": "Connecticut QSO Party"
+          },
+          "CVA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-CW",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CVA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-SSB",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CWOPS-CW-OPEN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CW-OPEN",
+            "Description": "CWops CW Open Competition"
+          },
+          "CWOPS-CWT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CWT",
+            "Description": "CWops Mini-CWT Test"
+          },
+          "DARC-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-10",
+            "Description": "DARC 10m Contest"
+          },
+          "DARC-CWA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-CWA",
+            "Description": "DARC CW Trainee Contest"
+          },
+          "DARC-FT4": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-FT4",
+            "Description": "DARC FT4 Contest"
+          },
+          "DARC-HELL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-HELL",
+            "Description": "DARC Hell Contest"
+          },
+          "DARC-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-MICROWAVE",
+            "Description": "DARC Microwave Contest"
+          },
+          "DARC-TRAINEE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-TRAINEE",
+            "Description": "DARC Trainee Contest"
+          },
+          "DARC-UKW-SPRING": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-SPRING",
+            "Description": "DARC UKW Spring Contest"
+          },
+          "DARC-UKW-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-FIELD-DAY",
+            "Description": "DARC UKW Summer Contest"
+          },
+          "DARC-VHF-UHF-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-VHF-UHF-MICROWAVE",
+            "Description": "DARC VHF-, UHF-, Microwave Contest (May)"
+          },
+          "DARC-WAEDC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-CW",
+            "Description": "WAE DX Contest (CW)"
+          },
+          "DARC-WAEDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-RTTY",
+            "Description": "WAE DX Contest (RTTY)"
+          },
+          "DARC-WAEDC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-SSB",
+            "Description": "WAE DX Contest (SSB)"
+          },
+          "DARC-WAG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAG",
+            "Description": "DARC Worked All Germany"
+          },
+          "DE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DE-QSO-PARTY",
+            "Description": "Delaware QSO Party"
+          },
+          "DL-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DL-DX-RTTY",
+            "Description": "DL-DX RTTY Contest"
+          },
+          "DMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DMC-RTTY",
+            "Description": "DMC RTTY Contest"
+          },
+          "EA-CNCW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-CNCW",
+            "Description": "Concurso Nacional de Telegrafía"
+          },
+          "EA-DME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-DME",
+            "Description": "Municipios Españoles"
+          },
+          "EA-MAJESTAD-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-CW",
+            "Description": "His Majesty The King of Spain CW Contest (2022 and later)"
+          },
+          "EA-MAJESTAD-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-SSB",
+            "Description": "His Majesty The King of Spain SSB Contest (2022 and later)"
+          },
+          "EA-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-PSK63",
+            "Description": "EA PSK63"
+          },
+          "EA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest",
+            "Import-only": "true"
+          },
+          "EA-SMRE-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-CW",
+            "Description": "Su Majestad El Rey de España - CW (2021 and earlier)"
+          },
+          "EA-SMRE-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-SSB",
+            "Description": "Su Majestad El Rey de España - SSB (2021 and earlier)"
+          },
+          "EA-VHF-ATLANTIC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-ATLANTIC",
+            "Description": "Atlántico V-UHF"
+          },
+          "EA-VHF-COM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COM",
+            "Description": "Combinado de V-UHF"
+          },
+          "EA-VHF-COSTA-SOL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COSTA-SOL",
+            "Description": "Costa del Sol V-UHF"
+          },
+          "EA-VHF-EA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA",
+            "Description": "Nacional VHF"
+          },
+          "EA-VHF-EA1RCS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA1RCS",
+            "Description": "Segovia EA1RCS V-UHF"
+          },
+          "EA-VHF-QSL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-QSL",
+            "Description": "QSL V-UHF \u0026 50MHz"
+          },
+          "EA-VHF-SADURNI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-SADURNI",
+            "Description": "Sant Sadurni V-UHF"
+          },
+          "EA-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-WW-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest"
+          },
+          "EASTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EASTER",
+            "Description": "DARC Easter Contest"
+          },
+          "EPC-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EPC-PSK63",
+            "Description": "PSK63 QSO Party"
+          },
+          "EU SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU SPRINT",
+            "Description": "EU Sprint"
+          },
+          "EU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-HF",
+            "Description": "EU HF Championship"
+          },
+          "EU-PSK-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-PSK-DX",
+            "Description": "EU PSK DX Contest"
+          },
+          "EUCW160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EUCW160M",
+            "Description": "European CW Association 160m CW Party"
+          },
+          "FALL SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FALL SPRINT",
+            "Description": "FISTS Fall Sprint"
+          },
+          "FL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FL-QSO-PARTY",
+            "Description": "Florida QSO Party"
+          },
+          "GA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "GA-QSO-PARTY",
+            "Description": "Georgia QSO Party"
+          },
+          "HA-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HA-DX",
+            "Description": "Hungarian DX Contest"
+          },
+          "HELVETIA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HELVETIA",
+            "Description": "Helvetia Contest"
+          },
+          "HI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HI-QSO-PARTY",
+            "Description": "Hawaiian QSO Party"
+          },
+          "HOLYLAND": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HOLYLAND",
+            "Description": "IARC Holyland Contest"
+          },
+          "IA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IA-QSO-PARTY",
+            "Description": "Iowa QSO Party"
+          },
+          "IARU-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-FIELD-DAY",
+            "Description": "DARC IARU Region 1 Field Day"
+          },
+          "IARU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-HF",
+            "Description": "IARU HF World Championship"
+          },
+          "ICWC-MST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ICWC-MST",
+            "Description": "ICWC Medium Speed Test"
+          },
+          "ID-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ID-QSO-PARTY",
+            "Description": "Idaho QSO Party"
+          },
+          "IL QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IL QSO PARTY",
+            "Description": "Illinois QSO Party"
+          },
+          "IN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IN-QSO-PARTY",
+            "Description": "Indiana QSO Party"
+          },
+          "JARTS-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JARTS-WW-RTTY",
+            "Description": "JARTS WW RTTY"
+          },
+          "JIDX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-CW",
+            "Description": "Japan International DX Contest (CW)"
+          },
+          "JIDX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-SSB",
+            "Description": "Japan International DX Contest (SSB)"
+          },
+          "JT-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JT-DX-RTTY",
+            "Description": "Mongolian RTTY DX Contest"
+          },
+          "K1USN-SSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SSO",
+            "Description": "K1USN Slow Speed Open"
+          },
+          "K1USN-SST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SST",
+            "Description": "K1USN Slow Speed Test"
+          },
+          "KS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KS-QSO-PARTY",
+            "Description": "Kansas QSO Party"
+          },
+          "KY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KY-QSO-PARTY",
+            "Description": "Kentucky QSO Party"
+          },
+          "LA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LA-QSO-PARTY",
+            "Description": "Louisiana QSO Party"
+          },
+          "LDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LDC-RTTY",
+            "Description": "DRCG Long Distance Contest (RTTY)"
+          },
+          "LZ DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LZ DX",
+            "Description": "LZ DX Contest"
+          },
+          "MAR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MAR-QSO-PARTY",
+            "Description": "Maritimes QSO Party"
+          },
+          "MD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MD-QSO-PARTY",
+            "Description": "Maryland QSO Party"
+          },
+          "ME-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ME-QSO-PARTY",
+            "Description": "Maine QSO Party"
+          },
+          "MI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MI-QSO-PARTY",
+            "Description": "Michigan QSO Party"
+          },
+          "MIDATLANTIC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MIDATLANTIC-QSO-PARTY",
+            "Description": "Mid-Atlantic QSO Party"
+          },
+          "MN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MN-QSO-PARTY",
+            "Description": "Minnesota QSO Party"
+          },
+          "MO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MO-QSO-PARTY",
+            "Description": "Missouri QSO Party"
+          },
+          "MS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MS-QSO-PARTY",
+            "Description": "Mississippi QSO Party"
+          },
+          "MT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MT-QSO-PARTY",
+            "Description": "Montana QSO Party"
+          },
+          "NA-SPRINT-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-CW",
+            "Description": "North America Sprint (CW)"
+          },
+          "NA-SPRINT-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-RTTY",
+            "Description": "North America Sprint (RTTY)"
+          },
+          "NA-SPRINT-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-SSB",
+            "Description": "North America Sprint (Phone)"
+          },
+          "NAQP-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-CW",
+            "Description": "North America QSO Party (CW)"
+          },
+          "NAQP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-RTTY",
+            "Description": "North America QSO Party (RTTY)"
+          },
+          "NAQP-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-SSB",
+            "Description": "North America QSO Party (Phone)"
+          },
+          "NAVAL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAVAL",
+            "Description": "International Naval Contest (INC)"
+          },
+          "NC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NC-QSO-PARTY",
+            "Description": "North Carolina QSO Party"
+          },
+          "ND-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ND-QSO-PARTY",
+            "Description": "North Dakota QSO Party"
+          },
+          "NE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NE-QSO-PARTY",
+            "Description": "Nebraska QSO Party"
+          },
+          "NEQP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NEQP",
+            "Description": "New England QSO Party"
+          },
+          "NH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NH-QSO-PARTY",
+            "Description": "New Hampshire QSO Party"
+          },
+          "NJ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NJ-QSO-PARTY",
+            "Description": "New Jersey QSO Party"
+          },
+          "NM-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NM-QSO-PARTY",
+            "Description": "New Mexico QSO Party"
+          },
+          "NRAU-BALTIC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-CW",
+            "Description": "NRAU-Baltic Contest (CW)"
+          },
+          "NRAU-BALTIC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-SSB",
+            "Description": "NRAU-Baltic Contest (SSB)"
+          },
+          "NV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NV-QSO-PARTY",
+            "Description": "Nevada QSO Party"
+          },
+          "NY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NY-QSO-PARTY",
+            "Description": "New York QSO Party"
+          },
+          "OCEANIA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-CW",
+            "Description": "Oceania DX Contest (CW)"
+          },
+          "OCEANIA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-SSB",
+            "Description": "Oceania DX Contest (SSB)"
+          },
+          "OH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OH-QSO-PARTY",
+            "Description": "Ohio QSO Party"
+          },
+          "OK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-DX-RTTY",
+            "Description": "Czech Radio Club OK DX Contest"
+          },
+          "OK-OM-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-OM-DX",
+            "Description": "Czech Radio Club OK-OM DX Contest"
+          },
+          "OK-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-QSO-PARTY",
+            "Description": "Oklahoma QSO Party"
+          },
+          "OMISS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OMISS-QSO-PARTY",
+            "Description": "Old Man International Sideband Society QSO Party"
+          },
+          "ON-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ON-QSO-PARTY",
+            "Description": "Ontario QSO Party"
+          },
+          "OR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OR-QSO-PARTY",
+            "Description": "Oregon QSO Party"
+          },
+          "ORARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ORARI-DX",
+            "Description": "ORARI DX Contest"
+          },
+          "PA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PA-QSO-PARTY",
+            "Description": "Pennsylvania QSO Party"
+          },
+          "PACC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PACC",
+            "Description": "Dutch PACC Contest"
+          },
+          "PCC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PCC",
+            "Description": "PCCPro CW Contest"
+          },
+          "PSK-DEATHMATCH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PSK-DEATHMATCH",
+            "Description": "MDXA PSK DeathMatch (2005-2010)"
+          },
+          "QC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "QC-QSO-PARTY",
+            "Description": "Quebec QSO Party"
+          },
+          "RAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC",
+            "Description": "Canadian Amateur Radio Society Contest",
+            "Import-only": "true"
+          },
+          "RAC-CANADA-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-DAY",
+            "Description": "RAC Canada Day Contest"
+          },
+          "RAC-CANADA-WINTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-WINTER",
+            "Description": "RAC Canada Winter Contest"
+          },
+          "RDAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDAC",
+            "Description": "Russian District Award Contest"
+          },
+          "RDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDXC",
+            "Description": "Russian DX Contest"
+          },
+          "REF-160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-160M",
+            "Description": "Reseau des Emetteurs Francais 160m Contest"
+          },
+          "REF-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-CW",
+            "Description": "Reseau des Emetteurs Francais Contest (CW)"
+          },
+          "REF-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-SSB",
+            "Description": "Reseau des Emetteurs Francais Contest (SSB)"
+          },
+          "REP-PORTUGAL-DAY-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REP-PORTUGAL-DAY-HF",
+            "Description": "Rede dos Emissores Portugueses Portugal Day HF Contest"
+          },
+          "RI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RI-QSO-PARTY",
+            "Description": "Rhode Island QSO Party"
+          },
+          "RSGB-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-160",
+            "Description": "1.8MHz Contest"
+          },
+          "RSGB-21/28-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-CW",
+            "Description": "21/28 MHz Contest (CW)"
+          },
+          "RSGB-21/28-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-SSB",
+            "Description": "21/28 MHz Contest (SSB)"
+          },
+          "RSGB-80M-CC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-80M-CC",
+            "Description": "80m Club Championships"
+          },
+          "RSGB-AFS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-CW",
+            "Description": "Affiliated Societies Team Contest (CW)"
+          },
+          "RSGB-AFS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-SSB",
+            "Description": "Affiliated Societies Team Contest (SSB)"
+          },
+          "RSGB-CLUB-CALLS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-CLUB-CALLS",
+            "Description": "Club Calls"
+          },
+          "RSGB-COMMONWEALTH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-COMMONWEALTH",
+            "Description": "Commonwealth Contest"
+          },
+          "RSGB-IOTA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-IOTA",
+            "Description": "IOTA Contest"
+          },
+          "RSGB-LOW-POWER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-LOW-POWER",
+            "Description": "Low Power Field Day"
+          },
+          "RSGB-NFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-NFD",
+            "Description": "National Field Day"
+          },
+          "RSGB-ROPOCO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-ROPOCO",
+            "Description": "RoPoCo"
+          },
+          "RSGB-SSB-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-SSB-FD",
+            "Description": "SSB Field Day"
+          },
+          "RUSSIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RUSSIAN-RTTY",
+            "Description": "Russian Radio RTTY Worldwide Contest"
+          },
+          "SAC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-CW",
+            "Description": "Scandinavian Activity Contest (CW)"
+          },
+          "SAC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-SSB",
+            "Description": "Scandinavian Activity Contest (SSB)"
+          },
+          "SARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SARTG-RTTY",
+            "Description": "SARTG WW RTTY"
+          },
+          "SC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SC-QSO-PARTY",
+            "Description": "South Carolina QSO Party"
+          },
+          "SCC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SCC-RTTY",
+            "Description": "SCC RTTY Championship"
+          },
+          "SD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SD-QSO-PARTY",
+            "Description": "South Dakota QSO Party"
+          },
+          "SHORTRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SHORTRY",
+            "Description": "DARC RTTY Short Contest"
+          },
+          "SMP-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-AUG",
+            "Description": "SSA Portabeltest"
+          },
+          "SMP-MAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-MAY",
+            "Description": "SSA Portabeltest"
+          },
+          "SP-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SP-DX-RTTY",
+            "Description": "PRC SPDX Contest (RTTY)"
+          },
+          "SPAR-WINTER-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPAR-WINTER-FD",
+            "Description": "SPAR Winter Field Day(2016 and earlier)"
+          },
+          "SPDXCONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPDXCONTEST",
+            "Description": "SP DX Contest"
+          },
+          "SPRING SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPRING SPRINT",
+            "Description": "FISTS Spring Sprint"
+          },
+          "SR-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SR-MARATHON",
+            "Description": "Scottish-Russian Marathon"
+          },
+          "STEW-PERRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "STEW-PERRY",
+            "Description": "Stew Perry Topband Distance Challenge"
+          },
+          "SUMMER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SUMMER SPRINT",
+            "Description": "FISTS Summer Sprint"
+          },
+          "TARA-GRID-DIP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-GRID-DIP",
+            "Description": "TARA Grid Dip PSK-RTTY Shindig"
+          },
+          "TARA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RTTY",
+            "Description": "TARA RTTY Mêlée"
+          },
+          "TARA-RUMBLE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RUMBLE",
+            "Description": "TARA Rumble PSK Contest"
+          },
+          "TARA-SKIRMISH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-SKIRMISH",
+            "Description": "TARA Skirmish Digital Prefix Contest"
+          },
+          "TEN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TEN-RTTY",
+            "Description": "Ten-Meter RTTY Contest (before 2011)"
+          },
+          "TMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TMC-RTTY",
+            "Description": "The Makrothen Contest"
+          },
+          "TN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TN-QSO-PARTY",
+            "Description": "Tennessee QSO Party"
+          },
+          "TX-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TX-QSO-PARTY",
+            "Description": "Texas QSO Party"
+          },
+          "UBA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-CW",
+            "Description": "UBA Contest (CW)"
+          },
+          "UBA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-SSB",
+            "Description": "UBA Contest (SSB)"
+          },
+          "UK-DX-BPSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-BPSK63",
+            "Description": "European PSK Club BPSK63 Contest"
+          },
+          "UK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-RTTY",
+            "Description": "UK DX RTTY Contest"
+          },
+          "UKR-CHAMP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKR-CHAMP-RTTY",
+            "Description": "Open Ukraine RTTY Championship"
+          },
+          "UKRAINIAN DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKRAINIAN DX",
+            "Description": "Ukrainian DX"
+          },
+          "UKSMG-6M-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-6M-MARATHON",
+            "Description": "UKSMG 6m Marathon"
+          },
+          "UKSMG-SUMMER-ES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-SUMMER-ES",
+            "Description": "UKSMG Summer Es Contest"
+          },
+          "URE-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "URE-DX",
+            "Description": "Ukrainian DX Contest",
+            "Import-only": "true"
+          },
+          "US-COUNTIES-QSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "US-COUNTIES-QSO",
+            "Description": "Mobile Amateur Awards Club"
+          },
+          "UT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UT-QSO-PARTY",
+            "Description": "Utah QSO Party"
+          },
+          "VA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VA-QSO-PARTY",
+            "Description": "Virginia QSO Party"
+          },
+          "VENEZ-IND-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VENEZ-IND-DAY",
+            "Description": "RCV Venezuelan Independence Day Contest"
+          },
+          "VIRGINIA QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VIRGINIA QSO PARTY",
+            "Description": "Virginia QSO Party",
+            "Import-only": "true"
+          },
+          "VOLTA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VOLTA-RTTY",
+            "Description": "Alessandro Volta RTTY DX Contest"
+          },
+          "VT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VT-QSO-PARTY",
+            "Description": "Vermont QSO Party"
+          },
+          "WA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WA-QSO-PARTY",
+            "Description": "Washington QSO Party"
+          },
+          "WFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WFD",
+            "Description": "Winter Field Day (2017 and later)"
+          },
+          "WI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WI-QSO-PARTY",
+            "Description": "Wisconsin QSO Party"
+          },
+          "WIA-HARRY ANGEL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-HARRY ANGEL",
+            "Description": "WIA Harry Angel Memorial 80m Sprint"
+          },
+          "WIA-JMMFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-JMMFD",
+            "Description": "WIA John Moyle Memorial Field Day"
+          },
+          "WIA-OCDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-OCDX",
+            "Description": "WIA Oceania DX (OCDX) Contest"
+          },
+          "WIA-REMEMBRANCE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-REMEMBRANCE",
+            "Description": "WIA Remembrance Day"
+          },
+          "WIA-ROSS HULL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-ROSS HULL",
+            "Description": "WIA Ross Hull Memorial VHF/UHF Contest"
+          },
+          "WIA-TRANS TASMAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-TRANS TASMAN",
+            "Description": "WIA Trans Tasman Low Bands Challenge"
+          },
+          "WIA-VHF/UHF FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VHF/UHF FD",
+            "Description": "WIA VHF UHF Field Days"
+          },
+          "WIA-VK SHIRES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VK SHIRES",
+            "Description": "WIA VK Shires"
+          },
+          "WINTER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WINTER SPRINT",
+            "Description": "FISTS Winter Sprint"
+          },
+          "WV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WV-QSO-PARTY",
+            "Description": "West Virginia QSO Party"
+          },
+          "WW-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WW-DIGI",
+            "Description": "World Wide Digi DX Contest"
+          },
+          "WY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WY-QSO-PARTY",
+            "Description": "Wyoming QSO Party"
+          },
+          "XE-INTL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "XE-INTL-RTTY",
+            "Description": "Mexico International Contest (RTTY)"
+          },
+          "YOHFDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YOHFDX",
+            "Description": "YODX HF contest"
+          },
+          "YUDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YUDXC",
+            "Description": "YU DX Contest"
+          }
+        }
+      },
+      "Continent": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Continent",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "NA",
+            "Continent": "North America"
+          },
+          "SA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "SA",
+            "Continent": "South America"
+          },
+          "EU": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "EU",
+            "Continent": "Europe"
+          },
+          "AF": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AF",
+            "Continent": "Africa"
+          },
+          "OC": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "OC",
+            "Continent": "Oceania"
+          },
+          "AS": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AS",
+            "Continent": "Asia"
+          },
+          "AN": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AN",
+            "Continent": "Antarctica"
+          }
+        }
+      },
+      "Credit": {
+        "Header": [
+          "Enumeration Name",
+          "Credit For",
+          "Sponsor",
+          "Award",
+          "Facet",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CQDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mixed"
+          },
+          "CQDX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Band"
+          },
+          "CQDX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mode"
+          },
+          "CQDX_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mobile"
+          },
+          "CQDX_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "QRP"
+          },
+          "CQDX_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Satellite"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mixed"
+          },
+          "CQDXFIELD_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Band"
+          },
+          "CQDXFIELD_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mode"
+          },
+          "CQDXFIELD_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mobile"
+          },
+          "CQDXFIELD_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "QRP"
+          },
+          "CQDXFIELD_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MIXED",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mixed"
+          },
+          "CQWAZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Band"
+          },
+          "CQWAZ_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mode"
+          },
+          "CQWAZ_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_EME",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "EME"
+          },
+          "CQWAZ_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mobile"
+          },
+          "CQWAZ_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "QRP"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mixed"
+          },
+          "CQWPX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Band"
+          },
+          "CQWPX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mode"
+          },
+          "DXCC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mixed"
+          },
+          "DXCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Band"
+          },
+          "DXCC_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_MODE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mode"
+          },
+          "DXCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Satellite"
+          },
+          "EAUSTRALIA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EAUSTRALIA",
+            "Sponsor": "eQSL",
+            "Award": "eAustralia",
+            "Facet": "Mixed"
+          },
+          "ECANADA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECANADA",
+            "Sponsor": "eQSL",
+            "Award": "eCanada",
+            "Facet": "Mixed"
+          },
+          "ECOUNTY_STATE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECOUNTY_STATE",
+            "Sponsor": "eQSL",
+            "Award": "eCounty",
+            "Facet": "State"
+          },
+          "EDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX",
+            "Sponsor": "eQSL",
+            "Award": "eDX",
+            "Facet": "Mixed"
+          },
+          "EDX100": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mixed"
+          },
+          "EDX100_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Band"
+          },
+          "EDX100_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mode"
+          },
+          "EECHOLINK50": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EECHOLINK50",
+            "Sponsor": "eQSL",
+            "Award": "eEcholink50",
+            "Facet": "Echolink"
+          },
+          "EGRID_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Band"
+          },
+          "EGRID_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Satellite"
+          },
+          "EPFX300": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mixed"
+          },
+          "EPFX300_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300_MODE",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mode"
+          },
+          "EWAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mixed"
+          },
+          "EWAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Band"
+          },
+          "EWAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mode"
+          },
+          "EWAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Satellite"
+          },
+          "EZ40": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mixed"
+          },
+          "EZ40_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mode"
+          },
+          "FFMA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "FFMA",
+            "Sponsor": "ARRL",
+            "Award": "Fred Fish Memorial Award (FFMA)",
+            "Facet": "Mixed"
+          },
+          "IOTA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_BASIC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_BASIC",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_CONT": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_CONT",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Continent"
+          },
+          "IOTA_GROUP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_GROUP",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Group"
+          },
+          "RDA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "RDA",
+            "Sponsor": "TAG",
+            "Award": "Russian Districts Award (RDA)",
+            "Facet": "Mixed"
+          },
+          "USACA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "USACA",
+            "Sponsor": "CQ Magazine",
+            "Award": "United States of America Counties (USA-CA)",
+            "Facet": "Mixed"
+          },
+          "VUCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Band"
+          },
+          "VUCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Satellite"
+          },
+          "WAB": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAB",
+            "Sponsor": "WAB AG",
+            "Award": "Worked All Britain (WAB)",
+            "Facet": "Mixed"
+          },
+          "WAC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Mixed"
+          },
+          "WAC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC_BAND",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Band"
+          },
+          "WAE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mixed"
+          },
+          "WAE_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_BAND",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Band"
+          },
+          "WAE_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_MODE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mode"
+          },
+          "WAIP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mixed"
+          },
+          "WAIP_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_BAND",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Band"
+          },
+          "WAIP_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_MODE",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mode"
+          },
+          "WAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mixed"
+          },
+          "WAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_BAND",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Band"
+          },
+          "WAS_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_EME",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "EME"
+          },
+          "WAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_MODE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mode"
+          },
+          "WAS_NOVICE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_NOVICE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Novice"
+          },
+          "WAS_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_QRP",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "QRP"
+          },
+          "WAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Satellite"
+          },
+          "WITUZ": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Mixed"
+          },
+          "WITUZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ_BAND",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Band"
+          }
+        }
+      },
+      "DXCC_Entity_Code": {
+        "Header": [
+          "Enumeration Name",
+          "Entity Code",
+          "Entity Name",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "0": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "0",
+            "Entity Name": "None (the contacted station is known to not be within a DXCC entity)"
+          },
+          "1": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "1",
+            "Entity Name": "CANADA"
+          },
+          "2": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "2",
+            "Entity Name": "ABU AIL IS.",
+            "Deleted": "true"
+          },
+          "3": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "3",
+            "Entity Name": "AFGHANISTAN"
+          },
+          "4": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "4",
+            "Entity Name": "AGALEGA \u0026 ST. BRANDON IS."
+          },
+          "5": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "5",
+            "Entity Name": "ALAND IS."
+          },
+          "6": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "6",
+            "Entity Name": "ALASKA"
+          },
+          "7": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "7",
+            "Entity Name": "ALBANIA"
+          },
+          "8": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "8",
+            "Entity Name": "ALDABRA",
+            "Deleted": "true"
+          },
+          "9": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "9",
+            "Entity Name": "AMERICAN SAMOA"
+          },
+          "10": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "10",
+            "Entity Name": "AMSTERDAM \u0026 ST. PAUL IS."
+          },
+          "11": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "11",
+            "Entity Name": "ANDAMAN \u0026 NICOBAR IS."
+          },
+          "12": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "12",
+            "Entity Name": "ANGUILLA"
+          },
+          "13": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "13",
+            "Entity Name": "ANTARCTICA"
+          },
+          "14": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "14",
+            "Entity Name": "ARMENIA"
+          },
+          "15": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "15",
+            "Entity Name": "ASIATIC RUSSIA"
+          },
+          "16": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "16",
+            "Entity Name": "NEW ZEALAND SUBANTARCTIC ISLANDS"
+          },
+          "17": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "17",
+            "Entity Name": "AVES I."
+          },
+          "18": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "18",
+            "Entity Name": "AZERBAIJAN"
+          },
+          "19": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "19",
+            "Entity Name": "BAJO NUEVO",
+            "Deleted": "true"
+          },
+          "20": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "20",
+            "Entity Name": "BAKER \u0026 HOWLAND IS."
+          },
+          "21": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "21",
+            "Entity Name": "BALEARIC IS."
+          },
+          "22": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "22",
+            "Entity Name": "PALAU"
+          },
+          "23": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "23",
+            "Entity Name": "BLENHEIM REEF",
+            "Deleted": "true"
+          },
+          "24": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "24",
+            "Entity Name": "BOUVET"
+          },
+          "25": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "25",
+            "Entity Name": "BRITISH NORTH BORNEO",
+            "Deleted": "true"
+          },
+          "26": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "26",
+            "Entity Name": "BRITISH SOMALILAND",
+            "Deleted": "true"
+          },
+          "27": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "27",
+            "Entity Name": "BELARUS"
+          },
+          "28": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "28",
+            "Entity Name": "CANAL ZONE",
+            "Deleted": "true"
+          },
+          "29": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "29",
+            "Entity Name": "CANARY IS."
+          },
+          "30": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "30",
+            "Entity Name": "CELEBE \u0026 MOLUCCA IS.",
+            "Deleted": "true"
+          },
+          "31": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "31",
+            "Entity Name": "C. KIRIBATI (BRITISH PHOENIX IS.)"
+          },
+          "32": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "32",
+            "Entity Name": "CEUTA \u0026 MELILLA"
+          },
+          "33": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "33",
+            "Entity Name": "CHAGOS IS."
+          },
+          "34": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "34",
+            "Entity Name": "CHATHAM IS."
+          },
+          "35": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "35",
+            "Entity Name": "CHRISTMAS I."
+          },
+          "36": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "36",
+            "Entity Name": "CLIPPERTON I."
+          },
+          "37": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "37",
+            "Entity Name": "COCOS I."
+          },
+          "38": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "38",
+            "Entity Name": "COCOS (KEELING) IS."
+          },
+          "39": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "39",
+            "Entity Name": "COMOROS",
+            "Deleted": "true"
+          },
+          "40": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "40",
+            "Entity Name": "CRETE"
+          },
+          "41": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "41",
+            "Entity Name": "CROZET I."
+          },
+          "42": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "42",
+            "Entity Name": "DAMAO, DIU",
+            "Deleted": "true"
+          },
+          "43": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "43",
+            "Entity Name": "DESECHEO I."
+          },
+          "44": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "44",
+            "Entity Name": "DESROCHES",
+            "Deleted": "true"
+          },
+          "45": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "45",
+            "Entity Name": "DODECANESE"
+          },
+          "46": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "46",
+            "Entity Name": "EAST MALAYSIA"
+          },
+          "47": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "47",
+            "Entity Name": "EASTER I."
+          },
+          "48": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "48",
+            "Entity Name": "E. KIRIBATI (LINE IS.)"
+          },
+          "49": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "49",
+            "Entity Name": "EQUATORIAL GUINEA"
+          },
+          "50": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "50",
+            "Entity Name": "MEXICO"
+          },
+          "51": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "51",
+            "Entity Name": "ERITREA"
+          },
+          "52": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "52",
+            "Entity Name": "ESTONIA"
+          },
+          "53": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "53",
+            "Entity Name": "ETHIOPIA"
+          },
+          "54": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "54",
+            "Entity Name": "EUROPEAN RUSSIA"
+          },
+          "55": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "55",
+            "Entity Name": "FARQUHAR",
+            "Deleted": "true"
+          },
+          "56": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "56",
+            "Entity Name": "FERNANDO DE NORONHA"
+          },
+          "57": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "57",
+            "Entity Name": "FRENCH EQUATORIAL AFRICA",
+            "Deleted": "true"
+          },
+          "58": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "58",
+            "Entity Name": "FRENCH INDO-CHINA",
+            "Deleted": "true"
+          },
+          "59": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "59",
+            "Entity Name": "FRENCH WEST AFRICA",
+            "Deleted": "true"
+          },
+          "60": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "60",
+            "Entity Name": "BAHAMAS"
+          },
+          "61": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "61",
+            "Entity Name": "FRANZ JOSEF LAND"
+          },
+          "62": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "62",
+            "Entity Name": "BARBADOS"
+          },
+          "63": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "63",
+            "Entity Name": "FRENCH GUIANA"
+          },
+          "64": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "64",
+            "Entity Name": "BERMUDA"
+          },
+          "65": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "65",
+            "Entity Name": "BRITISH VIRGIN IS."
+          },
+          "66": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "66",
+            "Entity Name": "BELIZE"
+          },
+          "67": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "67",
+            "Entity Name": "FRENCH INDIA",
+            "Deleted": "true"
+          },
+          "68": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "68",
+            "Entity Name": "KUWAIT/SAUDI ARABIA NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "69": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "69",
+            "Entity Name": "CAYMAN IS."
+          },
+          "70": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "70",
+            "Entity Name": "CUBA"
+          },
+          "71": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "71",
+            "Entity Name": "GALAPAGOS IS."
+          },
+          "72": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "72",
+            "Entity Name": "DOMINICAN REPUBLIC"
+          },
+          "74": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "74",
+            "Entity Name": "EL SALVADOR"
+          },
+          "75": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "75",
+            "Entity Name": "GEORGIA"
+          },
+          "76": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "76",
+            "Entity Name": "GUATEMALA"
+          },
+          "77": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "77",
+            "Entity Name": "GRENADA"
+          },
+          "78": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "78",
+            "Entity Name": "HAITI"
+          },
+          "79": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "79",
+            "Entity Name": "GUADELOUPE"
+          },
+          "80": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "80",
+            "Entity Name": "HONDURAS"
+          },
+          "81": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "81",
+            "Entity Name": "GERMANY",
+            "Deleted": "true"
+          },
+          "82": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "82",
+            "Entity Name": "JAMAICA"
+          },
+          "84": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "84",
+            "Entity Name": "MARTINIQUE"
+          },
+          "85": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "85",
+            "Entity Name": "BONAIRE, CURACAO",
+            "Deleted": "true"
+          },
+          "86": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "86",
+            "Entity Name": "NICARAGUA"
+          },
+          "88": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "88",
+            "Entity Name": "PANAMA"
+          },
+          "89": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "89",
+            "Entity Name": "TURKS \u0026 CAICOS IS."
+          },
+          "90": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "90",
+            "Entity Name": "TRINIDAD \u0026 TOBAGO"
+          },
+          "91": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "91",
+            "Entity Name": "ARUBA"
+          },
+          "93": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "93",
+            "Entity Name": "GEYSER REEF",
+            "Deleted": "true"
+          },
+          "94": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "94",
+            "Entity Name": "ANTIGUA \u0026 BARBUDA"
+          },
+          "95": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "95",
+            "Entity Name": "DOMINICA"
+          },
+          "96": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "96",
+            "Entity Name": "MONTSERRAT"
+          },
+          "97": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "97",
+            "Entity Name": "ST. LUCIA"
+          },
+          "98": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "98",
+            "Entity Name": "ST. VINCENT"
+          },
+          "99": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "99",
+            "Entity Name": "GLORIOSO IS."
+          },
+          "100": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "100",
+            "Entity Name": "ARGENTINA"
+          },
+          "101": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "101",
+            "Entity Name": "GOA",
+            "Deleted": "true"
+          },
+          "102": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "102",
+            "Entity Name": "GOLD COAST, TOGOLAND",
+            "Deleted": "true"
+          },
+          "103": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "103",
+            "Entity Name": "GUAM"
+          },
+          "104": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "104",
+            "Entity Name": "BOLIVIA"
+          },
+          "105": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "105",
+            "Entity Name": "GUANTANAMO BAY"
+          },
+          "106": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "106",
+            "Entity Name": "GUERNSEY"
+          },
+          "107": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "107",
+            "Entity Name": "GUINEA"
+          },
+          "108": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "108",
+            "Entity Name": "BRAZIL"
+          },
+          "109": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "109",
+            "Entity Name": "GUINEA-BISSAU"
+          },
+          "110": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "110",
+            "Entity Name": "HAWAII"
+          },
+          "111": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "111",
+            "Entity Name": "HEARD I."
+          },
+          "112": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "112",
+            "Entity Name": "CHILE"
+          },
+          "113": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "113",
+            "Entity Name": "IFNI",
+            "Deleted": "true"
+          },
+          "114": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "114",
+            "Entity Name": "ISLE OF MAN"
+          },
+          "115": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "115",
+            "Entity Name": "ITALIAN SOMALILAND",
+            "Deleted": "true"
+          },
+          "116": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "116",
+            "Entity Name": "COLOMBIA"
+          },
+          "117": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "117",
+            "Entity Name": "ITU HQ"
+          },
+          "118": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "118",
+            "Entity Name": "JAN MAYEN"
+          },
+          "119": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "119",
+            "Entity Name": "JAVA",
+            "Deleted": "true"
+          },
+          "120": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "120",
+            "Entity Name": "ECUADOR"
+          },
+          "122": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "122",
+            "Entity Name": "JERSEY"
+          },
+          "123": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "123",
+            "Entity Name": "JOHNSTON I."
+          },
+          "124": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "124",
+            "Entity Name": "JUAN DE NOVA, EUROPA"
+          },
+          "125": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "125",
+            "Entity Name": "JUAN FERNANDEZ IS."
+          },
+          "126": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "126",
+            "Entity Name": "KALININGRAD"
+          },
+          "127": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "127",
+            "Entity Name": "KAMARAN IS.",
+            "Deleted": "true"
+          },
+          "128": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "128",
+            "Entity Name": "KARELO-FINNISH REPUBLIC",
+            "Deleted": "true"
+          },
+          "129": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "129",
+            "Entity Name": "GUYANA"
+          },
+          "130": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "130",
+            "Entity Name": "KAZAKHSTAN"
+          },
+          "131": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "131",
+            "Entity Name": "KERGUELEN IS."
+          },
+          "132": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "132",
+            "Entity Name": "PARAGUAY"
+          },
+          "133": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "133",
+            "Entity Name": "KERMADEC IS."
+          },
+          "134": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "134",
+            "Entity Name": "KINGMAN REEF",
+            "Deleted": "true"
+          },
+          "135": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "135",
+            "Entity Name": "KYRGYZSTAN"
+          },
+          "136": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "136",
+            "Entity Name": "PERU"
+          },
+          "137": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "137",
+            "Entity Name": "REPUBLIC OF KOREA"
+          },
+          "138": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "138",
+            "Entity Name": "KURE I."
+          },
+          "139": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "139",
+            "Entity Name": "KURIA MURIA I.",
+            "Deleted": "true"
+          },
+          "140": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "140",
+            "Entity Name": "SURINAME"
+          },
+          "141": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "141",
+            "Entity Name": "FALKLAND IS."
+          },
+          "142": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "142",
+            "Entity Name": "LAKSHADWEEP IS."
+          },
+          "143": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "143",
+            "Entity Name": "LAOS"
+          },
+          "144": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "144",
+            "Entity Name": "URUGUAY"
+          },
+          "145": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "145",
+            "Entity Name": "LATVIA"
+          },
+          "146": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "146",
+            "Entity Name": "LITHUANIA"
+          },
+          "147": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "147",
+            "Entity Name": "LORD HOWE I."
+          },
+          "148": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "148",
+            "Entity Name": "VENEZUELA"
+          },
+          "149": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "149",
+            "Entity Name": "AZORES"
+          },
+          "150": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "150",
+            "Entity Name": "AUSTRALIA"
+          },
+          "151": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "151",
+            "Entity Name": "MALYJ VYSOTSKIJ I.",
+            "Deleted": "true"
+          },
+          "152": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "152",
+            "Entity Name": "MACAO"
+          },
+          "153": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "153",
+            "Entity Name": "MACQUARIE I."
+          },
+          "154": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "154",
+            "Entity Name": "YEMEN ARAB REPUBLIC",
+            "Deleted": "true"
+          },
+          "155": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "155",
+            "Entity Name": "MALAYA",
+            "Deleted": "true"
+          },
+          "157": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "157",
+            "Entity Name": "NAURU"
+          },
+          "158": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "158",
+            "Entity Name": "VANUATU"
+          },
+          "159": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "159",
+            "Entity Name": "MALDIVES"
+          },
+          "160": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "160",
+            "Entity Name": "TONGA"
+          },
+          "161": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "161",
+            "Entity Name": "MALPELO I."
+          },
+          "162": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "162",
+            "Entity Name": "NEW CALEDONIA"
+          },
+          "163": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "163",
+            "Entity Name": "PAPUA NEW GUINEA"
+          },
+          "164": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "164",
+            "Entity Name": "MANCHURIA",
+            "Deleted": "true"
+          },
+          "165": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "165",
+            "Entity Name": "MAURITIUS"
+          },
+          "166": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "166",
+            "Entity Name": "MARIANA IS."
+          },
+          "167": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "167",
+            "Entity Name": "MARKET REEF"
+          },
+          "168": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "168",
+            "Entity Name": "MARSHALL IS."
+          },
+          "169": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "169",
+            "Entity Name": "MAYOTTE"
+          },
+          "170": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "170",
+            "Entity Name": "NEW ZEALAND"
+          },
+          "171": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "171",
+            "Entity Name": "MELLISH REEF"
+          },
+          "172": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "172",
+            "Entity Name": "PITCAIRN I."
+          },
+          "173": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "173",
+            "Entity Name": "MICRONESIA"
+          },
+          "174": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "174",
+            "Entity Name": "MIDWAY I."
+          },
+          "175": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "175",
+            "Entity Name": "FRENCH POLYNESIA"
+          },
+          "176": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "176",
+            "Entity Name": "FIJI"
+          },
+          "177": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "177",
+            "Entity Name": "MINAMI TORISHIMA"
+          },
+          "178": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "178",
+            "Entity Name": "MINERVA REEF",
+            "Deleted": "true"
+          },
+          "179": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "179",
+            "Entity Name": "MOLDOVA"
+          },
+          "180": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "180",
+            "Entity Name": "MOUNT ATHOS"
+          },
+          "181": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "181",
+            "Entity Name": "MOZAMBIQUE"
+          },
+          "182": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "182",
+            "Entity Name": "NAVASSA I."
+          },
+          "183": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "183",
+            "Entity Name": "NETHERLANDS BORNEO",
+            "Deleted": "true"
+          },
+          "184": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "184",
+            "Entity Name": "NETHERLANDS NEW GUINEA",
+            "Deleted": "true"
+          },
+          "185": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "185",
+            "Entity Name": "SOLOMON IS."
+          },
+          "186": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "186",
+            "Entity Name": "NEWFOUNDLAND, LABRADOR",
+            "Deleted": "true"
+          },
+          "187": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "187",
+            "Entity Name": "NIGER"
+          },
+          "188": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "188",
+            "Entity Name": "NIUE"
+          },
+          "189": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "189",
+            "Entity Name": "NORFOLK I."
+          },
+          "190": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "190",
+            "Entity Name": "SAMOA"
+          },
+          "191": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "191",
+            "Entity Name": "NORTH COOK IS."
+          },
+          "192": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "192",
+            "Entity Name": "OGASAWARA"
+          },
+          "193": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "193",
+            "Entity Name": "OKINAWA (RYUKYU IS.)",
+            "Deleted": "true"
+          },
+          "194": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "194",
+            "Entity Name": "OKINO TORI-SHIMA",
+            "Deleted": "true"
+          },
+          "195": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "195",
+            "Entity Name": "ANNOBON I."
+          },
+          "196": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "196",
+            "Entity Name": "PALESTINE",
+            "Deleted": "true"
+          },
+          "197": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "197",
+            "Entity Name": "PALMYRA \u0026 JARVIS IS."
+          },
+          "198": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "198",
+            "Entity Name": "PAPUA TERRITORY",
+            "Deleted": "true"
+          },
+          "199": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "199",
+            "Entity Name": "PETER 1 I."
+          },
+          "200": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "200",
+            "Entity Name": "PORTUGUESE TIMOR",
+            "Deleted": "true"
+          },
+          "201": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "201",
+            "Entity Name": "PRINCE EDWARD \u0026 MARION IS."
+          },
+          "202": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "202",
+            "Entity Name": "PUERTO RICO"
+          },
+          "203": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "203",
+            "Entity Name": "ANDORRA"
+          },
+          "204": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "204",
+            "Entity Name": "REVILLAGIGEDO"
+          },
+          "205": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "205",
+            "Entity Name": "ASCENSION I."
+          },
+          "206": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "206",
+            "Entity Name": "AUSTRIA"
+          },
+          "207": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "207",
+            "Entity Name": "RODRIGUES I."
+          },
+          "208": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "208",
+            "Entity Name": "RUANDA-URUNDI",
+            "Deleted": "true"
+          },
+          "209": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "209",
+            "Entity Name": "BELGIUM"
+          },
+          "210": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "210",
+            "Entity Name": "SAAR",
+            "Deleted": "true"
+          },
+          "211": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "211",
+            "Entity Name": "SABLE I."
+          },
+          "212": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "212",
+            "Entity Name": "BULGARIA"
+          },
+          "213": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "213",
+            "Entity Name": "SAINT MARTIN"
+          },
+          "214": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "214",
+            "Entity Name": "CORSICA"
+          },
+          "215": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "215",
+            "Entity Name": "CYPRUS"
+          },
+          "216": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "216",
+            "Entity Name": "SAN ANDRES \u0026 PROVIDENCIA"
+          },
+          "217": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "217",
+            "Entity Name": "SAN FELIX \u0026 SAN AMBROSIO"
+          },
+          "218": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "218",
+            "Entity Name": "CZECHOSLOVAKIA",
+            "Deleted": "true"
+          },
+          "219": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "219",
+            "Entity Name": "SAO TOME \u0026 PRINCIPE"
+          },
+          "220": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "220",
+            "Entity Name": "SARAWAK",
+            "Deleted": "true"
+          },
+          "221": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "221",
+            "Entity Name": "DENMARK"
+          },
+          "222": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "222",
+            "Entity Name": "FAROE IS."
+          },
+          "223": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "223",
+            "Entity Name": "ENGLAND"
+          },
+          "224": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "224",
+            "Entity Name": "FINLAND"
+          },
+          "225": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "225",
+            "Entity Name": "SARDINIA"
+          },
+          "226": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "226",
+            "Entity Name": "SAUDI ARABIA/IRAQ NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "227": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "227",
+            "Entity Name": "FRANCE"
+          },
+          "228": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "228",
+            "Entity Name": "SERRANA BANK \u0026 RONCADOR CAY",
+            "Deleted": "true"
+          },
+          "229": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "229",
+            "Entity Name": "GERMAN DEMOCRATIC REPUBLIC",
+            "Deleted": "true"
+          },
+          "230": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "230",
+            "Entity Name": "FEDERAL REPUBLIC OF GERMANY"
+          },
+          "231": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "231",
+            "Entity Name": "SIKKIM",
+            "Deleted": "true"
+          },
+          "232": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "232",
+            "Entity Name": "SOMALIA"
+          },
+          "233": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "233",
+            "Entity Name": "GIBRALTAR"
+          },
+          "234": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "234",
+            "Entity Name": "SOUTH COOK IS."
+          },
+          "235": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "235",
+            "Entity Name": "SOUTH GEORGIA I."
+          },
+          "236": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "236",
+            "Entity Name": "GREECE"
+          },
+          "237": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "237",
+            "Entity Name": "GREENLAND"
+          },
+          "238": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "238",
+            "Entity Name": "SOUTH ORKNEY IS."
+          },
+          "239": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "239",
+            "Entity Name": "HUNGARY"
+          },
+          "240": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "240",
+            "Entity Name": "SOUTH SANDWICH IS."
+          },
+          "241": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "241",
+            "Entity Name": "SOUTH SHETLAND IS."
+          },
+          "242": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "242",
+            "Entity Name": "ICELAND"
+          },
+          "243": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "243",
+            "Entity Name": "PEOPLE\u0027S DEMOCRATIC REP. OF YEMEN",
+            "Deleted": "true"
+          },
+          "244": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "244",
+            "Entity Name": "SOUTHERN SUDAN",
+            "Deleted": "true"
+          },
+          "245": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "245",
+            "Entity Name": "IRELAND"
+          },
+          "246": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "246",
+            "Entity Name": "SOVEREIGN MILITARY ORDER OF MALTA"
+          },
+          "247": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "247",
+            "Entity Name": "SPRATLY IS."
+          },
+          "248": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "248",
+            "Entity Name": "ITALY"
+          },
+          "249": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "249",
+            "Entity Name": "ST. KITTS \u0026 NEVIS"
+          },
+          "250": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "250",
+            "Entity Name": "ST. HELENA"
+          },
+          "251": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "251",
+            "Entity Name": "LIECHTENSTEIN"
+          },
+          "252": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "252",
+            "Entity Name": "ST. PAUL I."
+          },
+          "253": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "253",
+            "Entity Name": "ST. PETER \u0026 ST. PAUL ROCKS"
+          },
+          "254": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "254",
+            "Entity Name": "LUXEMBOURG"
+          },
+          "255": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "255",
+            "Entity Name": "ST. MAARTEN, SABA, ST. EUSTATIUS",
+            "Deleted": "true"
+          },
+          "256": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "256",
+            "Entity Name": "MADEIRA IS."
+          },
+          "257": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "257",
+            "Entity Name": "MALTA"
+          },
+          "258": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "258",
+            "Entity Name": "SUMATRA",
+            "Deleted": "true"
+          },
+          "259": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "259",
+            "Entity Name": "SVALBARD"
+          },
+          "260": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "260",
+            "Entity Name": "MONACO"
+          },
+          "261": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "261",
+            "Entity Name": "SWAN IS.",
+            "Deleted": "true"
+          },
+          "262": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "262",
+            "Entity Name": "TAJIKISTAN"
+          },
+          "263": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "263",
+            "Entity Name": "NETHERLANDS"
+          },
+          "264": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "264",
+            "Entity Name": "TANGIER",
+            "Deleted": "true"
+          },
+          "265": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "265",
+            "Entity Name": "NORTHERN IRELAND"
+          },
+          "266": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "266",
+            "Entity Name": "NORWAY"
+          },
+          "267": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "267",
+            "Entity Name": "TERRITORY OF NEW GUINEA",
+            "Deleted": "true"
+          },
+          "268": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "268",
+            "Entity Name": "TIBET",
+            "Deleted": "true"
+          },
+          "269": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "269",
+            "Entity Name": "POLAND"
+          },
+          "270": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "270",
+            "Entity Name": "TOKELAU IS."
+          },
+          "271": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "271",
+            "Entity Name": "TRIESTE",
+            "Deleted": "true"
+          },
+          "272": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "272",
+            "Entity Name": "PORTUGAL"
+          },
+          "273": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "273",
+            "Entity Name": "TRINDADE \u0026 MARTIM VAZ IS."
+          },
+          "274": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "274",
+            "Entity Name": "TRISTAN DA CUNHA \u0026 GOUGH I."
+          },
+          "275": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "275",
+            "Entity Name": "ROMANIA"
+          },
+          "276": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "276",
+            "Entity Name": "TROMELIN I."
+          },
+          "277": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "277",
+            "Entity Name": "ST. PIERRE \u0026 MIQUELON"
+          },
+          "278": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "278",
+            "Entity Name": "SAN MARINO"
+          },
+          "279": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "279",
+            "Entity Name": "SCOTLAND"
+          },
+          "280": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "280",
+            "Entity Name": "TURKMENISTAN"
+          },
+          "281": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "281",
+            "Entity Name": "SPAIN"
+          },
+          "282": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "282",
+            "Entity Name": "TUVALU"
+          },
+          "283": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "283",
+            "Entity Name": "UK SOVEREIGN BASE AREAS ON CYPRUS"
+          },
+          "284": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "284",
+            "Entity Name": "SWEDEN"
+          },
+          "285": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "285",
+            "Entity Name": "VIRGIN IS."
+          },
+          "286": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "286",
+            "Entity Name": "UGANDA"
+          },
+          "287": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "287",
+            "Entity Name": "SWITZERLAND"
+          },
+          "288": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "288",
+            "Entity Name": "UKRAINE"
+          },
+          "289": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "289",
+            "Entity Name": "UNITED NATIONS HQ"
+          },
+          "291": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "291",
+            "Entity Name": "UNITED STATES OF AMERICA"
+          },
+          "292": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "292",
+            "Entity Name": "UZBEKISTAN"
+          },
+          "293": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "293",
+            "Entity Name": "VIET NAM"
+          },
+          "294": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "294",
+            "Entity Name": "WALES"
+          },
+          "295": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "295",
+            "Entity Name": "VATICAN"
+          },
+          "296": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "296",
+            "Entity Name": "SERBIA"
+          },
+          "297": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "297",
+            "Entity Name": "WAKE I."
+          },
+          "298": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "298",
+            "Entity Name": "WALLIS \u0026 FUTUNA IS."
+          },
+          "299": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "299",
+            "Entity Name": "WEST MALAYSIA"
+          },
+          "301": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "301",
+            "Entity Name": "W. KIRIBATI (GILBERT IS. )"
+          },
+          "302": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "302",
+            "Entity Name": "WESTERN SAHARA"
+          },
+          "303": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "303",
+            "Entity Name": "WILLIS I."
+          },
+          "304": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "304",
+            "Entity Name": "BAHRAIN"
+          },
+          "305": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "305",
+            "Entity Name": "BANGLADESH"
+          },
+          "306": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "306",
+            "Entity Name": "BHUTAN"
+          },
+          "307": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "307",
+            "Entity Name": "ZANZIBAR",
+            "Deleted": "true"
+          },
+          "308": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "308",
+            "Entity Name": "COSTA RICA"
+          },
+          "309": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "309",
+            "Entity Name": "MYANMAR"
+          },
+          "312": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "312",
+            "Entity Name": "CAMBODIA"
+          },
+          "315": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "315",
+            "Entity Name": "SRI LANKA"
+          },
+          "318": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "318",
+            "Entity Name": "CHINA"
+          },
+          "321": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "321",
+            "Entity Name": "HONG KONG"
+          },
+          "324": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "324",
+            "Entity Name": "INDIA"
+          },
+          "327": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "327",
+            "Entity Name": "INDONESIA"
+          },
+          "330": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "330",
+            "Entity Name": "IRAN"
+          },
+          "333": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "333",
+            "Entity Name": "IRAQ"
+          },
+          "336": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "336",
+            "Entity Name": "ISRAEL"
+          },
+          "339": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "339",
+            "Entity Name": "JAPAN"
+          },
+          "342": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "342",
+            "Entity Name": "JORDAN"
+          },
+          "344": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "344",
+            "Entity Name": "DEMOCRATIC PEOPLE\u0027S REP. OF KOREA"
+          },
+          "345": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "345",
+            "Entity Name": "BRUNEI DARUSSALAM"
+          },
+          "348": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "348",
+            "Entity Name": "KUWAIT"
+          },
+          "354": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "354",
+            "Entity Name": "LEBANON"
+          },
+          "363": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "363",
+            "Entity Name": "MONGOLIA"
+          },
+          "369": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "369",
+            "Entity Name": "NEPAL"
+          },
+          "370": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "370",
+            "Entity Name": "OMAN"
+          },
+          "372": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "372",
+            "Entity Name": "PAKISTAN"
+          },
+          "375": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "375",
+            "Entity Name": "PHILIPPINES"
+          },
+          "376": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "376",
+            "Entity Name": "QATAR"
+          },
+          "378": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "378",
+            "Entity Name": "SAUDI ARABIA"
+          },
+          "379": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "379",
+            "Entity Name": "SEYCHELLES"
+          },
+          "381": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "381",
+            "Entity Name": "SINGAPORE"
+          },
+          "382": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "382",
+            "Entity Name": "DJIBOUTI"
+          },
+          "384": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "384",
+            "Entity Name": "SYRIA"
+          },
+          "386": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "386",
+            "Entity Name": "TAIWAN"
+          },
+          "387": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "387",
+            "Entity Name": "THAILAND"
+          },
+          "390": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "390",
+            "Entity Name": "TURKEY"
+          },
+          "391": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "391",
+            "Entity Name": "UNITED ARAB EMIRATES"
+          },
+          "400": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "400",
+            "Entity Name": "ALGERIA"
+          },
+          "401": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "401",
+            "Entity Name": "ANGOLA"
+          },
+          "402": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "402",
+            "Entity Name": "BOTSWANA"
+          },
+          "404": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "404",
+            "Entity Name": "BURUNDI"
+          },
+          "406": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "406",
+            "Entity Name": "CAMEROON"
+          },
+          "408": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "408",
+            "Entity Name": "CENTRAL AFRICA"
+          },
+          "409": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "409",
+            "Entity Name": "CAPE VERDE"
+          },
+          "410": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "410",
+            "Entity Name": "CHAD"
+          },
+          "411": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "411",
+            "Entity Name": "COMOROS"
+          },
+          "412": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "412",
+            "Entity Name": "REPUBLIC OF THE CONGO"
+          },
+          "414": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "414",
+            "Entity Name": "DEMOCRATIC REPUBLIC OF THE CONGO"
+          },
+          "416": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "416",
+            "Entity Name": "BENIN"
+          },
+          "420": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "420",
+            "Entity Name": "GABON"
+          },
+          "422": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "422",
+            "Entity Name": "THE GAMBIA"
+          },
+          "424": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "424",
+            "Entity Name": "GHANA"
+          },
+          "428": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "428",
+            "Entity Name": "COTE D\u0027IVOIRE"
+          },
+          "430": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "430",
+            "Entity Name": "KENYA"
+          },
+          "432": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "432",
+            "Entity Name": "LESOTHO"
+          },
+          "434": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "434",
+            "Entity Name": "LIBERIA"
+          },
+          "436": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "436",
+            "Entity Name": "LIBYA"
+          },
+          "438": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "438",
+            "Entity Name": "MADAGASCAR"
+          },
+          "440": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "440",
+            "Entity Name": "MALAWI"
+          },
+          "442": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "442",
+            "Entity Name": "MALI"
+          },
+          "444": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "444",
+            "Entity Name": "MAURITANIA"
+          },
+          "446": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "446",
+            "Entity Name": "MOROCCO"
+          },
+          "450": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "450",
+            "Entity Name": "NIGERIA"
+          },
+          "452": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "452",
+            "Entity Name": "ZIMBABWE"
+          },
+          "453": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "453",
+            "Entity Name": "REUNION I."
+          },
+          "454": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "454",
+            "Entity Name": "RWANDA"
+          },
+          "456": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "456",
+            "Entity Name": "SENEGAL"
+          },
+          "458": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "458",
+            "Entity Name": "SIERRA LEONE"
+          },
+          "460": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "460",
+            "Entity Name": "ROTUMA I."
+          },
+          "462": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "462",
+            "Entity Name": "REPUBLIC OF SOUTH AFRICA"
+          },
+          "464": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "464",
+            "Entity Name": "NAMIBIA"
+          },
+          "466": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "466",
+            "Entity Name": "SUDAN"
+          },
+          "468": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "468",
+            "Entity Name": "KINGDOM OF ESWATINI"
+          },
+          "470": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "470",
+            "Entity Name": "TANZANIA"
+          },
+          "474": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "474",
+            "Entity Name": "TUNISIA"
+          },
+          "478": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "478",
+            "Entity Name": "EGYPT"
+          },
+          "480": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "480",
+            "Entity Name": "BURKINA FASO"
+          },
+          "482": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "482",
+            "Entity Name": "ZAMBIA"
+          },
+          "483": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "483",
+            "Entity Name": "TOGO"
+          },
+          "488": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "488",
+            "Entity Name": "WALVIS BAY",
+            "Deleted": "true"
+          },
+          "489": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "489",
+            "Entity Name": "CONWAY REEF"
+          },
+          "490": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "490",
+            "Entity Name": "BANABA I. (OCEAN I.)"
+          },
+          "492": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "492",
+            "Entity Name": "YEMEN"
+          },
+          "493": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "493",
+            "Entity Name": "PENGUIN IS.",
+            "Deleted": "true"
+          },
+          "497": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "497",
+            "Entity Name": "CROATIA"
+          },
+          "499": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "499",
+            "Entity Name": "SLOVENIA"
+          },
+          "501": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "501",
+            "Entity Name": "BOSNIA-HERZEGOVINA"
+          },
+          "502": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "502",
+            "Entity Name": "NORTH MACEDONIA (REPUBLIC OF)"
+          },
+          "503": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "503",
+            "Entity Name": "CZECH REPUBLIC"
+          },
+          "504": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "504",
+            "Entity Name": "SLOVAK REPUBLIC"
+          },
+          "505": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "505",
+            "Entity Name": "PRATAS I."
+          },
+          "506": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "506",
+            "Entity Name": "SCARBOROUGH REEF"
+          },
+          "507": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "507",
+            "Entity Name": "TEMOTU PROVINCE"
+          },
+          "508": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "508",
+            "Entity Name": "AUSTRAL I."
+          },
+          "509": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "509",
+            "Entity Name": "MARQUESAS IS."
+          },
+          "510": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "510",
+            "Entity Name": "PALESTINE"
+          },
+          "511": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "511",
+            "Entity Name": "TIMOR-LESTE"
+          },
+          "512": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "512",
+            "Entity Name": "CHESTERFIELD IS."
+          },
+          "513": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "513",
+            "Entity Name": "DUCIE I."
+          },
+          "514": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "514",
+            "Entity Name": "MONTENEGRO"
+          },
+          "515": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "515",
+            "Entity Name": "SWAINS I."
+          },
+          "516": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "516",
+            "Entity Name": "SAINT BARTHELEMY"
+          },
+          "517": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "517",
+            "Entity Name": "CURACAO"
+          },
+          "518": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "518",
+            "Entity Name": "SINT MAARTEN"
+          },
+          "519": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "519",
+            "Entity Name": "SABA \u0026 ST. EUSTATIUS"
+          },
+          "520": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "520",
+            "Entity Name": "BONAIRE"
+          },
+          "521": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "521",
+            "Entity Name": "SOUTH SUDAN (REPUBLIC OF)"
+          },
+          "522": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "522",
+            "Entity Name": "REPUBLIC OF KOSOVO"
+          }
+        }
+      },
+      "EQSL_AG": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "Y",
+            "Description": "The QSO\u0027s callsign holds eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "N": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "N",
+            "Description": "The QSO\u0027s callsign does not hold eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "U": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "U",
+            "Description": "Unspecified (Default)"
+          }
+        }
+      },
+      "Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Mode",
+          "Submodes",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AM": {
+            "Enumeration Name": "Mode",
+            "Mode": "AM"
+          },
+          "ARDOP": {
+            "Enumeration Name": "Mode",
+            "Mode": "ARDOP",
+            "Description": "Amateur Radio Digital Open Protocol"
+          },
+          "ATV": {
+            "Enumeration Name": "Mode",
+            "Mode": "ATV"
+          },
+          "CHIP": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP",
+            "Submodes": "CHIP64,CHIP128"
+          },
+          "CLO": {
+            "Enumeration Name": "Mode",
+            "Mode": "CLO"
+          },
+          "CONTESTI": {
+            "Enumeration Name": "Mode",
+            "Mode": "CONTESTI"
+          },
+          "CW": {
+            "Enumeration Name": "Mode",
+            "Mode": "CW",
+            "Submodes": "PCW"
+          },
+          "DIGITALVOICE": {
+            "Enumeration Name": "Mode",
+            "Mode": "DIGITALVOICE",
+            "Submodes": "C4FM,DMR,DSTAR,FREEDV,M17"
+          },
+          "DOMINO": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINO",
+            "Submodes": "DOM-M,DOM4,DOM5,DOM8,DOM11,DOM16,DOM22,DOM44,DOM88,DOMINOEX,DOMINOF"
+          },
+          "DYNAMIC": {
+            "Enumeration Name": "Mode",
+            "Mode": "DYNAMIC",
+            "Submodes": "FREEDATA,VARA HF,VARA SATELLITE,VARA FM 1200,VARA FM 9600"
+          },
+          "FAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "FAX"
+          },
+          "FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "FM"
+          },
+          "FSK441": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK441"
+          },
+          "FSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK",
+            "Submodes": "SCAMP_FAST,SCAMP_SLOW,SCAMP_VSLOW",
+            "Description": "Frequency shift keying"
+          },
+          "FT8": {
+            "Enumeration Name": "Mode",
+            "Mode": "FT8",
+            "Description": "Franke-Taylor design, 8-FSK modulation"
+          },
+          "HELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL",
+            "Submodes": "FMHELL,FSKH105,FSKH245,FSKHELL,HELL80,HELLX5,HELLX9,HFSK,PSKHELL,SLOWHELL"
+          },
+          "ISCAT": {
+            "Enumeration Name": "Mode",
+            "Mode": "ISCAT",
+            "Submodes": "ISCAT-A,ISCAT-B"
+          },
+          "JT4": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4",
+            "Submodes": "JT4A,JT4B,JT4C,JT4D,JT4E,JT4F,JT4G"
+          },
+          "JT6M": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT6M"
+          },
+          "JT9": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT9",
+            "Submodes": "JT9-1,JT9-2,JT9-5,JT9-10,JT9-30,JT9A,JT9B,JT9C,JT9D,JT9E,JT9E FAST,JT9F,JT9F FAST,JT9G,JT9G FAST,JT9H,JT9H FAST"
+          },
+          "JT44": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT44"
+          },
+          "JT65": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65",
+            "Submodes": "JT65A,JT65B,JT65B2,JT65C,JT65C2"
+          },
+          "MFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK",
+            "Submodes": "FSQCALL,FST4,FST4W,FT2,FT4,JS8,JTMS,MFSK4,MFSK8,MFSK11,MFSK16,MFSK22,MFSK31,MFSK32,MFSK64,MFSK64L,MFSK128 MFSK128L,Q65"
+          },
+          "MSK144": {
+            "Enumeration Name": "Mode",
+            "Mode": "MSK144"
+          },
+          "MTONE": {
+            "Enumeration Name": "Mode",
+            "Mode": "MTONE",
+            "Submodes": "SCAMP_OO,SCAMP_OO_SLW",
+            "Description": "Single modulated tone"
+          },
+          "MT63": {
+            "Enumeration Name": "Mode",
+            "Mode": "MT63"
+          },
+          "OFDM": {
+            "Enumeration Name": "Mode",
+            "Mode": "OFDM",
+            "Submodes": "RIBBIT_PIX,RIBBIT_SMS",
+            "Description": "Orthogonal Frequency-Division Multiplexing including COFDM"
+          },
+          "OLIVIA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OLIVIA",
+            "Submodes": "OLIVIA 4/125,OLIVIA 4/250,OLIVIA 8/250,OLIVIA 8/500,OLIVIA 16/500,OLIVIA 16/1000,OLIVIA 32/1000"
+          },
+          "OPERA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OPERA",
+            "Submodes": "OPERA-BEACON,OPERA-QSO"
+          },
+          "PAC": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC",
+            "Submodes": "PAC2,PAC3,PAC4"
+          },
+          "PAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX",
+            "Submodes": "PAX2"
+          },
+          "PKT": {
+            "Enumeration Name": "Mode",
+            "Mode": "PKT"
+          },
+          "PSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK",
+            "Submodes": "8PSK125,8PSK125F,8PSK125FL,8PSK250,8PSK250F,8PSK250FL,8PSK500,8PSK500F,8PSK1000,8PSK1000F,8PSK1200F,FSK31,PSK10,PSK31,PSK63,PSK63F,PSK63RC4,PSK63RC5,PSK63RC10,PSK63RC20,PSK63RC32,PSK125,PSK125C12,PSK125R,PSK125RC10,PSK125RC12,PSK125RC16,PSK125RC4,PSK125RC5,PSK250,PSK250C6,PSK250R,PSK250RC2,PSK250RC3,PSK250RC5,PSK250RC6,PSK250RC7,PSK500,PSK500C2,PSK500C4,PSK500R,PSK500RC2,PSK500RC3,PSK500RC4,PSK800C2,PSK800RC2,PSK1000,PSK1000C2,PSK1000R,PSK1000RC2,PSKAM10,PSKAM31,PSKAM50,PSKFEC31,QPSK31,QPSK63,QPSK125,QPSK250,QPSK500,SIM31"
+          },
+          "PSK2K": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK2K"
+          },
+          "Q15": {
+            "Enumeration Name": "Mode",
+            "Mode": "Q15"
+          },
+          "QRA64": {
+            "Enumeration Name": "Mode",
+            "Mode": "QRA64",
+            "Submodes": "QRA64A,QRA64B,QRA64C,QRA64D,QRA64E"
+          },
+          "ROS": {
+            "Enumeration Name": "Mode",
+            "Mode": "ROS",
+            "Submodes": "ROS-EME,ROS-HF,ROS-MF"
+          },
+          "RTTY": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTY",
+            "Submodes": "ASCI"
+          },
+          "RTTYM": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTYM"
+          },
+          "SSB": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSB",
+            "Submodes": "LSB,USB"
+          },
+          "SSTV": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSTV"
+          },
+          "T10": {
+            "Enumeration Name": "Mode",
+            "Mode": "T10",
+            "Description": "Tonal 10 digital mode with focus on sensitivity, band capacity and resistance to the HF Doppler frequency spread"
+          },
+          "THOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "THOR",
+            "Submodes": "THOR-M,THOR4,THOR5,THOR8,THOR11,THOR16,THOR22,THOR25X4,THOR50X1,THOR50X2,THOR100"
+          },
+          "THRB": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRB",
+            "Submodes": "THRBX,THRBX1,THRBX2,THRBX4,THROB1,THROB2,THROB4"
+          },
+          "TOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "TOR",
+            "Submodes": "AMTORFEC,GTOR,NAVTEX,SITORB"
+          },
+          "V4": {
+            "Enumeration Name": "Mode",
+            "Mode": "V4"
+          },
+          "VOI": {
+            "Enumeration Name": "Mode",
+            "Mode": "VOI"
+          },
+          "WINMOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WINMOR"
+          },
+          "WSPR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WSPR"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Mode",
+            "Mode": "AMTORFEC",
+            "Import-only": "true"
+          },
+          "ASCI": {
+            "Enumeration Name": "Mode",
+            "Mode": "ASCI",
+            "Import-only": "true"
+          },
+          "C4FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "C4FM",
+            "Description": "C4FM 4-level FSK Technology Imported QSOs with \u003CMODE:4\u003EC4FM\u003E must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:4\u003EC4FM",
+            "Import-only": "true"
+          },
+          "CHIP64": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP64",
+            "Import-only": "true"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP128",
+            "Import-only": "true"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINOF",
+            "Import-only": "true"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Mode",
+            "Mode": "DSTAR",
+            "Description": "Digital Smart Technologies for Amateur Radio Imported QSOs with \u003CMODE:5\u003EDSTAR must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:5\u003EDSTAR",
+            "Import-only": "true"
+          },
+          "FMHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "FMHELL",
+            "Import-only": "true"
+          },
+          "FSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK31",
+            "Import-only": "true"
+          },
+          "GTOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "GTOR",
+            "Import-only": "true"
+          },
+          "HELL80": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL80",
+            "Import-only": "true"
+          },
+          "HFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "HFSK",
+            "Import-only": "true"
+          },
+          "JT4A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4A",
+            "Import-only": "true"
+          },
+          "JT4B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4B",
+            "Import-only": "true"
+          },
+          "JT4C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4C",
+            "Import-only": "true"
+          },
+          "JT4D": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4D",
+            "Import-only": "true"
+          },
+          "JT4E": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4E",
+            "Import-only": "true"
+          },
+          "JT4F": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4F",
+            "Import-only": "true"
+          },
+          "JT4G": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4G",
+            "Import-only": "true"
+          },
+          "JT65A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65A",
+            "Import-only": "true"
+          },
+          "JT65B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65B",
+            "Import-only": "true"
+          },
+          "JT65C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65C",
+            "Import-only": "true"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK8",
+            "Import-only": "true"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK16",
+            "Import-only": "true"
+          },
+          "PAC2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC2",
+            "Import-only": "true"
+          },
+          "PAC3": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC3",
+            "Import-only": "true"
+          },
+          "PAX2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX2",
+            "Import-only": "true"
+          },
+          "PCW": {
+            "Enumeration Name": "Mode",
+            "Mode": "PCW",
+            "Import-only": "true"
+          },
+          "PSK10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK10",
+            "Import-only": "true"
+          },
+          "PSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK31",
+            "Import-only": "true"
+          },
+          "PSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63",
+            "Import-only": "true"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63F",
+            "Import-only": "true"
+          },
+          "PSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK125",
+            "Import-only": "true"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM10",
+            "Import-only": "true"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM31",
+            "Import-only": "true"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM50",
+            "Import-only": "true"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKFEC31",
+            "Import-only": "true"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKHELL",
+            "Import-only": "true"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK31",
+            "Import-only": "true"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK63",
+            "Import-only": "true"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK125",
+            "Import-only": "true"
+          },
+          "THRBX": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRBX",
+            "Import-only": "true"
+          }
+        }
+      },
+      "Morse_Key_Type": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Characteristics",
+          "Morse Composition",
+          "Examples",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "SK": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SK",
+            "Meaning": "Straight Key",
+            "Characteristics": "a single control which actuates a single switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "Lionel J-38"
+          },
+          "SS": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SS",
+            "Meaning": "Sideswiper",
+            "Characteristics": "a single control which actuates a SPDT (single poll, double throw) switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "W1SFR Green Machine Torsion Bar Cootie"
+          },
+          "BUG": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "BUG",
+            "Meaning": "Mechanical semi-automatic keyer or Bug",
+            "Characteristics": "a control which actuates a switch as well as a control which actuates a spring and pendulum mechanism which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and a human makes the dahs and builds characters.",
+            "Examples": "Vibroplex Blue Racer Deluxe"
+          },
+          "FAB": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "FAB",
+            "Meaning": "Mechanical fully-automatic keyer or Bug",
+            "Characteristics": "a control which actuates one of two separate spring and pendulum mechanisms at a time, each of which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds characters.",
+            "Examples": "GHD GN209FA fully-automatic bug"
+          },
+          "SP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SP",
+            "Meaning": "Single Paddle",
+            "Characteristics": "a single control which actuates two independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "American Morse Mini-B"
+          },
+          "DP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "DP",
+            "Meaning": "Dual Paddle",
+            "Characteristics": "two controls which actuate independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "Begali Sculpture, VK3IL pressure paddles, M0UKD capacitive touch paddles"
+          },
+          "CPU": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "CPU",
+            "Meaning": "Computer Driven",
+            "Characteristics": "an electronic device performs the actuation of the switch.",
+            "Morse Composition": "a machine makes the dits and dahs to build the characters.",
+            "Examples": "N1MM\u002B Logging Software"
+          }
+        }
+      },
+      "Primary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Primary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Contained Within",
+          "Oblast #",
+          "CQ Zone",
+          "ITU Zone",
+          "Prefix",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NS.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "QC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QC",
+            "Primary Administrative Subdivision": "Québec",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "04,09"
+          },
+          "ON.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ON",
+            "Primary Administrative Subdivision": "Ontario",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "MB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Manitoba",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "SK.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Saskatchewan",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03"
+          },
+          "AB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alberta",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "02"
+          },
+          "BC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "British Columbia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "03",
+            "ITU Zone": "02"
+          },
+          "NT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northwest Territories",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01,02,04",
+            "ITU Zone": "03,04,75"
+          },
+          "NB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NL.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Newfoundland and Labrador",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "09"
+          },
+          "YT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YT",
+            "Primary Administrative Subdivision": "Yukon",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01",
+            "ITU Zone": "02"
+          },
+          "PE.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NU.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nunavut",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02",
+            "ITU Zone": "04,09"
+          },
+          "001.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "001",
+            "Primary Administrative Subdivision": "Brändö",
+            "DXCC Entity Code": "5"
+          },
+          "002.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "002",
+            "Primary Administrative Subdivision": "Eckerö",
+            "DXCC Entity Code": "5"
+          },
+          "003.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "003",
+            "Primary Administrative Subdivision": "Finström",
+            "DXCC Entity Code": "5"
+          },
+          "004.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "004",
+            "Primary Administrative Subdivision": "Föglö",
+            "DXCC Entity Code": "5"
+          },
+          "005.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "005",
+            "Primary Administrative Subdivision": "Geta",
+            "DXCC Entity Code": "5"
+          },
+          "006.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "006",
+            "Primary Administrative Subdivision": "Hammarland",
+            "DXCC Entity Code": "5"
+          },
+          "007.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "007",
+            "Primary Administrative Subdivision": "Jomala",
+            "DXCC Entity Code": "5"
+          },
+          "008.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "008",
+            "Primary Administrative Subdivision": "Kumlinge",
+            "DXCC Entity Code": "5"
+          },
+          "009.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "009",
+            "Primary Administrative Subdivision": "Kökar",
+            "DXCC Entity Code": "5"
+          },
+          "010.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "010",
+            "Primary Administrative Subdivision": "Lemland",
+            "DXCC Entity Code": "5"
+          },
+          "011.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "011",
+            "Primary Administrative Subdivision": "Lumparland",
+            "DXCC Entity Code": "5"
+          },
+          "012.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "012",
+            "Primary Administrative Subdivision": "Maarianhamina",
+            "DXCC Entity Code": "5"
+          },
+          "013.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "013",
+            "Primary Administrative Subdivision": "Saltvik",
+            "DXCC Entity Code": "5"
+          },
+          "014.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "014",
+            "Primary Administrative Subdivision": "Sottunga",
+            "DXCC Entity Code": "5"
+          },
+          "015.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Sund",
+            "DXCC Entity Code": "5"
+          },
+          "016.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "016",
+            "Primary Administrative Subdivision": "Vårdö",
+            "DXCC Entity Code": "5"
+          },
+          "051.5.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "051",
+            "Primary Administrative Subdivision": "Märket",
+            "DXCC Entity Code": "5",
+            "Deleted": "true"
+          },
+          "AK.6": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AK",
+            "Primary Administrative Subdivision": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AN.11": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Andaman and Nicobar Islands",
+            "DXCC Entity Code": "11",
+            "Comments": "Union territory"
+          },
+          "UO.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UO",
+            "Primary Administrative Subdivision": "Ust’-Ordynsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "174",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-01-01"
+          },
+          "AB.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Aginsky Buryatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "175",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-03-01"
+          },
+          "CB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Chelyabinsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "165",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Chelyabinskaya oblast"
+          },
+          "SV.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Sverdlovskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "154",
+            "CQ Zone": "17",
+            "ITU Zone": "30"
+          },
+          "PM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Perm\u0060",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "for contacts made on or after 2005-12-01; Permskaya oblast"
+          },
+          "PM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Permskaya Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "KP.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KP",
+            "Primary Administrative Subdivision": "Komi-Permyatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "141",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "TO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tomsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "158",
+            "CQ Zone": "18",
+            "ITU Zone": "30",
+            "Comments": "Tomskaya oblast"
+          },
+          "HM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khanty-Mansyisky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "162",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "YN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yamalo-Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "163",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "TN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tyumen\u0027",
+            "DXCC Entity Code": "15",
+            "Oblast #": "161",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Tyumenskaya oblast"
+          },
+          "OM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OM",
+            "Primary Administrative Subdivision": "Omsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "146",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Omskaya oblast"
+          },
+          "NS.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Novosibirsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "145",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Novosibirskaya oblast"
+          },
+          "KN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KN",
+            "Primary Administrative Subdivision": "Kurgan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "134",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Kurganskaya oblast"
+          },
+          "OB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OB",
+            "Primary Administrative Subdivision": "Orenburg",
+            "DXCC Entity Code": "15",
+            "Oblast #": "167",
+            "CQ Zone": "S=16 T=17",
+            "ITU Zone": "30",
+            "Comments": "Orenburgskaya oblast"
+          },
+          "KE.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kemerovo",
+            "DXCC Entity Code": "15",
+            "Oblast #": "130",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Kemerovskaya oblast"
+          },
+          "BA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Republic of Bashkortostan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "84",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "KO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Republic of Komi",
+            "DXCC Entity Code": "15",
+            "Oblast #": "90",
+            "CQ Zone": "17",
+            "ITU Zone": "20"
+          },
+          "AL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Altaysky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "99",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "GA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Republic Gorny Altay",
+            "DXCC Entity Code": "15",
+            "Oblast #": "100",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "KK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Krasnoyarsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "103",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Krasnoyarsk Kraj"
+          },
+          "TM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Taymyr Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "105",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "HK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HK",
+            "Primary Administrative Subdivision": "Khabarovsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "110",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Khabarovsky Kraj"
+          },
+          "EA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EA",
+            "Primary Administrative Subdivision": "Yevreyskaya Autonomous Oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "111",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "SL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sakhalin",
+            "DXCC Entity Code": "15",
+            "Oblast #": "153",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Sakhalinskaya oblast"
+          },
+          "EV.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evenkiysky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "106",
+            "CQ Zone": "18",
+            "ITU Zone": "22",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "MG.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Magadan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "138",
+            "CQ Zone": "19",
+            "ITU Zone": "24",
+            "Comments": "Magadanskaya oblast"
+          },
+          "AM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amurskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "112",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "CK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CK",
+            "Primary Administrative Subdivision": "Chukotka Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "139",
+            "CQ Zone": "19",
+            "ITU Zone": "26"
+          },
+          "PK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Primorsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "107",
+            "CQ Zone": "19",
+            "ITU Zone": "34"
+          },
+          "BU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Republic of Buryatia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "85",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "YA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Republic of Sakha",
+            "DXCC Entity Code": "15",
+            "Oblast #": "98",
+            "CQ Zone": "19",
+            "ITU Zone": "32"
+          },
+          "IR.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IR",
+            "Primary Administrative Subdivision": "Irkutsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "124",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Irkutskaya oblast"
+          },
+          "CT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Zabaykalsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "166",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Comments": "referred to as Chita (Chitinskaya oblast) before 2008-03-01"
+          },
+          "HA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Republic of Khakassia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "104",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "KY.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Koryaksky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "129",
+            "CQ Zone": "19",
+            "ITU Zone": "25",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "TU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Republic of Tuva",
+            "DXCC Entity Code": "15",
+            "Oblast #": "159",
+            "CQ Zone": "23",
+            "ITU Zone": "32"
+          },
+          "KT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KT",
+            "Primary Administrative Subdivision": "Kamchatka",
+            "DXCC Entity Code": "15",
+            "Oblast #": "128",
+            "CQ Zone": "19",
+            "ITU Zone": "35",
+            "Comments": "Kamchatskaya oblast"
+          },
+          "IB.21": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IB",
+            "Primary Administrative Subdivision": "Balears",
+            "DXCC Entity Code": "21"
+          },
+          "MI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Minsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Minskaya voblasts\u0027"
+          },
+          "BR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brest",
+            "DXCC Entity Code": "27",
+            "Comments": "Brestskaya voblasts\u0027"
+          },
+          "HR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Grodno",
+            "DXCC Entity Code": "27",
+            "Comments": "Hrodzenskaya voblasts\u0027"
+          },
+          "VI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vitebsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Vitsyebskaya voblasts\u0027"
+          },
+          "MA.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mogilev",
+            "DXCC Entity Code": "27",
+            "Comments": "Mahilyowskaya voblasts\u0027"
+          },
+          "HO.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Gomel",
+            "DXCC Entity Code": "27",
+            "Comments": "Homyel\u0027skaya voblasts\u0027"
+          },
+          "HM.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Horad Minsk",
+            "DXCC Entity Code": "27"
+          },
+          "GC.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Las Palmas",
+            "DXCC Entity Code": "29"
+          },
+          "TF.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TF",
+            "Primary Administrative Subdivision": "Santa Cruz de Tenerife",
+            "DXCC Entity Code": "29"
+          },
+          "CE.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceuta",
+            "DXCC Entity Code": "32"
+          },
+          "ML.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Melilla",
+            "DXCC Entity Code": "32"
+          },
+          "COL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COL",
+            "Primary Administrative Subdivision": "Colima",
+            "DXCC Entity Code": "50"
+          },
+          "DF.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "50",
+            "Import-only": "true",
+            "Comments": "replaced by CMX"
+          },
+          "CMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CMX",
+            "Primary Administrative Subdivision": "Ciudad de México",
+            "DXCC Entity Code": "50"
+          },
+          "EMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMX",
+            "Primary Administrative Subdivision": "Estado de México",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "MEX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MEX",
+            "Primary Administrative Subdivision": "México",
+            "DXCC Entity Code": "50"
+          },
+          "GTO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTO",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "GUA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUA",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50"
+          },
+          "HGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HGO",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "HID.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HID",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50"
+          },
+          "JAL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JAL",
+            "Primary Administrative Subdivision": "Jalisco",
+            "DXCC Entity Code": "50"
+          },
+          "MIC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michoacán de Ocampo",
+            "DXCC Entity Code": "50"
+          },
+          "MOR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOR",
+            "Primary Administrative Subdivision": "Morelos",
+            "DXCC Entity Code": "50"
+          },
+          "NAY.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAY",
+            "Primary Administrative Subdivision": "Nayarit",
+            "DXCC Entity Code": "50"
+          },
+          "PUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUE",
+            "Primary Administrative Subdivision": "Puebla",
+            "DXCC Entity Code": "50"
+          },
+          "QRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QRO",
+            "Primary Administrative Subdivision": "Querétaro de Arteaga",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "QUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Querétaro",
+            "DXCC Entity Code": "50"
+          },
+          "TLX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLX",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TLA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLA",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50"
+          },
+          "VER.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VER",
+            "Primary Administrative Subdivision": "Veracruz de Ignacio de la Llave",
+            "DXCC Entity Code": "50"
+          },
+          "AGS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "AGU.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGU",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50"
+          },
+          "BC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "BCN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCN",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50"
+          },
+          "BCS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCS",
+            "Primary Administrative Subdivision": "Baja California Sur",
+            "DXCC Entity Code": "50"
+          },
+          "CHH.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHH",
+            "Primary Administrative Subdivision": "Chihuahua",
+            "DXCC Entity Code": "50"
+          },
+          "COA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COA",
+            "Primary Administrative Subdivision": "Coahuila de Zaragoza",
+            "DXCC Entity Code": "50"
+          },
+          "DGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DGO",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "DUR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DUR",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50"
+          },
+          "NL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nuevo Leon",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "NLE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NLE",
+            "Primary Administrative Subdivision": "Nuevo León",
+            "DXCC Entity Code": "50"
+          },
+          "SLP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLP",
+            "Primary Administrative Subdivision": "San Luis Potosí",
+            "DXCC Entity Code": "50"
+          },
+          "SIN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIN",
+            "Primary Administrative Subdivision": "Sinaloa",
+            "DXCC Entity Code": "50"
+          },
+          "SON.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SON",
+            "Primary Administrative Subdivision": "Sonora",
+            "DXCC Entity Code": "50"
+          },
+          "TMS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TMS",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAM",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50"
+          },
+          "ZAC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAC",
+            "Primary Administrative Subdivision": "Zacatecas",
+            "DXCC Entity Code": "50"
+          },
+          "CAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Campeche",
+            "DXCC Entity Code": "50"
+          },
+          "CHS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHS",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "CHP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHP",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50"
+          },
+          "GRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GRO",
+            "Primary Administrative Subdivision": "Guerrero",
+            "DXCC Entity Code": "50"
+          },
+          "OAX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OAX",
+            "Primary Administrative Subdivision": "Oaxaca",
+            "DXCC Entity Code": "50"
+          },
+          "QTR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QTR",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "ROO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROO",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50"
+          },
+          "TAB.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAB",
+            "Primary Administrative Subdivision": "Tabasco",
+            "DXCC Entity Code": "50"
+          },
+          "YUC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUC",
+            "Primary Administrative Subdivision": "Yucatán",
+            "DXCC Entity Code": "50"
+          },
+          "SP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "City of St. Petersburg",
+            "DXCC Entity Code": "54",
+            "Oblast #": "169",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "LO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "136",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Republic of Karelia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "88",
+            "CQ Zone": "16",
+            "ITU Zone": "19"
+          },
+          "AR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "113",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "NO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "54",
+            "Oblast #": "114",
+            "CQ Zone": "16",
+            "ITU Zone": "20"
+          },
+          "VO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Vologda",
+            "DXCC Entity Code": "54",
+            "Oblast #": "120",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vologodskaya oblast"
+          },
+          "NV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Novgorodskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "144",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "PS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pskov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "149",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Pskovskaya oblast"
+          },
+          "MU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murmansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "143",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Murmanskaya oblast"
+          },
+          "MA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "City of Moscow",
+            "DXCC Entity Code": "54",
+            "Oblast #": "170",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Moscowskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "142",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "OR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oryel",
+            "DXCC Entity Code": "54",
+            "Oblast #": "147",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Orlovskaya oblast"
+          },
+          "LP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LP",
+            "Primary Administrative Subdivision": "Lipetsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "137",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Lipetskaya oblast"
+          },
+          "TV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Tver\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "126",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tverskaya oblast"
+          },
+          "SM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smolensk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "155",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Smolenskaya oblast"
+          },
+          "YR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YR",
+            "Primary Administrative Subdivision": "Yaroslavl",
+            "DXCC Entity Code": "54",
+            "Oblast #": "168",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Yaroslavskaya oblast"
+          },
+          "KS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kostroma",
+            "DXCC Entity Code": "54",
+            "Oblast #": "132",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kostromskaya oblast"
+          },
+          "TL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tula",
+            "DXCC Entity Code": "54",
+            "Oblast #": "160",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tul\u0027skaya oblast"
+          },
+          "VR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Voronezh",
+            "DXCC Entity Code": "54",
+            "Oblast #": "121",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Voronezhskaya oblast"
+          },
+          "TB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TB",
+            "Primary Administrative Subdivision": "Tambov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "157",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tambovskaya oblast"
+          },
+          "RA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ryazan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "151",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ryazanskaya oblast"
+          },
+          "NN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NN",
+            "Primary Administrative Subdivision": "Nizhni Novgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "122",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Nizhegorodskaya oblast"
+          },
+          "IV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Ivanovo",
+            "DXCC Entity Code": "54",
+            "Oblast #": "123",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ivanovskaya oblast"
+          },
+          "VL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vladimir",
+            "DXCC Entity Code": "54",
+            "Oblast #": "119",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vladimirskaya oblast"
+          },
+          "KU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kursk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "135",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kurskaya oblast"
+          },
+          "KG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KG",
+            "Primary Administrative Subdivision": "Kaluga",
+            "DXCC Entity Code": "54",
+            "Oblast #": "127",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kaluzhskaya oblast"
+          },
+          "BR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bryansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "118",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Bryanskaya oblast"
+          },
+          "BO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Belgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "117",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Belgorodskaya oblast"
+          },
+          "VG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VG",
+            "Primary Administrative Subdivision": "Volgograd",
+            "DXCC Entity Code": "54",
+            "Oblast #": "156",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Volgogradskaya oblast"
+          },
+          "SA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Saratov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "152",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Saratovskaya oblast"
+          },
+          "PE.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Penza",
+            "DXCC Entity Code": "54",
+            "Oblast #": "148",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Penzenskaya oblast"
+          },
+          "SR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Samara",
+            "DXCC Entity Code": "54",
+            "Oblast #": "133",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Samarskaya oblast"
+          },
+          "UL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UL",
+            "Primary Administrative Subdivision": "Ulyanovsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "164",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ulyanovskaya oblast"
+          },
+          "KI.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "131",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Kirovskaya oblast"
+          },
+          "TA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Republic of Tataria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "94",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "MR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MR",
+            "Primary Administrative Subdivision": "Republic of Marij-El",
+            "DXCC Entity Code": "54",
+            "Oblast #": "91",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Republic of Mordovia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "92",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "UD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Republic of Udmurtia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "95",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "CU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Republic of Chuvashia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "97",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krasnodar",
+            "DXCC Entity Code": "54",
+            "Oblast #": "101",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Krasnodarsky Kraj"
+          },
+          "KC.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Republic of Karachaevo-Cherkessia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "109",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "ST.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Stavropol\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "108",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Stavropolsky Kraj"
+          },
+          "KM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KM",
+            "Primary Administrative Subdivision": "Republic of Kalmykia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "89",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "SO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Republic of Northern Ossetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "93",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "RO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rostov-on-Don",
+            "DXCC Entity Code": "54",
+            "Oblast #": "150",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Rostovskaya oblast"
+          },
+          "CN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Republic Chechnya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "IN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Republic of Ingushetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Astrakhan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "115",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Astrakhanskaya oblast"
+          },
+          "DA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Republic of Daghestan",
+            "DXCC Entity Code": "54",
+            "Oblast #": "86",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Republic of Kabardino-Balkaria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "87",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AD",
+            "Primary Administrative Subdivision": "Republic of Adygeya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "102",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AR.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "61",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "FJL.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJL",
+            "Primary Administrative Subdivision": "Franz Josef Land",
+            "DXCC Entity Code": "61",
+            "Import-only": "true"
+          },
+          "15.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Artemisa",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "09.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Camagüey",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "08.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ciego de Ávila",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "06.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Cienfuegos",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "12.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Granma",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "14.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Guantánamo",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "11.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Holguín",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "99.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "99",
+            "Primary Administrative Subdivision": "Isla de la Juventud",
+            "DXCC Entity Code": "70",
+            "Comments": "special municipality"
+          },
+          "03.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "La Habana",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "10.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Las Tunas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "04.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Matanzas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "16.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Mayabeque",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "01.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Pinar del Río",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "07.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Sancti Spíritus",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "13.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Santiago de Cuba",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "05.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Villa Clara",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "C.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Capital federal",
+            "DXCC Entity Code": "100",
+            "Comments": "Buenos Aires City"
+          },
+          "B.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Buenos Aires Province",
+            "DXCC Entity Code": "100"
+          },
+          "S.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Santa Fe",
+            "DXCC Entity Code": "100"
+          },
+          "H.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chaco",
+            "DXCC Entity Code": "100"
+          },
+          "P.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Formosa",
+            "DXCC Entity Code": "100"
+          },
+          "X.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "100"
+          },
+          "N.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "100"
+          },
+          "E.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Entre Ríos",
+            "DXCC Entity Code": "100"
+          },
+          "T.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tucumán",
+            "DXCC Entity Code": "100"
+          },
+          "W.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Corrientes",
+            "DXCC Entity Code": "100"
+          },
+          "M.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Mendoza",
+            "DXCC Entity Code": "100"
+          },
+          "G.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Santiago del Estero",
+            "DXCC Entity Code": "100"
+          },
+          "A.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Salta",
+            "DXCC Entity Code": "100"
+          },
+          "J.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "San Juan",
+            "DXCC Entity Code": "100"
+          },
+          "D.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "San Luis",
+            "DXCC Entity Code": "100"
+          },
+          "K.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Catamarca",
+            "DXCC Entity Code": "100"
+          },
+          "F.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "100"
+          },
+          "Y.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Jujuy",
+            "DXCC Entity Code": "100"
+          },
+          "L.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "La Pampa",
+            "DXCC Entity Code": "100"
+          },
+          "R.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "100"
+          },
+          "U.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Chubut",
+            "DXCC Entity Code": "100"
+          },
+          "Z.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Santa Cruz",
+            "DXCC Entity Code": "100"
+          },
+          "V.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Tierra del Fuego",
+            "DXCC Entity Code": "100"
+          },
+          "Q.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Neuquén",
+            "DXCC Entity Code": "100"
+          },
+          "ES.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ES",
+            "Primary Administrative Subdivision": "Espírito Santo",
+            "DXCC Entity Code": "108"
+          },
+          "GO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Goiás",
+            "DXCC Entity Code": "108"
+          },
+          "SC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Santa Catarina",
+            "DXCC Entity Code": "108"
+          },
+          "SE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sergipe",
+            "DXCC Entity Code": "108"
+          },
+          "AL.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alagoas",
+            "DXCC Entity Code": "108"
+          },
+          "AM.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "108"
+          },
+          "TO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tocantins",
+            "DXCC Entity Code": "108"
+          },
+          "AP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Amapá",
+            "DXCC Entity Code": "108"
+          },
+          "PB.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Paraíba",
+            "DXCC Entity Code": "108"
+          },
+          "MA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maranhão",
+            "DXCC Entity Code": "108"
+          },
+          "RN.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rio Grande do Norte",
+            "DXCC Entity Code": "108"
+          },
+          "PI.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Piauí",
+            "DXCC Entity Code": "108"
+          },
+          "DF.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "108"
+          },
+          "CE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceará",
+            "DXCC Entity Code": "108"
+          },
+          "AC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Acre",
+            "DXCC Entity Code": "108"
+          },
+          "MS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mato Grosso do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "RR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RR",
+            "Primary Administrative Subdivision": "Roraima",
+            "DXCC Entity Code": "108"
+          },
+          "RO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rondônia",
+            "DXCC Entity Code": "108"
+          },
+          "RJ.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rio de Janeiro",
+            "DXCC Entity Code": "108"
+          },
+          "SP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "São Paulo",
+            "DXCC Entity Code": "108"
+          },
+          "RS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Rio Grande do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "MG.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Minas Gerais",
+            "DXCC Entity Code": "108"
+          },
+          "PR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Paraná",
+            "DXCC Entity Code": "108"
+          },
+          "BA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bahia",
+            "DXCC Entity Code": "108"
+          },
+          "PE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pernambuco",
+            "DXCC Entity Code": "108"
+          },
+          "PA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pará",
+            "DXCC Entity Code": "108"
+          },
+          "MT.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Mato Grosso",
+            "DXCC Entity Code": "108"
+          },
+          "HI.110": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hawaii",
+            "DXCC Entity Code": "110"
+          },
+          "II.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "II",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AN.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112"
+          },
+          "III.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "III",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AT.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112"
+          },
+          "I.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "TA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112"
+          },
+          "XV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XV",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AP.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112"
+          },
+          "IV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "CO.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112"
+          },
+          "V.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "VS.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112"
+          },
+          "RM.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Region Metropolitana de Santiago",
+            "DXCC Entity Code": "112"
+          },
+          "VI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112"
+          },
+          "VII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VII",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "ML.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112"
+          },
+          "VIII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIII",
+            "Primary Administrative Subdivision": "Bío-Bío",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "BI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biobío",
+            "DXCC Entity Code": "112"
+          },
+          "IX.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IX",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112"
+          },
+          "XIV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XIV",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112"
+          },
+          "X.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LL.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112"
+          },
+          "XI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibáñez del Campo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibañez del Campo",
+            "DXCC Entity Code": "112"
+          },
+          "XII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XII",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "MA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112"
+          },
+          "NB.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Ñuble",
+            "DXCC Entity Code": "112"
+          },
+          "22.118": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Jan Mayen",
+            "DXCC Entity Code": "118"
+          },
+          "KA.126": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kalingrad",
+            "DXCC Entity Code": "126",
+            "Oblast #": "125",
+            "CQ Zone": "15",
+            "ITU Zone": "29",
+            "Comments": "Kaliningradskaya oblast"
+          },
+          "16.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Alto Paraguay",
+            "DXCC Entity Code": "132"
+          },
+          "19.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Boquerón",
+            "DXCC Entity Code": "132"
+          },
+          "15.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Presidente Hayes",
+            "DXCC Entity Code": "132"
+          },
+          "13.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Amambay",
+            "DXCC Entity Code": "132"
+          },
+          "01.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "1.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "1",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132"
+          },
+          "14.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Canindeyú",
+            "DXCC Entity Code": "132"
+          },
+          "02.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "2.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132"
+          },
+          "ASU.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ASU",
+            "Primary Administrative Subdivision": "Asunción",
+            "DXCC Entity Code": "132"
+          },
+          "11.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "132"
+          },
+          "03.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "3.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "3",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132"
+          },
+          "09.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "9.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "9",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132"
+          },
+          "06.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Caazapl",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "6.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "6",
+            "Primary Administrative Subdivision": "Caazapá",
+            "DXCC Entity Code": "132"
+          },
+          "05.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "5.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "5",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132"
+          },
+          "04.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "4.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "4",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132"
+          },
+          "08.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Miaiones",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "8.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "8",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "132"
+          },
+          "12.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Ñeembucú",
+            "DXCC Entity Code": "132"
+          },
+          "10.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Alto Paraná",
+            "DXCC Entity Code": "132"
+          },
+          "07.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Itapua",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "7.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "7",
+            "Primary Administrative Subdivision": "Itapúa",
+            "DXCC Entity Code": "132"
+          },
+          "A.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Seoul",
+            "DXCC Entity Code": "137",
+            "Comments": "Seoul Teugbyeolsi"
+          },
+          "N.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Inchon",
+            "DXCC Entity Code": "137",
+            "Comments": "Incheon Gwang\u0027yeogsi"
+          },
+          "D.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Kangwon-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gang \u0027weondo"
+          },
+          "C.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Kyunggi-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeonggido"
+          },
+          "E.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Choongchungbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongbugdo"
+          },
+          "F.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Choongchungnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongnamdo"
+          },
+          "R.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Taejon",
+            "DXCC Entity Code": "137",
+            "Comments": "Daejeon Gwang\u0027yeogsi"
+          },
+          "M.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Cheju-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jejudo"
+          },
+          "G.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Chollabuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonrabugdo"
+          },
+          "H.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chollanam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonranamdo"
+          },
+          "Q.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Kwangju",
+            "DXCC Entity Code": "137",
+            "Comments": "Gwangju Gwang\u0027yeogsi"
+          },
+          "K.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Kyungsangbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangbugdo"
+          },
+          "L.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Kyungsangnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangnamdo"
+          },
+          "B.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Pusan",
+            "DXCC Entity Code": "137",
+            "Comments": "Busan Gwang\u0027yeogsi"
+          },
+          "P.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Taegu",
+            "DXCC Entity Code": "137",
+            "Comments": "Daegu Gwang\u0027yeogsi"
+          },
+          "S.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Ulsan",
+            "DXCC Entity Code": "137",
+            "Comments": "Ulsan Gwanq\u0027yeogsi"
+          },
+          "T.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Sejong",
+            "DXCC Entity Code": "137"
+          },
+          "IS.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Special Island",
+            "DXCC Entity Code": "137"
+          },
+          "KI.138": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kure Island",
+            "DXCC Entity Code": "138"
+          },
+          "LD.142": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Lakshadweep",
+            "DXCC Entity Code": "142",
+            "Comments": "Union territory"
+          },
+          "MO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Montevideo",
+            "DXCC Entity Code": "144"
+          },
+          "CA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Canelones",
+            "DXCC Entity Code": "144"
+          },
+          "SJ.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "San José",
+            "DXCC Entity Code": "144"
+          },
+          "CO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colonia",
+            "DXCC Entity Code": "144"
+          },
+          "SO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soriano",
+            "DXCC Entity Code": "144"
+          },
+          "RN.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "144"
+          },
+          "PA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Paysandú",
+            "DXCC Entity Code": "144"
+          },
+          "SA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salto",
+            "DXCC Entity Code": "144"
+          },
+          "AR.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Artigas",
+            "DXCC Entity Code": "144"
+          },
+          "FD.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FD",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "144"
+          },
+          "FS.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FS",
+            "Primary Administrative Subdivision": "Flores",
+            "DXCC Entity Code": "144"
+          },
+          "DU.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DU",
+            "Primary Administrative Subdivision": "Durazno",
+            "DXCC Entity Code": "144"
+          },
+          "TA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tacuarembó",
+            "DXCC Entity Code": "144"
+          },
+          "RV.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RV",
+            "Primary Administrative Subdivision": "Rivera",
+            "DXCC Entity Code": "144"
+          },
+          "MA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maldonado",
+            "DXCC Entity Code": "144"
+          },
+          "LA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lavalleja",
+            "DXCC Entity Code": "144"
+          },
+          "RO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rocha",
+            "DXCC Entity Code": "144"
+          },
+          "TT.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TT",
+            "Primary Administrative Subdivision": "Treinta y Tres",
+            "DXCC Entity Code": "144"
+          },
+          "CL.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Cerro Largo",
+            "DXCC Entity Code": "144"
+          },
+          "LH.147": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Lord Howe Is",
+            "DXCC Entity Code": "147"
+          },
+          "AM.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "148"
+          },
+          "AN.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Anzoátegui",
+            "DXCC Entity Code": "148"
+          },
+          "AP.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Apure",
+            "DXCC Entity Code": "148"
+          },
+          "AR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Aragua",
+            "DXCC Entity Code": "148"
+          },
+          "BA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Barinas",
+            "DXCC Entity Code": "148"
+          },
+          "BO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bolívar",
+            "DXCC Entity Code": "148"
+          },
+          "CA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Carabobo",
+            "DXCC Entity Code": "148"
+          },
+          "CO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cojedes",
+            "DXCC Entity Code": "148"
+          },
+          "DA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Delta Amacuro",
+            "DXCC Entity Code": "148"
+          },
+          "DC.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "Distrito Capital",
+            "DXCC Entity Code": "148"
+          },
+          "FA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FA",
+            "Primary Administrative Subdivision": "Falcón",
+            "DXCC Entity Code": "148"
+          },
+          "GU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guárico",
+            "DXCC Entity Code": "148"
+          },
+          "LA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lara",
+            "DXCC Entity Code": "148"
+          },
+          "ME.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Mérida",
+            "DXCC Entity Code": "148"
+          },
+          "MI.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Miranda",
+            "DXCC Entity Code": "148"
+          },
+          "MO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Monagas",
+            "DXCC Entity Code": "148"
+          },
+          "NE.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nueva Esparta",
+            "DXCC Entity Code": "148"
+          },
+          "PO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Portuguesa",
+            "DXCC Entity Code": "148"
+          },
+          "SU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sucre",
+            "DXCC Entity Code": "148"
+          },
+          "TA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Táchira",
+            "DXCC Entity Code": "148"
+          },
+          "TR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Trujillo",
+            "DXCC Entity Code": "148"
+          },
+          "VA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vargas",
+            "DXCC Entity Code": "148"
+          },
+          "YA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yaracuy",
+            "DXCC Entity Code": "148"
+          },
+          "ZU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZU",
+            "Primary Administrative Subdivision": "Zulia",
+            "DXCC Entity Code": "148"
+          },
+          "AC.149": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Açores",
+            "DXCC Entity Code": "149"
+          },
+          "ACT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ACT",
+            "Primary Administrative Subdivision": "Australian Capital Territory",
+            "DXCC Entity Code": "150"
+          },
+          "NSW.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSW",
+            "Primary Administrative Subdivision": "New South Wales",
+            "DXCC Entity Code": "150"
+          },
+          "VIC.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIC",
+            "Primary Administrative Subdivision": "Victoria",
+            "DXCC Entity Code": "150"
+          },
+          "QLD.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QLD",
+            "Primary Administrative Subdivision": "Queensland",
+            "DXCC Entity Code": "150"
+          },
+          "SA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "South Australia",
+            "DXCC Entity Code": "150"
+          },
+          "WA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Western Australia",
+            "DXCC Entity Code": "150"
+          },
+          "TAS.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasmania",
+            "DXCC Entity Code": "150"
+          },
+          "NT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northern Territory",
+            "DXCC Entity Code": "150"
+          },
+          "LO.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya Oblast",
+            "DXCC Entity Code": "151"
+          },
+          "MV.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Malyj Vysotskij",
+            "DXCC Entity Code": "151",
+            "Import-only": "true"
+          },
+          "MA.153": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Macquarie Is",
+            "DXCC Entity Code": "153"
+          },
+          "NCD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCD",
+            "Primary Administrative Subdivision": "National Capital District",
+            "DXCC Entity Code": "163",
+            "Comments": "Port Moresby"
+          },
+          "CPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPM",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "163"
+          },
+          "CPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPK",
+            "Primary Administrative Subdivision": "Chimbu",
+            "DXCC Entity Code": "163"
+          },
+          "EHG.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EHG",
+            "Primary Administrative Subdivision": "Eastern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "EBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EBR",
+            "Primary Administrative Subdivision": "East New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "ESW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ESW",
+            "Primary Administrative Subdivision": "East Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "EPW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EPW",
+            "Primary Administrative Subdivision": "Enga",
+            "DXCC Entity Code": "163"
+          },
+          "GPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPK",
+            "Primary Administrative Subdivision": "Gulf",
+            "DXCC Entity Code": "163"
+          },
+          "MPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPM",
+            "Primary Administrative Subdivision": "Madang",
+            "DXCC Entity Code": "163"
+          },
+          "MRL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MRL",
+            "Primary Administrative Subdivision": "Manus",
+            "DXCC Entity Code": "163"
+          },
+          "MBA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBA",
+            "Primary Administrative Subdivision": "Milne Bay",
+            "DXCC Entity Code": "163"
+          },
+          "MPL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPL",
+            "Primary Administrative Subdivision": "Morobe",
+            "DXCC Entity Code": "163"
+          },
+          "NIK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIK",
+            "Primary Administrative Subdivision": "New Ireland",
+            "DXCC Entity Code": "163"
+          },
+          "NPP.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NPP",
+            "Primary Administrative Subdivision": "Northern",
+            "DXCC Entity Code": "163"
+          },
+          "NSA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "North Solomons",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "NSB.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSB",
+            "Primary Administrative Subdivision": "Bougainville",
+            "DXCC Entity Code": "163"
+          },
+          "SAN.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAN",
+            "Primary Administrative Subdivision": "West Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "SHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SHM",
+            "Primary Administrative Subdivision": "Southern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WPD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WPD",
+            "Primary Administrative Subdivision": "Western",
+            "DXCC Entity Code": "163"
+          },
+          "WHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WHM",
+            "Primary Administrative Subdivision": "Western Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBR",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "WBK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBK",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "HLA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLA",
+            "Primary Administrative Subdivision": "Hela",
+            "DXCC Entity Code": "163"
+          },
+          "JWK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JWK",
+            "Primary Administrative Subdivision": "Jiwaka",
+            "DXCC Entity Code": "163"
+          },
+          "AUK.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUK",
+            "Primary Administrative Subdivision": "Auckland",
+            "DXCC Entity Code": "170"
+          },
+          "BOP.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOP",
+            "Primary Administrative Subdivision": "Bay of Plenty",
+            "DXCC Entity Code": "170"
+          },
+          "NTL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NTL",
+            "Primary Administrative Subdivision": "Northland",
+            "DXCC Entity Code": "170"
+          },
+          "WKO.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WKO",
+            "Primary Administrative Subdivision": "Waikato",
+            "DXCC Entity Code": "170"
+          },
+          "GIS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GIS",
+            "Primary Administrative Subdivision": "Gisborne",
+            "DXCC Entity Code": "170"
+          },
+          "HKB.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKB",
+            "Primary Administrative Subdivision": "Hawke\u0027s Bay",
+            "DXCC Entity Code": "170"
+          },
+          "MWT.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MWT",
+            "Primary Administrative Subdivision": "Manawatū-Whanganui",
+            "DXCC Entity Code": "170"
+          },
+          "TKI.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TKI",
+            "Primary Administrative Subdivision": "Taranaki",
+            "DXCC Entity Code": "170"
+          },
+          "WGN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WGN",
+            "Primary Administrative Subdivision": "Greater Wellington",
+            "DXCC Entity Code": "170"
+          },
+          "CAN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Canterbury",
+            "DXCC Entity Code": "170"
+          },
+          "MBH.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBH",
+            "Primary Administrative Subdivision": "Marlborough",
+            "DXCC Entity Code": "170"
+          },
+          "NSN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSN",
+            "Primary Administrative Subdivision": "Nelson",
+            "DXCC Entity Code": "170"
+          },
+          "TAS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasman",
+            "DXCC Entity Code": "170"
+          },
+          "WTC.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WTC",
+            "Primary Administrative Subdivision": "West Coast",
+            "DXCC Entity Code": "170"
+          },
+          "OTA.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OTA",
+            "Primary Administrative Subdivision": "Otago",
+            "DXCC Entity Code": "170"
+          },
+          "STL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STL",
+            "Primary Administrative Subdivision": "Southland",
+            "DXCC Entity Code": "170"
+          },
+          "MT.177": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Minami Torishima",
+            "DXCC Entity Code": "177"
+          },
+          "O.192": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Ogasawara",
+            "DXCC Entity Code": "192"
+          },
+          "WC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WC",
+            "Primary Administrative Subdivision": "Wien",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vienna (Wien)"
+          },
+          "HA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Hallein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "JO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JO",
+            "Primary Administrative Subdivision": "St. Johann",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Salzburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Salzburg-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "TA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tamsweg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "ZE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zell Am See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "AM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amstetten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Bruck/Leitha",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Baden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gmünd",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GF",
+            "Primary Administrative Subdivision": "Gänserndorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Hollabrunn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Horn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Korneuburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krems-Region",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Krems",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "LF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LF",
+            "Primary Administrative Subdivision": "Lilienfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Mödling",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ME.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Melk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Mistelbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "NK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NK",
+            "Primary Administrative Subdivision": "Neunkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "St. Pölten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "St. Pölten-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Scheibbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SW",
+            "Primary Administrative Subdivision": "Schwechat",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "TU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Tulln",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "Wr.Neustadt-Bezirk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WN",
+            "Primary Administrative Subdivision": "Wr.Neustadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WT",
+            "Primary Administrative Subdivision": "Waidhofen/Thaya",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WU",
+            "Primary Administrative Subdivision": "Wien-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WY.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Waidhofen/Ybbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ZT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZT",
+            "Primary Administrative Subdivision": "Zwettl",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "EC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EC",
+            "Primary Administrative Subdivision": "Eisenstadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "EU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EU",
+            "Primary Administrative Subdivision": "Eisenstadt-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "GS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Güssing",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "JE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JE",
+            "Primary Administrative Subdivision": "Jennersdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "MA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mattersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "ND.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "Neusiedl/See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OP",
+            "Primary Administrative Subdivision": "Oberpullendorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Oberwart",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "BR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braunau/Inn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "EF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EF",
+            "Primary Administrative Subdivision": "Eferding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "FR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freistadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GM",
+            "Primary Administrative Subdivision": "Gmunden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grieskirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "KI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirchdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Linz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Linz-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "PE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Perg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Ried/Innkreis",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rohrbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Schärding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Steyr-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Steyr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "UU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UU",
+            "Primary Administrative Subdivision": "Urfahr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "VB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vöcklabruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WE",
+            "Primary Administrative Subdivision": "Wels",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WL",
+            "Primary Administrative Subdivision": "Wels-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "BA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bad Aussee",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "BM.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck/Mur",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "BM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck-Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "DL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Deutschlandsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "FB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FB",
+            "Primary Administrative Subdivision": "Feldbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "FF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FF",
+            "Primary Administrative Subdivision": "Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "GB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GB",
+            "Primary Administrative Subdivision": "Gröbming",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Graz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Graz-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "HB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hartberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "HF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HF",
+            "Primary Administrative Subdivision": "Hartberg-Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "JU.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Judenburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "KF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KF",
+            "Primary Administrative Subdivision": "Knittelfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "LB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Leibnitz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Leoben",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Liezen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Leoben-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Murtal",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2012/01/01"
+          },
+          "MU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MZ.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "RA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Radkersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "SO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Südoststeiermark",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "VO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Voitsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "WZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WZ",
+            "Primary Administrative Subdivision": "Weiz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "IC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IC",
+            "Primary Administrative Subdivision": "Innsbruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Innsbruck-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imst",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Kitzbühel",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kufstein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Landeck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LZ",
+            "Primary Administrative Subdivision": "Lienz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "RE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reutte",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "SZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwaz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "FE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Feldkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "HE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hermagor",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Klagenfurt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Klagenfurt-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "Spittal/Drau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SV.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "St.Veit/Glan",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Villach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VK",
+            "Primary Administrative Subdivision": "Völkermarkt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Villach-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "WO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WO",
+            "Primary Administrative Subdivision": "Wolfsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "BC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bregenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "BZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bludenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "DO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dornbirn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "FK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FK",
+            "Primary Administrative Subdivision": "Feldkirch",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "AN.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antwerpen",
+            "DXCC Entity Code": "209"
+          },
+          "BR.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brussels",
+            "DXCC Entity Code": "209"
+          },
+          "BW.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Brabant Wallon",
+            "DXCC Entity Code": "209"
+          },
+          "HT.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HT",
+            "Primary Administrative Subdivision": "Hainaut",
+            "DXCC Entity Code": "209"
+          },
+          "LB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "209"
+          },
+          "LG.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LG",
+            "Primary Administrative Subdivision": "Liêge",
+            "DXCC Entity Code": "209"
+          },
+          "NM.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Namur",
+            "DXCC Entity Code": "209"
+          },
+          "LU.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luxembourg",
+            "DXCC Entity Code": "209"
+          },
+          "OV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Oost-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "VB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vlaams Brabant",
+            "DXCC Entity Code": "209"
+          },
+          "WV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "BU.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgas",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "SL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sliven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "YA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yambol",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas",
+            "Comments": "Jambol"
+          },
+          "SO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sofija Grad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "City of Sofia"
+          },
+          "HA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Haskovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "KA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kărdžali",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "SZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Stara Zagora",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "PA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pazardžik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "PD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Plovdiv",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "SM.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smoljan",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "BL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Blagoevgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "KD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KD",
+            "Primary Administrative Subdivision": "Kjustendil",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "PK.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Pernik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "SF.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SF",
+            "Primary Administrative Subdivision": "Sofija",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia",
+            "Comments": "Sofia"
+          },
+          "GA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Gabrovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "LV.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "Loveč",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč",
+            "Comments": "Lovech"
+          },
+          "PL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "Pleven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "VT.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Veliko Tărnovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "MN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Vidin",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VR.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vraca",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "RZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RZ",
+            "Primary Administrative Subdivision": "Razgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "RS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Ruse",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "SS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Silistra",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "TA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tărgovište",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "DO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dobrič",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "SN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Šumen",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "VN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Varna",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "2A.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2A",
+            "Primary Administrative Subdivision": "Corse-du-Sud",
+            "DXCC Entity Code": "214"
+          },
+          "2B.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2B",
+            "Primary Administrative Subdivision": "Haute-Corse",
+            "DXCC Entity Code": "214"
+          },
+          "015.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Koebenhavns amt",
+            "DXCC Entity Code": "221"
+          },
+          "020.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "020",
+            "Primary Administrative Subdivision": "Frederiksborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "025.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "025",
+            "Primary Administrative Subdivision": "Roskilde amt",
+            "DXCC Entity Code": "221"
+          },
+          "030.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "030",
+            "Primary Administrative Subdivision": "Vestsjaellands amt",
+            "DXCC Entity Code": "221"
+          },
+          "035.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "035",
+            "Primary Administrative Subdivision": "Storstrøm amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Storstroems"
+          },
+          "040.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "040",
+            "Primary Administrative Subdivision": "Bornholms amt",
+            "DXCC Entity Code": "221"
+          },
+          "042.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "042",
+            "Primary Administrative Subdivision": "Fyns amt",
+            "DXCC Entity Code": "221"
+          },
+          "050.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "050",
+            "Primary Administrative Subdivision": "Sínderjylland amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Sydjyllands"
+          },
+          "055.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "055",
+            "Primary Administrative Subdivision": "Ribe amt",
+            "DXCC Entity Code": "221"
+          },
+          "060.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "060",
+            "Primary Administrative Subdivision": "Vejle amt",
+            "DXCC Entity Code": "221"
+          },
+          "065.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "065",
+            "Primary Administrative Subdivision": "Ringkøbing amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Ringkoebing"
+          },
+          "070.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "070",
+            "Primary Administrative Subdivision": "Århus amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Aarhus"
+          },
+          "076.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "076",
+            "Primary Administrative Subdivision": "Viborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "080.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "080",
+            "Primary Administrative Subdivision": "Nordjyllands amt",
+            "DXCC Entity Code": "221"
+          },
+          "101.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "101",
+            "Primary Administrative Subdivision": "Copenhagen City",
+            "DXCC Entity Code": "221"
+          },
+          "147.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Frederiksberg",
+            "DXCC Entity Code": "221"
+          },
+          "100.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "100",
+            "Primary Administrative Subdivision": "Somero",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "102.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "102",
+            "Primary Administrative Subdivision": "Alastaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "103.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "103",
+            "Primary Administrative Subdivision": "Askainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "104.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "104",
+            "Primary Administrative Subdivision": "Aura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "105.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "105",
+            "Primary Administrative Subdivision": "Dragsfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "106.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "106",
+            "Primary Administrative Subdivision": "Eura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "107.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "107",
+            "Primary Administrative Subdivision": "Eurajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "108.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "108",
+            "Primary Administrative Subdivision": "Halikko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "109.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "109",
+            "Primary Administrative Subdivision": "Harjavalta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "110.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "110",
+            "Primary Administrative Subdivision": "Honkajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "111.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "111",
+            "Primary Administrative Subdivision": "Houtskari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "112.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "112",
+            "Primary Administrative Subdivision": "Huittinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "115.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "115",
+            "Primary Administrative Subdivision": "Iniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "116.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "116",
+            "Primary Administrative Subdivision": "Jämijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "117.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "117",
+            "Primary Administrative Subdivision": "Kaarina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "119.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "119",
+            "Primary Administrative Subdivision": "Kankaanpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "120.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "120",
+            "Primary Administrative Subdivision": "Karinainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "122.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "122",
+            "Primary Administrative Subdivision": "Karvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "123.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "123",
+            "Primary Administrative Subdivision": "Äetsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "124.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "124",
+            "Primary Administrative Subdivision": "Kemiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "126.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "126",
+            "Primary Administrative Subdivision": "Kiikala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "128.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "128",
+            "Primary Administrative Subdivision": "Kiikoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "129.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "129",
+            "Primary Administrative Subdivision": "Kisko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "130.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "130",
+            "Primary Administrative Subdivision": "Kiukainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "131.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "131",
+            "Primary Administrative Subdivision": "Kodisjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "132.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "132",
+            "Primary Administrative Subdivision": "Kokemäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "133.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "133",
+            "Primary Administrative Subdivision": "Korppoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "134.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "134",
+            "Primary Administrative Subdivision": "Koski tl",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "135.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "135",
+            "Primary Administrative Subdivision": "Kullaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "136.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "136",
+            "Primary Administrative Subdivision": "Kustavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "137.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "137",
+            "Primary Administrative Subdivision": "Kuusjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "138.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "138",
+            "Primary Administrative Subdivision": "Köyliö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "139.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "139",
+            "Primary Administrative Subdivision": "Laitila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "140.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "140",
+            "Primary Administrative Subdivision": "Lappi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "141.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "141",
+            "Primary Administrative Subdivision": "Lavia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "142.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "142",
+            "Primary Administrative Subdivision": "Lemu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "143.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "143",
+            "Primary Administrative Subdivision": "Lieto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "144.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "144",
+            "Primary Administrative Subdivision": "Loimaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "145.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "145",
+            "Primary Administrative Subdivision": "Loimaan kunta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "147.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Luvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "148.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "148",
+            "Primary Administrative Subdivision": "Marttila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "149.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "149",
+            "Primary Administrative Subdivision": "Masku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "150.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "150",
+            "Primary Administrative Subdivision": "Mellilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "151.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "151",
+            "Primary Administrative Subdivision": "Merikarvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "152.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "152",
+            "Primary Administrative Subdivision": "Merimasku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "154.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "154",
+            "Primary Administrative Subdivision": "Mietoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "156.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "156",
+            "Primary Administrative Subdivision": "Muurla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "157.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "157",
+            "Primary Administrative Subdivision": "Mynämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "158.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "158",
+            "Primary Administrative Subdivision": "Naantali",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "159.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "159",
+            "Primary Administrative Subdivision": "Nakkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "160.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "160",
+            "Primary Administrative Subdivision": "Nauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "161.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "161",
+            "Primary Administrative Subdivision": "Noormarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "162.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "162",
+            "Primary Administrative Subdivision": "Nousiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "163.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "163",
+            "Primary Administrative Subdivision": "Oripää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "164.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "164",
+            "Primary Administrative Subdivision": "Paimio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "165.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "165",
+            "Primary Administrative Subdivision": "Parainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "167.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "167",
+            "Primary Administrative Subdivision": "Perniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "168.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "168",
+            "Primary Administrative Subdivision": "Pertteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "169.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "169",
+            "Primary Administrative Subdivision": "Piikkiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "170.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "170",
+            "Primary Administrative Subdivision": "Pomarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "171.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "171",
+            "Primary Administrative Subdivision": "Pori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "172.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "172",
+            "Primary Administrative Subdivision": "Punkalaidun",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "173.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "173",
+            "Primary Administrative Subdivision": "Pyhäranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "174.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "174",
+            "Primary Administrative Subdivision": "Pöytyä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "175.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "175",
+            "Primary Administrative Subdivision": "Raisio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "176.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "176",
+            "Primary Administrative Subdivision": "Rauma",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "178.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "178",
+            "Primary Administrative Subdivision": "Rusko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "179.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "179",
+            "Primary Administrative Subdivision": "Rymättylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "180.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "180",
+            "Primary Administrative Subdivision": "Salo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "181.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "181",
+            "Primary Administrative Subdivision": "Sauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "182.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "182",
+            "Primary Administrative Subdivision": "Siikainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "183.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "183",
+            "Primary Administrative Subdivision": "Suodenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "184.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "184",
+            "Primary Administrative Subdivision": "Suomusjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "185.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "185",
+            "Primary Administrative Subdivision": "Säkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "186.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "186",
+            "Primary Administrative Subdivision": "Särkisalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "187.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "187",
+            "Primary Administrative Subdivision": "Taivassalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "188.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "188",
+            "Primary Administrative Subdivision": "Tarvasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "189.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "189",
+            "Primary Administrative Subdivision": "Turku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "190.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "190",
+            "Primary Administrative Subdivision": "Ulvila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "191.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "191",
+            "Primary Administrative Subdivision": "Uusikaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "192.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "192",
+            "Primary Administrative Subdivision": "Vahto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "193.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "193",
+            "Primary Administrative Subdivision": "Vammala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "194.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "194",
+            "Primary Administrative Subdivision": "Vampula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "195.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "195",
+            "Primary Administrative Subdivision": "Vehmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "196.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "196",
+            "Primary Administrative Subdivision": "Velkua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "198.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "198",
+            "Primary Administrative Subdivision": "Västanfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "199.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "199",
+            "Primary Administrative Subdivision": "Yläne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "201.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "201",
+            "Primary Administrative Subdivision": "Artjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "202.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "202",
+            "Primary Administrative Subdivision": "Askola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "204.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "204",
+            "Primary Administrative Subdivision": "Espoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "205.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "205",
+            "Primary Administrative Subdivision": "Hanko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "206.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "206",
+            "Primary Administrative Subdivision": "Helsinki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "207.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "207",
+            "Primary Administrative Subdivision": "Hyvinkää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "208.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "208",
+            "Primary Administrative Subdivision": "Inkoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "209.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "209",
+            "Primary Administrative Subdivision": "Järvenpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "210.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "210",
+            "Primary Administrative Subdivision": "Karjaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "211.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "211",
+            "Primary Administrative Subdivision": "Karjalohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "212.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "212",
+            "Primary Administrative Subdivision": "Karkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "213.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "213",
+            "Primary Administrative Subdivision": "Kauniainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "214.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "214",
+            "Primary Administrative Subdivision": "Kerava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "215.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "215",
+            "Primary Administrative Subdivision": "Kirkkonummi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "216.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "216",
+            "Primary Administrative Subdivision": "Lapinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "217.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "217",
+            "Primary Administrative Subdivision": "Liljendal",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "218.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "218",
+            "Primary Administrative Subdivision": "Lohjan kaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "220.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "220",
+            "Primary Administrative Subdivision": "Loviisa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "221.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "221",
+            "Primary Administrative Subdivision": "Myrskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "222.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "222",
+            "Primary Administrative Subdivision": "Mäntsälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "223.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "223",
+            "Primary Administrative Subdivision": "Nummi-Pusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "224.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "224",
+            "Primary Administrative Subdivision": "Nurmijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "225.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "225",
+            "Primary Administrative Subdivision": "Orimattila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "226.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "226",
+            "Primary Administrative Subdivision": "Pernaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "227.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "227",
+            "Primary Administrative Subdivision": "Pohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "228.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "228",
+            "Primary Administrative Subdivision": "Pornainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "229.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "229",
+            "Primary Administrative Subdivision": "Porvoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "231.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "231",
+            "Primary Administrative Subdivision": "Pukkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "233.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "233",
+            "Primary Administrative Subdivision": "Ruotsinpyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "234.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "234",
+            "Primary Administrative Subdivision": "Sammatti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "235.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "235",
+            "Primary Administrative Subdivision": "Sipoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "236.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "236",
+            "Primary Administrative Subdivision": "Siuntio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "238.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "238",
+            "Primary Administrative Subdivision": "Tammisaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "241.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "241",
+            "Primary Administrative Subdivision": "Tuusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "242.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "242",
+            "Primary Administrative Subdivision": "Vantaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "243.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "243",
+            "Primary Administrative Subdivision": "Vihti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "301.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "301",
+            "Primary Administrative Subdivision": "Asikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "303.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "303",
+            "Primary Administrative Subdivision": "Forssa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "304.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "304",
+            "Primary Administrative Subdivision": "Hattula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "305.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "305",
+            "Primary Administrative Subdivision": "Hauho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "306.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "306",
+            "Primary Administrative Subdivision": "Hausjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "307.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "307",
+            "Primary Administrative Subdivision": "Hollola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "308.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "308",
+            "Primary Administrative Subdivision": "Humppila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "309.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "309",
+            "Primary Administrative Subdivision": "Hämeenlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "310.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "310",
+            "Primary Administrative Subdivision": "Janakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "311.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "311",
+            "Primary Administrative Subdivision": "Jokioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "312.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "312",
+            "Primary Administrative Subdivision": "Juupajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "313.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "313",
+            "Primary Administrative Subdivision": "Kalvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "314.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "314",
+            "Primary Administrative Subdivision": "Kangasala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "315.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "315",
+            "Primary Administrative Subdivision": "Hämeenkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "316.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "316",
+            "Primary Administrative Subdivision": "Kuhmalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "318.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "318",
+            "Primary Administrative Subdivision": "Kuru",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "319.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "319",
+            "Primary Administrative Subdivision": "Kylmäkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "320.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "320",
+            "Primary Administrative Subdivision": "Kärkölä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "321.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "321",
+            "Primary Administrative Subdivision": "Lahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "322.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "322",
+            "Primary Administrative Subdivision": "Lammi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "323.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "323",
+            "Primary Administrative Subdivision": "Lempäälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "324.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "324",
+            "Primary Administrative Subdivision": "Loppi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "325.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "325",
+            "Primary Administrative Subdivision": "Luopioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "326.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "326",
+            "Primary Administrative Subdivision": "Längelmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "327.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "327",
+            "Primary Administrative Subdivision": "Mänttä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "328.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "328",
+            "Primary Administrative Subdivision": "Nastola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "329.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "329",
+            "Primary Administrative Subdivision": "Nokia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "330.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "330",
+            "Primary Administrative Subdivision": "Orivesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "331.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "331",
+            "Primary Administrative Subdivision": "Padasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "332.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "332",
+            "Primary Administrative Subdivision": "Pirkkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "333.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "333",
+            "Primary Administrative Subdivision": "Pälkäne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "334.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "334",
+            "Primary Administrative Subdivision": "Renko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "335.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "335",
+            "Primary Administrative Subdivision": "Riihimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "336.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "336",
+            "Primary Administrative Subdivision": "Ruovesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "337.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "337",
+            "Primary Administrative Subdivision": "Sahalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "340.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "340",
+            "Primary Administrative Subdivision": "Tammela",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "341.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "341",
+            "Primary Administrative Subdivision": "Tampere",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "342.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "342",
+            "Primary Administrative Subdivision": "Toijala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "344.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "344",
+            "Primary Administrative Subdivision": "Tuulos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "345.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "345",
+            "Primary Administrative Subdivision": "Urjala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "346.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "346",
+            "Primary Administrative Subdivision": "Valkeakoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "347.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "347",
+            "Primary Administrative Subdivision": "Vesilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "348.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "348",
+            "Primary Administrative Subdivision": "Viiala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "349.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "349",
+            "Primary Administrative Subdivision": "Vilppula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "350.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "350",
+            "Primary Administrative Subdivision": "Virrat",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "351.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "351",
+            "Primary Administrative Subdivision": "Ylöjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "352.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "352",
+            "Primary Administrative Subdivision": "Ypäjä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "353.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "353",
+            "Primary Administrative Subdivision": "Hämeenkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "354.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "354",
+            "Primary Administrative Subdivision": "Ikaalinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "355.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "355",
+            "Primary Administrative Subdivision": "Kihniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "356.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "356",
+            "Primary Administrative Subdivision": "Mouhijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "357.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "357",
+            "Primary Administrative Subdivision": "Parkano",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "358.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "358",
+            "Primary Administrative Subdivision": "Viljakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "402.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "402",
+            "Primary Administrative Subdivision": "Enonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "403.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "403",
+            "Primary Administrative Subdivision": "Hartola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "404.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "404",
+            "Primary Administrative Subdivision": "Haukivuori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "405.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "405",
+            "Primary Administrative Subdivision": "Heinola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "407.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "407",
+            "Primary Administrative Subdivision": "Heinävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "408.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "408",
+            "Primary Administrative Subdivision": "Hirvensalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "409.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "409",
+            "Primary Administrative Subdivision": "Joroinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "410.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "410",
+            "Primary Administrative Subdivision": "Juva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "411.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "411",
+            "Primary Administrative Subdivision": "Jäppilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "412.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "412",
+            "Primary Administrative Subdivision": "Kangaslampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "413.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "413",
+            "Primary Administrative Subdivision": "Kangasniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "414.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "414",
+            "Primary Administrative Subdivision": "Kerimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "415.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "415",
+            "Primary Administrative Subdivision": "Mikkeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "417.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "417",
+            "Primary Administrative Subdivision": "Mäntyharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "418.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "418",
+            "Primary Administrative Subdivision": "Pertunmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "419.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "419",
+            "Primary Administrative Subdivision": "Pieksämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "420.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "420",
+            "Primary Administrative Subdivision": "Pieksänmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "421.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "421",
+            "Primary Administrative Subdivision": "Punkaharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "422.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "422",
+            "Primary Administrative Subdivision": "Puumala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "423.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "423",
+            "Primary Administrative Subdivision": "Rantasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "424.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "424",
+            "Primary Administrative Subdivision": "Ristiina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "425.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "425",
+            "Primary Administrative Subdivision": "Savonlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "426.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "426",
+            "Primary Administrative Subdivision": "Savonranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "427.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "427",
+            "Primary Administrative Subdivision": "Sulkava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "428.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "428",
+            "Primary Administrative Subdivision": "Sysmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "502.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "502",
+            "Primary Administrative Subdivision": "Elimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "503.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "503",
+            "Primary Administrative Subdivision": "Hamina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "504.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "504",
+            "Primary Administrative Subdivision": "Iitti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "505.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "505",
+            "Primary Administrative Subdivision": "Imatra",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "506.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "506",
+            "Primary Administrative Subdivision": "Jaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "507.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "507",
+            "Primary Administrative Subdivision": "Joutseno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "509.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "509",
+            "Primary Administrative Subdivision": "Kotka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "510.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "510",
+            "Primary Administrative Subdivision": "Kouvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "511.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "511",
+            "Primary Administrative Subdivision": "Kuusankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "513.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "513",
+            "Primary Administrative Subdivision": "Lappeenranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "514.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "514",
+            "Primary Administrative Subdivision": "Lemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "515.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "515",
+            "Primary Administrative Subdivision": "Luumäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "516.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "516",
+            "Primary Administrative Subdivision": "Miehikkälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "518.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "518",
+            "Primary Administrative Subdivision": "Parikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "519.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "519",
+            "Primary Administrative Subdivision": "Pyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "520.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "520",
+            "Primary Administrative Subdivision": "Rautjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "521.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "521",
+            "Primary Administrative Subdivision": "Ruokolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "522.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "522",
+            "Primary Administrative Subdivision": "Saari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "523.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "523",
+            "Primary Administrative Subdivision": "Savitaipale",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "525.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "525",
+            "Primary Administrative Subdivision": "Suomenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "526.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "526",
+            "Primary Administrative Subdivision": "Taipalsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "527.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "527",
+            "Primary Administrative Subdivision": "Uukuniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "528.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "528",
+            "Primary Administrative Subdivision": "Valkeala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "530.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "530",
+            "Primary Administrative Subdivision": "Virolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "531.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "531",
+            "Primary Administrative Subdivision": "Ylämaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "532.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "532",
+            "Primary Administrative Subdivision": "Anjalankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "601.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "601",
+            "Primary Administrative Subdivision": "Alahärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "602.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "602",
+            "Primary Administrative Subdivision": "Alajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "603.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "603",
+            "Primary Administrative Subdivision": "Alavus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "604.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "604",
+            "Primary Administrative Subdivision": "Evijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "605.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "605",
+            "Primary Administrative Subdivision": "Halsua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "606.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "606",
+            "Primary Administrative Subdivision": "Hankasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "607.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "607",
+            "Primary Administrative Subdivision": "Himanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "608.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "608",
+            "Primary Administrative Subdivision": "Ilmajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "609.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "609",
+            "Primary Administrative Subdivision": "Isojoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "610.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "610",
+            "Primary Administrative Subdivision": "Isokyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "611.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "611",
+            "Primary Administrative Subdivision": "Jalasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "612.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "612",
+            "Primary Administrative Subdivision": "Joutsa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "613.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "613",
+            "Primary Administrative Subdivision": "Jurva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "614.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "614",
+            "Primary Administrative Subdivision": "Jyväskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "615.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "615",
+            "Primary Administrative Subdivision": "Jyväskylän mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "616.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "616",
+            "Primary Administrative Subdivision": "Jämsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "617.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "617",
+            "Primary Administrative Subdivision": "Jämsänkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "619.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "619",
+            "Primary Administrative Subdivision": "Kannonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "620.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "620",
+            "Primary Administrative Subdivision": "Kannus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "621.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "621",
+            "Primary Administrative Subdivision": "Karijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "622.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "622",
+            "Primary Administrative Subdivision": "Karstula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "623.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "623",
+            "Primary Administrative Subdivision": "Kaskinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "624.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "624",
+            "Primary Administrative Subdivision": "Kauhajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "625.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "625",
+            "Primary Administrative Subdivision": "Kauhava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "626.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "626",
+            "Primary Administrative Subdivision": "Kaustinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "627.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "627",
+            "Primary Administrative Subdivision": "Keuruu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "628.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "628",
+            "Primary Administrative Subdivision": "Kinnula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "629.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "629",
+            "Primary Administrative Subdivision": "Kivijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "630.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "630",
+            "Primary Administrative Subdivision": "Kokkola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "632.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "632",
+            "Primary Administrative Subdivision": "Konnevesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "633.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "633",
+            "Primary Administrative Subdivision": "Korpilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "634.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "634",
+            "Primary Administrative Subdivision": "Korsnäs",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "635.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "635",
+            "Primary Administrative Subdivision": "Kortesjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "636.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "636",
+            "Primary Administrative Subdivision": "Kristiinankaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "637.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "637",
+            "Primary Administrative Subdivision": "Kruunupyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "638.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "638",
+            "Primary Administrative Subdivision": "Kuhmoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "639.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "639",
+            "Primary Administrative Subdivision": "Kuortane",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "640.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "640",
+            "Primary Administrative Subdivision": "Kurikka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "641.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "641",
+            "Primary Administrative Subdivision": "Kyyjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "642.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "642",
+            "Primary Administrative Subdivision": "Kälviä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "643.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "643",
+            "Primary Administrative Subdivision": "Laihia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "644.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "644",
+            "Primary Administrative Subdivision": "Lappajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "645.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "645",
+            "Primary Administrative Subdivision": "Lapua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "646.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "646",
+            "Primary Administrative Subdivision": "Laukaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "647.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "647",
+            "Primary Administrative Subdivision": "Lehtimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "648.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "648",
+            "Primary Administrative Subdivision": "Leivonmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "649.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "649",
+            "Primary Administrative Subdivision": "Lestijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "650.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "650",
+            "Primary Administrative Subdivision": "Lohtaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "651.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "651",
+            "Primary Administrative Subdivision": "Luhanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "652.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "652",
+            "Primary Administrative Subdivision": "Luoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "653.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "653",
+            "Primary Administrative Subdivision": "Maalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "654.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "654",
+            "Primary Administrative Subdivision": "Maksamaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "655.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "655",
+            "Primary Administrative Subdivision": "Multia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "656.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "656",
+            "Primary Administrative Subdivision": "Mustasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "657.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "657",
+            "Primary Administrative Subdivision": "Muurame",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "658.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "658",
+            "Primary Administrative Subdivision": "Nurmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "659.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "659",
+            "Primary Administrative Subdivision": "Närpiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "660.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "660",
+            "Primary Administrative Subdivision": "Oravainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "661.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "661",
+            "Primary Administrative Subdivision": "Perho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "662.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "662",
+            "Primary Administrative Subdivision": "Peräseinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "663.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "663",
+            "Primary Administrative Subdivision": "Petäjävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "664.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "664",
+            "Primary Administrative Subdivision": "Pietarsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "665.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "665",
+            "Primary Administrative Subdivision": "Pedersöre",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "666.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "666",
+            "Primary Administrative Subdivision": "Pihtipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "668.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "668",
+            "Primary Administrative Subdivision": "Pylkönmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "669.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "669",
+            "Primary Administrative Subdivision": "Saarijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "670.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "670",
+            "Primary Administrative Subdivision": "Seinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "671.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "671",
+            "Primary Administrative Subdivision": "Soini",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "672.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "672",
+            "Primary Administrative Subdivision": "Sumiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "673.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "673",
+            "Primary Administrative Subdivision": "Suolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "675.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "675",
+            "Primary Administrative Subdivision": "Teuva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "676.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "676",
+            "Primary Administrative Subdivision": "Toholampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "677.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "677",
+            "Primary Administrative Subdivision": "Toivakka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "678.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "678",
+            "Primary Administrative Subdivision": "Töysä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "679.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "679",
+            "Primary Administrative Subdivision": "Ullava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "680.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "680",
+            "Primary Administrative Subdivision": "Uurainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "681.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "681",
+            "Primary Administrative Subdivision": "Uusikaarlepyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "682.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "682",
+            "Primary Administrative Subdivision": "Vaasa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "683.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "683",
+            "Primary Administrative Subdivision": "Veteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "684.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "684",
+            "Primary Administrative Subdivision": "Viitasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "685.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "685",
+            "Primary Administrative Subdivision": "Vimpeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "686.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "686",
+            "Primary Administrative Subdivision": "Vähäkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "687.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "687",
+            "Primary Administrative Subdivision": "Vöyri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "688.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "688",
+            "Primary Administrative Subdivision": "Ylihärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "689.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "689",
+            "Primary Administrative Subdivision": "Ylistaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "690.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "690",
+            "Primary Administrative Subdivision": "Ähtäri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "692.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "692",
+            "Primary Administrative Subdivision": "Äänekoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "701.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "701",
+            "Primary Administrative Subdivision": "Eno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "702.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "702",
+            "Primary Administrative Subdivision": "Iisalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "703.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "703",
+            "Primary Administrative Subdivision": "Ilomantsi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "704.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "704",
+            "Primary Administrative Subdivision": "Joensuu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "705.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "705",
+            "Primary Administrative Subdivision": "Juankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "706.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "706",
+            "Primary Administrative Subdivision": "Juuka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "707.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "707",
+            "Primary Administrative Subdivision": "Kaavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "708.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "708",
+            "Primary Administrative Subdivision": "Karttula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "709.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "709",
+            "Primary Administrative Subdivision": "Keitele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "710.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "710",
+            "Primary Administrative Subdivision": "Kesälahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "711.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "711",
+            "Primary Administrative Subdivision": "Kiihtelysvaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "712.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "712",
+            "Primary Administrative Subdivision": "Kitee",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "713.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "713",
+            "Primary Administrative Subdivision": "Kiuruvesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "714.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "714",
+            "Primary Administrative Subdivision": "Kontiolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "715.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "715",
+            "Primary Administrative Subdivision": "Kuopio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "716.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "716",
+            "Primary Administrative Subdivision": "Lapinlahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "717.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "717",
+            "Primary Administrative Subdivision": "Leppävirta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "718.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "718",
+            "Primary Administrative Subdivision": "Lieksa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "719.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "719",
+            "Primary Administrative Subdivision": "Liperi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "720.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "720",
+            "Primary Administrative Subdivision": "Maaninka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "721.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "721",
+            "Primary Administrative Subdivision": "Nilsiä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "722.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "722",
+            "Primary Administrative Subdivision": "Nurmes",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "723.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "723",
+            "Primary Administrative Subdivision": "Outokumpu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "724.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "724",
+            "Primary Administrative Subdivision": "Pielavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "725.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "725",
+            "Primary Administrative Subdivision": "Polvijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "726.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "726",
+            "Primary Administrative Subdivision": "Pyhäselkä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "727.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "727",
+            "Primary Administrative Subdivision": "Rautalampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "728.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "728",
+            "Primary Administrative Subdivision": "Rautavaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "729.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "729",
+            "Primary Administrative Subdivision": "Rääkkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "730.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "730",
+            "Primary Administrative Subdivision": "Siilinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "731.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "731",
+            "Primary Administrative Subdivision": "Sonkajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "732.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "732",
+            "Primary Administrative Subdivision": "Suonenjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "733.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "733",
+            "Primary Administrative Subdivision": "Tervo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "734.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "734",
+            "Primary Administrative Subdivision": "Tohmajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "735.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "735",
+            "Primary Administrative Subdivision": "Tuupovaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "736.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "736",
+            "Primary Administrative Subdivision": "Tuusniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "737.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "737",
+            "Primary Administrative Subdivision": "Valtimo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "738.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "738",
+            "Primary Administrative Subdivision": "Varkaus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "739.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "739",
+            "Primary Administrative Subdivision": "Varpaisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "740.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "740",
+            "Primary Administrative Subdivision": "Vehmersalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "741.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "741",
+            "Primary Administrative Subdivision": "Vesanto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "742.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "742",
+            "Primary Administrative Subdivision": "Vieremä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "743.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "743",
+            "Primary Administrative Subdivision": "Värtsilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "801.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "801",
+            "Primary Administrative Subdivision": "Alavieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "802.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "802",
+            "Primary Administrative Subdivision": "Haapajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "803.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "803",
+            "Primary Administrative Subdivision": "Haapavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "804.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "804",
+            "Primary Administrative Subdivision": "Hailuoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "805.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "805",
+            "Primary Administrative Subdivision": "Haukipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "806.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "806",
+            "Primary Administrative Subdivision": "Hyrynsalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "807.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "807",
+            "Primary Administrative Subdivision": "Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "808.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "808",
+            "Primary Administrative Subdivision": "Kajaani",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "810.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "810",
+            "Primary Administrative Subdivision": "Kalajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "811.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "811",
+            "Primary Administrative Subdivision": "Kempele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "812.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "812",
+            "Primary Administrative Subdivision": "Kestilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "813.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "813",
+            "Primary Administrative Subdivision": "Kiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "814.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "814",
+            "Primary Administrative Subdivision": "Kuhmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "815.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "815",
+            "Primary Administrative Subdivision": "Kuivaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "816.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "816",
+            "Primary Administrative Subdivision": "Kuusamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "817.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "817",
+            "Primary Administrative Subdivision": "Kärsämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "818.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "818",
+            "Primary Administrative Subdivision": "Liminka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "819.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "819",
+            "Primary Administrative Subdivision": "Lumijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "820.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "820",
+            "Primary Administrative Subdivision": "Merijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "821.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "821",
+            "Primary Administrative Subdivision": "Muhos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "822.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "822",
+            "Primary Administrative Subdivision": "Nivala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "823.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "823",
+            "Primary Administrative Subdivision": "Oulainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "824.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "824",
+            "Primary Administrative Subdivision": "Oulu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "825.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "825",
+            "Primary Administrative Subdivision": "Oulunsalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "826.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "826",
+            "Primary Administrative Subdivision": "Paltamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "827.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "827",
+            "Primary Administrative Subdivision": "Pattijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "828.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "828",
+            "Primary Administrative Subdivision": "Piippola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "829.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "829",
+            "Primary Administrative Subdivision": "Pudasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "830.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "830",
+            "Primary Administrative Subdivision": "Pulkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "831.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "831",
+            "Primary Administrative Subdivision": "Puolanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "832.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "832",
+            "Primary Administrative Subdivision": "Pyhäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "833.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "833",
+            "Primary Administrative Subdivision": "Pyhäjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "834.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "834",
+            "Primary Administrative Subdivision": "Pyhäntä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "835.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "835",
+            "Primary Administrative Subdivision": "Raahe",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "836.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "836",
+            "Primary Administrative Subdivision": "Rantsila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "837.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "837",
+            "Primary Administrative Subdivision": "Reisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "838.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "838",
+            "Primary Administrative Subdivision": "Ristijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "839.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "839",
+            "Primary Administrative Subdivision": "Ruukki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "840.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "840",
+            "Primary Administrative Subdivision": "Sievi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "841.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "841",
+            "Primary Administrative Subdivision": "Siikajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "842.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "842",
+            "Primary Administrative Subdivision": "Sotkamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "843.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "843",
+            "Primary Administrative Subdivision": "Suomussalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "844.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "844",
+            "Primary Administrative Subdivision": "Taivalkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "846.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "846",
+            "Primary Administrative Subdivision": "Tyrnävä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "847.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "847",
+            "Primary Administrative Subdivision": "Utajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "848.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "848",
+            "Primary Administrative Subdivision": "Vaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "849.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "849",
+            "Primary Administrative Subdivision": "Vihanti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "850.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "850",
+            "Primary Administrative Subdivision": "Vuolijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "851.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "851",
+            "Primary Administrative Subdivision": "Yli-Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "852.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "852",
+            "Primary Administrative Subdivision": "Ylikiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "853.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "853",
+            "Primary Administrative Subdivision": "Ylivieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "901.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "901",
+            "Primary Administrative Subdivision": "Enontekiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "902.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "902",
+            "Primary Administrative Subdivision": "Inari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "903.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "903",
+            "Primary Administrative Subdivision": "Kemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "904.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "904",
+            "Primary Administrative Subdivision": "Keminmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "905.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "905",
+            "Primary Administrative Subdivision": "Kemijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "907.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "907",
+            "Primary Administrative Subdivision": "Kittilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "908.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "908",
+            "Primary Administrative Subdivision": "Kolari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "909.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "909",
+            "Primary Administrative Subdivision": "Muonio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "910.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "910",
+            "Primary Administrative Subdivision": "Pelkosenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "911.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "911",
+            "Primary Administrative Subdivision": "Pello",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "912.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "912",
+            "Primary Administrative Subdivision": "Posio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "913.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "913",
+            "Primary Administrative Subdivision": "Ranua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "914.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "914",
+            "Primary Administrative Subdivision": "Rovaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "915.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "915",
+            "Primary Administrative Subdivision": "Rovaniemen mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "916.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "916",
+            "Primary Administrative Subdivision": "Salla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "917.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "917",
+            "Primary Administrative Subdivision": "Savukoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "918.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "918",
+            "Primary Administrative Subdivision": "Simo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "919.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "919",
+            "Primary Administrative Subdivision": "Sodankylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "920.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "920",
+            "Primary Administrative Subdivision": "Tervola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "921.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "921",
+            "Primary Administrative Subdivision": "Tornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "922.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "922",
+            "Primary Administrative Subdivision": "Utsjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "923.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "923",
+            "Primary Administrative Subdivision": "Ylitornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "CA.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cagliari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "CI.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CI",
+            "Primary Administrative Subdivision": "Carbonia-Iglesias",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true",
+            "Comments": "replaced by SU"
+          },
+          "SU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sud Sardegna",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "MD.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Medio Campidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true"
+          },
+          "NU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nuoro",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OG.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OG",
+            "Primary Administrative Subdivision": "Ogliastra",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OR.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oristano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OT.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olbia-Tempio",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "SS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Sassari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "VS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "MedioCampidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "01.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Ain",
+            "DXCC Entity Code": "227"
+          },
+          "02.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aisne",
+            "DXCC Entity Code": "227"
+          },
+          "03.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Allier",
+            "DXCC Entity Code": "227"
+          },
+          "04.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Alpes-de-Haute-Provence",
+            "DXCC Entity Code": "227"
+          },
+          "05.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Hautes-Alpes",
+            "DXCC Entity Code": "227"
+          },
+          "06.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Alpes-Maritimes",
+            "DXCC Entity Code": "227"
+          },
+          "07.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Ardèche",
+            "DXCC Entity Code": "227"
+          },
+          "08.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ardennes",
+            "DXCC Entity Code": "227"
+          },
+          "09.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ariège",
+            "DXCC Entity Code": "227"
+          },
+          "10.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Aube",
+            "DXCC Entity Code": "227"
+          },
+          "11.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Aude",
+            "DXCC Entity Code": "227"
+          },
+          "12.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Aveyron",
+            "DXCC Entity Code": "227"
+          },
+          "13.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Bouches-du-Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "14.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Calvados",
+            "DXCC Entity Code": "227"
+          },
+          "15.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Cantal",
+            "DXCC Entity Code": "227"
+          },
+          "16.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Charente",
+            "DXCC Entity Code": "227"
+          },
+          "17.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Charente-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "18.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Cher",
+            "DXCC Entity Code": "227"
+          },
+          "19.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Corrèze",
+            "DXCC Entity Code": "227"
+          },
+          "21.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Côte-d\u0027Or",
+            "DXCC Entity Code": "227"
+          },
+          "22.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Côtes-d\u0027Armor",
+            "DXCC Entity Code": "227"
+          },
+          "23.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Creuse",
+            "DXCC Entity Code": "227"
+          },
+          "24.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Dordogne",
+            "DXCC Entity Code": "227"
+          },
+          "25.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Doubs",
+            "DXCC Entity Code": "227"
+          },
+          "26.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Drôme",
+            "DXCC Entity Code": "227"
+          },
+          "27.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Eure",
+            "DXCC Entity Code": "227"
+          },
+          "28.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Eure-et-Loir",
+            "DXCC Entity Code": "227"
+          },
+          "29.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Finistère",
+            "DXCC Entity Code": "227"
+          },
+          "30.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Gard",
+            "DXCC Entity Code": "227"
+          },
+          "31.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Haute-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "32.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Gers",
+            "DXCC Entity Code": "227"
+          },
+          "33.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Gironde",
+            "DXCC Entity Code": "227"
+          },
+          "34.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Hérault",
+            "DXCC Entity Code": "227"
+          },
+          "35.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Ille-et-Vilaine",
+            "DXCC Entity Code": "227"
+          },
+          "36.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Indre",
+            "DXCC Entity Code": "227"
+          },
+          "37.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Indre-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "38.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Isère",
+            "DXCC Entity Code": "227"
+          },
+          "39.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "227"
+          },
+          "40.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Landes",
+            "DXCC Entity Code": "227"
+          },
+          "41.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Loir-et-Cher",
+            "DXCC Entity Code": "227"
+          },
+          "42.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Loire",
+            "DXCC Entity Code": "227"
+          },
+          "43.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Haute-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "44.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Loire-Atlantique",
+            "DXCC Entity Code": "227"
+          },
+          "45.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Loiret",
+            "DXCC Entity Code": "227"
+          },
+          "46.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Lot",
+            "DXCC Entity Code": "227"
+          },
+          "47.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Lot-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "48.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "48",
+            "Primary Administrative Subdivision": "Lozère",
+            "DXCC Entity Code": "227"
+          },
+          "49.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "49",
+            "Primary Administrative Subdivision": "Maine-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "50.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Manche",
+            "DXCC Entity Code": "227"
+          },
+          "51.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "51",
+            "Primary Administrative Subdivision": "Marne",
+            "DXCC Entity Code": "227"
+          },
+          "52.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "52",
+            "Primary Administrative Subdivision": "Haute-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "53.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "53",
+            "Primary Administrative Subdivision": "Mayenne",
+            "DXCC Entity Code": "227"
+          },
+          "54.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Meurthe-et-Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "55.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "55",
+            "Primary Administrative Subdivision": "Meuse",
+            "DXCC Entity Code": "227"
+          },
+          "56.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "56",
+            "Primary Administrative Subdivision": "Morbihan",
+            "DXCC Entity Code": "227"
+          },
+          "57.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "57",
+            "Primary Administrative Subdivision": "Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "58.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "58",
+            "Primary Administrative Subdivision": "Nièvre",
+            "DXCC Entity Code": "227"
+          },
+          "59.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "59",
+            "Primary Administrative Subdivision": "Nord",
+            "DXCC Entity Code": "227"
+          },
+          "60.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "60",
+            "Primary Administrative Subdivision": "Oise",
+            "DXCC Entity Code": "227"
+          },
+          "61.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "61",
+            "Primary Administrative Subdivision": "Orne",
+            "DXCC Entity Code": "227"
+          },
+          "62.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "62",
+            "Primary Administrative Subdivision": "Pas-de-Calais",
+            "DXCC Entity Code": "227"
+          },
+          "63.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "63",
+            "Primary Administrative Subdivision": "Puy-de-Dôme",
+            "DXCC Entity Code": "227"
+          },
+          "64.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "64",
+            "Primary Administrative Subdivision": "Pyrénées-Atlantiques",
+            "DXCC Entity Code": "227"
+          },
+          "65.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "65",
+            "Primary Administrative Subdivision": "Hautes-Pyrénées",
+            "DXCC Entity Code": "227"
+          },
+          "66.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "66",
+            "Primary Administrative Subdivision": "Pyrénées-Orientales",
+            "DXCC Entity Code": "227"
+          },
+          "67.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "67",
+            "Primary Administrative Subdivision": "Bas-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "68.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "68",
+            "Primary Administrative Subdivision": "Haut-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "69.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "69",
+            "Primary Administrative Subdivision": "Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "70.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "70",
+            "Primary Administrative Subdivision": "Haute-Saône",
+            "DXCC Entity Code": "227"
+          },
+          "71.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "71",
+            "Primary Administrative Subdivision": "Saône-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "72.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "72",
+            "Primary Administrative Subdivision": "Sarthe",
+            "DXCC Entity Code": "227"
+          },
+          "73.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "73",
+            "Primary Administrative Subdivision": "Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "74.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "74",
+            "Primary Administrative Subdivision": "Haute-Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "75.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "75",
+            "Primary Administrative Subdivision": "Paris",
+            "DXCC Entity Code": "227"
+          },
+          "76.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "76",
+            "Primary Administrative Subdivision": "Seine-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "77.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "77",
+            "Primary Administrative Subdivision": "Seine-et-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "78.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "78",
+            "Primary Administrative Subdivision": "Yvelines",
+            "DXCC Entity Code": "227"
+          },
+          "79.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "79",
+            "Primary Administrative Subdivision": "Deux-Sèvres",
+            "DXCC Entity Code": "227"
+          },
+          "80.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "80",
+            "Primary Administrative Subdivision": "Somme",
+            "DXCC Entity Code": "227"
+          },
+          "81.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "81",
+            "Primary Administrative Subdivision": "Tarn",
+            "DXCC Entity Code": "227"
+          },
+          "82.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "82",
+            "Primary Administrative Subdivision": "Tarn-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "83.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "83",
+            "Primary Administrative Subdivision": "Var",
+            "DXCC Entity Code": "227"
+          },
+          "84.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "84",
+            "Primary Administrative Subdivision": "Vaucluse",
+            "DXCC Entity Code": "227"
+          },
+          "85.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "85",
+            "Primary Administrative Subdivision": "Vendée",
+            "DXCC Entity Code": "227"
+          },
+          "86.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "86",
+            "Primary Administrative Subdivision": "Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "87.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "87",
+            "Primary Administrative Subdivision": "Haute-Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "88.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "88",
+            "Primary Administrative Subdivision": "Vosges",
+            "DXCC Entity Code": "227"
+          },
+          "89.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "89",
+            "Primary Administrative Subdivision": "Yonne",
+            "DXCC Entity Code": "227"
+          },
+          "90.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "90",
+            "Primary Administrative Subdivision": "Territoire de Belfort",
+            "DXCC Entity Code": "227"
+          },
+          "91.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "91",
+            "Primary Administrative Subdivision": "Essonne",
+            "DXCC Entity Code": "227"
+          },
+          "92.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "92",
+            "Primary Administrative Subdivision": "Hauts-de-Seine",
+            "DXCC Entity Code": "227"
+          },
+          "93.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "93",
+            "Primary Administrative Subdivision": "Seine-Saint-Denis",
+            "DXCC Entity Code": "227"
+          },
+          "94.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "94",
+            "Primary Administrative Subdivision": "Val-de-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "95.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "95",
+            "Primary Administrative Subdivision": "Val-d\u0027Oise",
+            "DXCC Entity Code": "227"
+          },
+          "BB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BB",
+            "Primary Administrative Subdivision": "Brandenburg",
+            "DXCC Entity Code": "230"
+          },
+          "BE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Berlin",
+            "DXCC Entity Code": "230"
+          },
+          "BW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Baden-Württemberg",
+            "DXCC Entity Code": "230"
+          },
+          "BY.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BY",
+            "Primary Administrative Subdivision": "Bayern",
+            "DXCC Entity Code": "230"
+          },
+          "HB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Bremen",
+            "DXCC Entity Code": "230"
+          },
+          "HE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hessen",
+            "DXCC Entity Code": "230"
+          },
+          "HH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HH",
+            "Primary Administrative Subdivision": "Hamburg",
+            "DXCC Entity Code": "230"
+          },
+          "MV.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Mecklenburg-Vorpommern",
+            "DXCC Entity Code": "230"
+          },
+          "NI.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Niedersachsen",
+            "DXCC Entity Code": "230"
+          },
+          "NW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nordrhein-Westfalen",
+            "DXCC Entity Code": "230"
+          },
+          "RP.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RP",
+            "Primary Administrative Subdivision": "Rheinland-Pfalz",
+            "DXCC Entity Code": "230"
+          },
+          "SL.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Saarland",
+            "DXCC Entity Code": "230"
+          },
+          "SH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schleswig-Holstein",
+            "DXCC Entity Code": "230"
+          },
+          "SN.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Sachsen",
+            "DXCC Entity Code": "230"
+          },
+          "ST.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Sachsen-Anhalt",
+            "DXCC Entity Code": "230"
+          },
+          "TH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TH",
+            "Primary Administrative Subdivision": "Thüringen",
+            "DXCC Entity Code": "230"
+          },
+          "GY.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GY",
+            "Primary Administrative Subdivision": "Gyõr",
+            "DXCC Entity Code": "239",
+            "Comments": "Gyõr-Moson-Sopron"
+          },
+          "VA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vas",
+            "DXCC Entity Code": "239"
+          },
+          "ZA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zala",
+            "DXCC Entity Code": "239"
+          },
+          "KO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Komárom",
+            "DXCC Entity Code": "239",
+            "Comments": "Komárom-Esztergom"
+          },
+          "VE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Veszprém",
+            "DXCC Entity Code": "239"
+          },
+          "BA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Baranya",
+            "DXCC Entity Code": "239"
+          },
+          "SO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Somogy",
+            "DXCC Entity Code": "239"
+          },
+          "TO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tolna",
+            "DXCC Entity Code": "239"
+          },
+          "FE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Fejér",
+            "DXCC Entity Code": "239"
+          },
+          "BP.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BP",
+            "Primary Administrative Subdivision": "Budapest",
+            "DXCC Entity Code": "239"
+          },
+          "HE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Heves",
+            "DXCC Entity Code": "239"
+          },
+          "NG.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NG",
+            "Primary Administrative Subdivision": "Nógrád",
+            "DXCC Entity Code": "239"
+          },
+          "PE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pest",
+            "DXCC Entity Code": "239"
+          },
+          "SZ.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Szolnok",
+            "DXCC Entity Code": "239",
+            "Comments": "Jász-Nagykun-Szolnok"
+          },
+          "BE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Békés",
+            "DXCC Entity Code": "239"
+          },
+          "BN.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bács-Kiskun",
+            "DXCC Entity Code": "239"
+          },
+          "CS.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Csongrád",
+            "DXCC Entity Code": "239"
+          },
+          "BO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Borsod",
+            "DXCC Entity Code": "239",
+            "Comments": "Borsod-Abaúj-Zemplén"
+          },
+          "HB.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hajdú-Bihar",
+            "DXCC Entity Code": "239"
+          },
+          "SA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Szabolcs",
+            "DXCC Entity Code": "239",
+            "Comments": "Szabolcs-Szatmár-Bereg"
+          },
+          "CW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CW",
+            "Primary Administrative Subdivision": "Carlow",
+            "DXCC Entity Code": "245",
+            "Comments": "Ceatharlach"
+          },
+          "CN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cavan",
+            "DXCC Entity Code": "245",
+            "Comments": "An Cabhán"
+          },
+          "CE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Clare",
+            "DXCC Entity Code": "245",
+            "Comments": "An Clár"
+          },
+          "C.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Import-only": "true",
+            "Comments": "Corcaigh"
+          },
+          "CO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Comments": "Corcaigh"
+          },
+          "DL.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Donegal",
+            "DXCC Entity Code": "245",
+            "Comments": "Dún na nGall"
+          },
+          "D.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dublin",
+            "DXCC Entity Code": "245",
+            "Comments": "Baile Áth Cliath"
+          },
+          "G.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Galway",
+            "DXCC Entity Code": "245",
+            "Comments": "Gaillimh"
+          },
+          "KY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kerry",
+            "DXCC Entity Code": "245",
+            "Comments": "Ciarraí"
+          },
+          "KE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kildare",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Dara"
+          },
+          "KK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Kilkenny",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Chainnigh"
+          },
+          "LS.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LS",
+            "Primary Administrative Subdivision": "Laois",
+            "DXCC Entity Code": "245",
+            "Comments": "Laois"
+          },
+          "LM.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LM",
+            "Primary Administrative Subdivision": "Leitrim",
+            "DXCC Entity Code": "245",
+            "Comments": "Liatroim"
+          },
+          "LK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LK",
+            "Primary Administrative Subdivision": "Limerick",
+            "DXCC Entity Code": "245",
+            "Comments": "Luimneach"
+          },
+          "LD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Longford",
+            "DXCC Entity Code": "245",
+            "Comments": "An Longfort"
+          },
+          "LH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Louth",
+            "DXCC Entity Code": "245",
+            "Comments": "Lú"
+          },
+          "MO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Mayo",
+            "DXCC Entity Code": "245",
+            "Comments": "Maigh Eo"
+          },
+          "MH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Meath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Mhí"
+          },
+          "MN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Monaghan",
+            "DXCC Entity Code": "245",
+            "Comments": "Muineachán"
+          },
+          "OY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OY",
+            "Primary Administrative Subdivision": "Offaly",
+            "DXCC Entity Code": "245",
+            "Comments": "Uíbh Fhailí"
+          },
+          "RN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Roscommon",
+            "DXCC Entity Code": "245",
+            "Comments": "Ros Comáin"
+          },
+          "SO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sligo",
+            "DXCC Entity Code": "245",
+            "Comments": "Sligeach"
+          },
+          "TA.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tipperary",
+            "DXCC Entity Code": "245",
+            "Comments": "Tiobraid Árann"
+          },
+          "WD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WD",
+            "Primary Administrative Subdivision": "Waterford",
+            "DXCC Entity Code": "245",
+            "Comments": "Port Láirge"
+          },
+          "WH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WH",
+            "Primary Administrative Subdivision": "Westmeath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Iarmhí"
+          },
+          "WX.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WX",
+            "Primary Administrative Subdivision": "Wexford",
+            "DXCC Entity Code": "245",
+            "Comments": "Loch Garman"
+          },
+          "WW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WW",
+            "Primary Administrative Subdivision": "Wicklow",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Mhantáin"
+          },
+          "GE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "IM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imperia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "La Spezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Savona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "AL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alessandria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Asti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "BI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biella",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "CN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cuneo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "NO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Novara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "TO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Torino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Verbano Cusio Ossola",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Vercelli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Aosta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Aosta Valley (Valle D\u0027Aosta)"
+          },
+          "BG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bergamo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Brescia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Como",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Cremona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Lecco",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Lodi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Monza e Brianza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Mantova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Milano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "PV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PV",
+            "Primary Administrative Subdivision": "Pavia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "SO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sondrio",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "VA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Varese",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Belluno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "PD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Padova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "RO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rovigo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "TV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Treviso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Venezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Verona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vicenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "BZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bolzano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "TN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Trento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "GO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Gorizia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "PN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PN",
+            "Primary Administrative Subdivision": "Pordenone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "TS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TS",
+            "Primary Administrative Subdivision": "Trieste",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "UD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Udine",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "BO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bologna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Ferrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FO",
+            "Primary Administrative Subdivision": "Forlì",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna",
+            "Import-only": "true"
+          },
+          "FC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FC",
+            "Primary Administrative Subdivision": "Forlì-Cesena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "MO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Modena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Parma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "Piacenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ravenna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reggio Emilia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rimini",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "AR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arezzo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "FI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FI",
+            "Primary Administrative Subdivision": "Firenze",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "GR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grosseto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Livorno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lucca",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "MS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Massa Carrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Pistoia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Pisa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Prato",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "SI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SI",
+            "Primary Administrative Subdivision": "Siena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "CH.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AQ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AQ",
+            "Primary Administrative Subdivision": "L\u0027Aquila",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "PE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pescara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "TE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teramo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Ancona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "AP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Ascoli Piceno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "FM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FM",
+            "Primary Administrative Subdivision": "Fermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MC",
+            "Primary Administrative Subdivision": "Macerata",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "PS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche",
+            "Import-only": "true"
+          },
+          "PU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PU",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Matera",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "PZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PZ",
+            "Primary Administrative Subdivision": "Potenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "BA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bari",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Barletta-Andria-Trani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brindisi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "FG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FG",
+            "Primary Administrative Subdivision": "Foggia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "LE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Lecce",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "TA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Taranto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "CZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CZ",
+            "Primary Administrative Subdivision": "Catanzaro",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "CS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Cosenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "KR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Crotone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "RC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RC",
+            "Primary Administrative Subdivision": "Reggio Calabria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "VV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VV",
+            "Primary Administrative Subdivision": "Vibo Valentia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "AV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Avellino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "BN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Benevento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "CE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Caserta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "NA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Napoli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "SA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salerno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "IS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Isernia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "CB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Campobasso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "FR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Frosinone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "LT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LT",
+            "Primary Administrative Subdivision": "Latina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Roma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "VT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Viterbo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "PG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Perugia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "TR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Terni",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "AG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Agrigento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Caltanissetta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Catania",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "EN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EN",
+            "Primary Administrative Subdivision": "Enna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "ME.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Messina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "PA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Palermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "RG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RG",
+            "Primary Administrative Subdivision": "Ragusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "SR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Siracusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "TP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TP",
+            "Primary Administrative Subdivision": "Trapani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "21.259": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Svalbard",
+            "DXCC Entity Code": "259"
+          },
+          "42.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Agder",
+            "DXCC Entity Code": "266"
+          },
+          "34.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Innlandet",
+            "DXCC Entity Code": "266"
+          },
+          "15.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Møre og Romsdal",
+            "DXCC Entity Code": "266"
+          },
+          "18.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Nordland",
+            "DXCC Entity Code": "266"
+          },
+          "03.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Oslo",
+            "DXCC Entity Code": "266"
+          },
+          "11.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Rogaland",
+            "DXCC Entity Code": "266"
+          },
+          "54.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Troms og Finnmark",
+            "DXCC Entity Code": "266"
+          },
+          "50.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Trøndelag",
+            "DXCC Entity Code": "266"
+          },
+          "38.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Vestfold og Telemark",
+            "DXCC Entity Code": "266"
+          },
+          "46.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Vestland",
+            "DXCC Entity Code": "266"
+          },
+          "30.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Viken",
+            "DXCC Entity Code": "266"
+          },
+          "MD.256": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Madeira",
+            "DXCC Entity Code": "256"
+          },
+          "DR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DR",
+            "Primary Administrative Subdivision": "Drenthe",
+            "DXCC Entity Code": "263"
+          },
+          "FR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Fryslân",
+            "DXCC Entity Code": "263"
+          },
+          "GR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Groningen",
+            "DXCC Entity Code": "263"
+          },
+          "NB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Noord-Brabant",
+            "DXCC Entity Code": "263"
+          },
+          "OV.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Overijssel",
+            "DXCC Entity Code": "263"
+          },
+          "ZH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuid-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "FL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Flevoland",
+            "DXCC Entity Code": "263"
+          },
+          "GD.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "GE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263"
+          },
+          "LB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "LI.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263"
+          },
+          "NH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "Noord-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "UT.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utrecht",
+            "DXCC Entity Code": "263"
+          },
+          "ZL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZL",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "ZE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263"
+          },
+          "Z.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zachodnio-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "F.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "P.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Kujawsko-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "B.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Lubuskie",
+            "DXCC Entity Code": "269"
+          },
+          "W.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Wielkopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "J.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Warminsko-Mazurskie",
+            "DXCC Entity Code": "269"
+          },
+          "O.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Podlaskie",
+            "DXCC Entity Code": "269"
+          },
+          "R.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Mazowieckie",
+            "DXCC Entity Code": "269"
+          },
+          "D.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dolnoslaskie",
+            "DXCC Entity Code": "269"
+          },
+          "U.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Opolskie",
+            "DXCC Entity Code": "269"
+          },
+          "C.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Lodzkie",
+            "DXCC Entity Code": "269"
+          },
+          "S.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Swietokrzyskie",
+            "DXCC Entity Code": "269"
+          },
+          "K.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Podkarpackie",
+            "DXCC Entity Code": "269"
+          },
+          "L.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lubelskie",
+            "DXCC Entity Code": "269"
+          },
+          "G.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Slaskie",
+            "DXCC Entity Code": "269"
+          },
+          "M.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Malopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "AV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Aveiro",
+            "DXCC Entity Code": "272"
+          },
+          "BJ.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beja",
+            "DXCC Entity Code": "272"
+          },
+          "BR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braga",
+            "DXCC Entity Code": "272"
+          },
+          "BG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bragança",
+            "DXCC Entity Code": "272"
+          },
+          "CB.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Castelo Branco",
+            "DXCC Entity Code": "272"
+          },
+          "CO.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coimbra",
+            "DXCC Entity Code": "272"
+          },
+          "EV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evora",
+            "DXCC Entity Code": "272"
+          },
+          "FR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Faro",
+            "DXCC Entity Code": "272"
+          },
+          "GD.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guarda",
+            "DXCC Entity Code": "272"
+          },
+          "LR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Leiria",
+            "DXCC Entity Code": "272"
+          },
+          "LX.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LX",
+            "Primary Administrative Subdivision": "Lisboa",
+            "DXCC Entity Code": "272"
+          },
+          "PG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Portalegre",
+            "DXCC Entity Code": "272"
+          },
+          "PT.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Porto",
+            "DXCC Entity Code": "272"
+          },
+          "SR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Santarem",
+            "DXCC Entity Code": "272"
+          },
+          "ST.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Setubal",
+            "DXCC Entity Code": "272"
+          },
+          "VC.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Viana do Castelo",
+            "DXCC Entity Code": "272"
+          },
+          "VR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vila Real",
+            "DXCC Entity Code": "272"
+          },
+          "VS.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Viseu",
+            "DXCC Entity Code": "272"
+          },
+          "AR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arad",
+            "DXCC Entity Code": "275"
+          },
+          "CS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Caraș-Severin",
+            "DXCC Entity Code": "275"
+          },
+          "HD.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HD",
+            "Primary Administrative Subdivision": "Hunedoara",
+            "DXCC Entity Code": "275"
+          },
+          "TM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Timiș",
+            "DXCC Entity Code": "275"
+          },
+          "BU.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Bucureşti",
+            "DXCC Entity Code": "275",
+            "Import-only": "true",
+            "Comments": "Bucure\u0027ti"
+          },
+          "B.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "București",
+            "DXCC Entity Code": "275"
+          },
+          "IF.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ilfov",
+            "DXCC Entity Code": "275"
+          },
+          "BR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brăila",
+            "DXCC Entity Code": "275"
+          },
+          "CT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Constanța",
+            "DXCC Entity Code": "275"
+          },
+          "GL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Galați",
+            "DXCC Entity Code": "275"
+          },
+          "TL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tulcea",
+            "DXCC Entity Code": "275"
+          },
+          "VN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Vrancea",
+            "DXCC Entity Code": "275"
+          },
+          "AB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alba",
+            "DXCC Entity Code": "275"
+          },
+          "BH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BH",
+            "Primary Administrative Subdivision": "Bihor",
+            "DXCC Entity Code": "275"
+          },
+          "BN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bistrița-Năsăud",
+            "DXCC Entity Code": "275"
+          },
+          "CJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJ",
+            "Primary Administrative Subdivision": "Cluj",
+            "DXCC Entity Code": "275"
+          },
+          "MM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MM",
+            "Primary Administrative Subdivision": "Maramureș",
+            "DXCC Entity Code": "275"
+          },
+          "SJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "Sălaj",
+            "DXCC Entity Code": "275"
+          },
+          "SM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Satu Mare",
+            "DXCC Entity Code": "275"
+          },
+          "BV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BV",
+            "Primary Administrative Subdivision": "Brașov",
+            "DXCC Entity Code": "275"
+          },
+          "CV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CV",
+            "Primary Administrative Subdivision": "Covasna",
+            "DXCC Entity Code": "275"
+          },
+          "HR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Harghita",
+            "DXCC Entity Code": "275"
+          },
+          "MS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mureș",
+            "DXCC Entity Code": "275"
+          },
+          "SB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Sibiu",
+            "DXCC Entity Code": "275"
+          },
+          "AG.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Argeș",
+            "DXCC Entity Code": "275"
+          },
+          "DJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DJ",
+            "Primary Administrative Subdivision": "Dolj",
+            "DXCC Entity Code": "275"
+          },
+          "GJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gorj",
+            "DXCC Entity Code": "275"
+          },
+          "MH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mehedinți",
+            "DXCC Entity Code": "275"
+          },
+          "OT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olt",
+            "DXCC Entity Code": "275"
+          },
+          "VL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vâlcea",
+            "DXCC Entity Code": "275"
+          },
+          "BC.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bacău",
+            "DXCC Entity Code": "275"
+          },
+          "BT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Botoșani",
+            "DXCC Entity Code": "275"
+          },
+          "IS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Iași",
+            "DXCC Entity Code": "275"
+          },
+          "NT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Neamț",
+            "DXCC Entity Code": "275"
+          },
+          "SV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Suceava",
+            "DXCC Entity Code": "275"
+          },
+          "VS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Vaslui",
+            "DXCC Entity Code": "275"
+          },
+          "BZ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Buzău",
+            "DXCC Entity Code": "275"
+          },
+          "CL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Călărași",
+            "DXCC Entity Code": "275"
+          },
+          "DB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DB",
+            "Primary Administrative Subdivision": "Dâmbovița",
+            "DXCC Entity Code": "275"
+          },
+          "GR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Giurgiu",
+            "DXCC Entity Code": "275"
+          },
+          "IL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Ialomița",
+            "DXCC Entity Code": "275"
+          },
+          "PH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PH",
+            "Primary Administrative Subdivision": "Prahova",
+            "DXCC Entity Code": "275"
+          },
+          "TR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Teleorman",
+            "DXCC Entity Code": "275"
+          },
+          "AV.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Ávila",
+            "DXCC Entity Code": "281"
+          },
+          "BU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgos",
+            "DXCC Entity Code": "281"
+          },
+          "C.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "A Coruña",
+            "DXCC Entity Code": "281"
+          },
+          "LE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "León",
+            "DXCC Entity Code": "281"
+          },
+          "LO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "281"
+          },
+          "LU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lugo",
+            "DXCC Entity Code": "281"
+          },
+          "O.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Asturias",
+            "DXCC Entity Code": "281"
+          },
+          "OU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OU",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281",
+            "Import-only": "true"
+          },
+          "OR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281"
+          },
+          "P.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Palencia",
+            "DXCC Entity Code": "281"
+          },
+          "PO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Pontevedra",
+            "DXCC Entity Code": "281"
+          },
+          "S.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Cantabria",
+            "DXCC Entity Code": "281"
+          },
+          "SA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salamanca",
+            "DXCC Entity Code": "281"
+          },
+          "SG.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "Segovia",
+            "DXCC Entity Code": "281"
+          },
+          "SO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soria",
+            "DXCC Entity Code": "281"
+          },
+          "VA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Valladolid",
+            "DXCC Entity Code": "281"
+          },
+          "ZA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zamora",
+            "DXCC Entity Code": "281"
+          },
+          "BI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Bizkaia",
+            "DXCC Entity Code": "281"
+          },
+          "HU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HU",
+            "Primary Administrative Subdivision": "Huesca",
+            "DXCC Entity Code": "281"
+          },
+          "NA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Navarra",
+            "DXCC Entity Code": "281"
+          },
+          "SS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Gipuzkoa",
+            "DXCC Entity Code": "281"
+          },
+          "TE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teruel",
+            "DXCC Entity Code": "281"
+          },
+          "VI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Álava",
+            "DXCC Entity Code": "281"
+          },
+          "Z.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zaragoza",
+            "DXCC Entity Code": "281"
+          },
+          "B.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Barcelona",
+            "DXCC Entity Code": "281"
+          },
+          "GI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GI",
+            "Primary Administrative Subdivision": "Girona",
+            "DXCC Entity Code": "281"
+          },
+          "L.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lleida",
+            "DXCC Entity Code": "281"
+          },
+          "T.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tarragona",
+            "DXCC Entity Code": "281"
+          },
+          "BA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Badajoz",
+            "DXCC Entity Code": "281"
+          },
+          "CC.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CC",
+            "Primary Administrative Subdivision": "Cáceres",
+            "DXCC Entity Code": "281"
+          },
+          "CR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Ciudad Real",
+            "DXCC Entity Code": "281"
+          },
+          "CU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Cuenca",
+            "DXCC Entity Code": "281"
+          },
+          "GU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guadalajara",
+            "DXCC Entity Code": "281"
+          },
+          "M.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Madrid",
+            "DXCC Entity Code": "281"
+          },
+          "TO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Toledo",
+            "DXCC Entity Code": "281"
+          },
+          "A.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Alicante",
+            "DXCC Entity Code": "281"
+          },
+          "AB.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Albacete",
+            "DXCC Entity Code": "281"
+          },
+          "CS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Castellón",
+            "DXCC Entity Code": "281"
+          },
+          "MU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murcia",
+            "DXCC Entity Code": "281"
+          },
+          "V.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "València",
+            "DXCC Entity Code": "281"
+          },
+          "AL.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Almeria",
+            "DXCC Entity Code": "281"
+          },
+          "CA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cádiz",
+            "DXCC Entity Code": "281"
+          },
+          "CO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "281"
+          },
+          "GR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Granada",
+            "DXCC Entity Code": "281"
+          },
+          "H.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Huelva",
+            "DXCC Entity Code": "281"
+          },
+          "J.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Jaén",
+            "DXCC Entity Code": "281"
+          },
+          "MA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Málaga",
+            "DXCC Entity Code": "281"
+          },
+          "SE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sevilla",
+            "DXCC Entity Code": "281"
+          },
+          "AB.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Stockholms län",
+            "DXCC Entity Code": "284"
+          },
+          "I.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Gotlands län",
+            "DXCC Entity Code": "284"
+          },
+          "BD.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BD",
+            "Primary Administrative Subdivision": "Norrbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "AC.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Västerbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "X.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Gävleborgs län",
+            "DXCC Entity Code": "284"
+          },
+          "Z.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Jämtlands län",
+            "DXCC Entity Code": "284"
+          },
+          "Y.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Västernorrlands län",
+            "DXCC Entity Code": "284"
+          },
+          "W.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Dalarnas län",
+            "DXCC Entity Code": "284"
+          },
+          "S.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Värmlands län",
+            "DXCC Entity Code": "284"
+          },
+          "O.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Västra Götalands län",
+            "DXCC Entity Code": "284"
+          },
+          "T.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Örebro län",
+            "DXCC Entity Code": "284"
+          },
+          "E.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Östergötlands län",
+            "DXCC Entity Code": "284"
+          },
+          "D.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Södermanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "C.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Uppsala län",
+            "DXCC Entity Code": "284"
+          },
+          "U.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Västmanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "N.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Hallands län",
+            "DXCC Entity Code": "284"
+          },
+          "K.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Blekinge län",
+            "DXCC Entity Code": "284"
+          },
+          "F.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Jönköpings län",
+            "DXCC Entity Code": "284"
+          },
+          "H.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Kalmar län",
+            "DXCC Entity Code": "284"
+          },
+          "G.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Kronobergs län",
+            "DXCC Entity Code": "284"
+          },
+          "M.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Skåne län",
+            "DXCC Entity Code": "284"
+          },
+          "AG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Aargau",
+            "DXCC Entity Code": "287"
+          },
+          "AR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Appenzell Ausserrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "AI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Appenzell Innerrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "BL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Basel Landschaft",
+            "DXCC Entity Code": "287"
+          },
+          "BS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Basel Stadt",
+            "DXCC Entity Code": "287"
+          },
+          "BE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Bern",
+            "DXCC Entity Code": "287"
+          },
+          "FR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freiburg / Fribourg",
+            "DXCC Entity Code": "287"
+          },
+          "GE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genf / Genève",
+            "DXCC Entity Code": "287"
+          },
+          "GL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Glarus",
+            "DXCC Entity Code": "287"
+          },
+          "GR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Graubuenden / Grisons",
+            "DXCC Entity Code": "287"
+          },
+          "JU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "287"
+          },
+          "LU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luzern",
+            "DXCC Entity Code": "287"
+          },
+          "NE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Neuenburg / Neuchâtel",
+            "DXCC Entity Code": "287"
+          },
+          "NW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nidwalden",
+            "DXCC Entity Code": "287"
+          },
+          "OW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Obwalden",
+            "DXCC Entity Code": "287"
+          },
+          "SH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schaffhausen",
+            "DXCC Entity Code": "287"
+          },
+          "SZ.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwyz",
+            "DXCC Entity Code": "287"
+          },
+          "SO.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Solothurn",
+            "DXCC Entity Code": "287"
+          },
+          "SG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "St. Gallen",
+            "DXCC Entity Code": "287"
+          },
+          "TI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TI",
+            "Primary Administrative Subdivision": "Tessin / Ticino",
+            "DXCC Entity Code": "287"
+          },
+          "TG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Thurgau",
+            "DXCC Entity Code": "287"
+          },
+          "UR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UR",
+            "Primary Administrative Subdivision": "Uri",
+            "DXCC Entity Code": "287"
+          },
+          "VD.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Waadt / Vaud",
+            "DXCC Entity Code": "287"
+          },
+          "VS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Wallis / Valais",
+            "DXCC Entity Code": "287"
+          },
+          "ZH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuerich",
+            "DXCC Entity Code": "287"
+          },
+          "ZG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZG",
+            "Primary Administrative Subdivision": "Zug",
+            "DXCC Entity Code": "287"
+          },
+          "SU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sums\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "TE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Ternopil\u0027s\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Cherkas\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zakarpats\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dnipropetrovs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "OD.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odes\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Khersons\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "PO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Poltavs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Donets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "RI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rivnens\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Kharkivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luhans\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vinnyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Volyos\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZP.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZP",
+            "Primary Administrative Subdivision": "Zaporiz\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Chernihivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "IF.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ivano-Frankivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HM.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khmel\u0027nyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KV",
+            "Primary Administrative Subdivision": "Kyïv",
+            "DXCC Entity Code": "288"
+          },
+          "KO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Kyivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirovohrads\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "L\u0027vivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zhytomyrs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Chernivets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "NI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Mykolaivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Respublika Krym",
+            "DXCC Entity Code": "288"
+          },
+          "SL.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sevastopol\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Connecticut",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "ME.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Maine",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Massachusetts",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "New Hampshire",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "RI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rhode Island",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "VT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Vermont",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NJ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NJ",
+            "Primary Administrative Subdivision": "New Jersey",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NY",
+            "Primary Administrative Subdivision": "New York",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DE",
+            "Primary Administrative Subdivision": "Delaware",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "District of Columbia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Maryland",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "PA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pennsylvania",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alabama",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "FL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "GA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Georgia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "KY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kentucky",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "NC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NC",
+            "Primary Administrative Subdivision": "North Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "SC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "South Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "TN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tennessee",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "VA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "LA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Louisiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mississippi",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NM.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "New Mexico",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "OK.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OK",
+            "Primary Administrative Subdivision": "Oklahoma",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "TX.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TX",
+            "Primary Administrative Subdivision": "Texas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "CA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "California",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "AZ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AZ",
+            "Primary Administrative Subdivision": "Arizona",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "ID.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ID",
+            "Primary Administrative Subdivision": "Idaho",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "MT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "06/07"
+          },
+          "NV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Nevada",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "OR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oregon",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "UT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utah",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "WA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Washington",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "WY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Wyoming",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Michigan",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "OH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OH",
+            "Primary Administrative Subdivision": "Ohio",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "IL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Illinois",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "IN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Indiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WI",
+            "Primary Administrative Subdivision": "Wisconsin",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "CO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colorado",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "IA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IA",
+            "Primary Administrative Subdivision": "Iowa",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "KS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Minnesota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Missouri",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nebraska",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "ND.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "North Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "SD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "South Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "AH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AH",
+            "Primary Administrative Subdivision": "Anhui",
+            "DXCC Entity Code": "318"
+          },
+          "BJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beijing",
+            "DXCC Entity Code": "318"
+          },
+          "CQ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CQ",
+            "Primary Administrative Subdivision": "Chongqing",
+            "DXCC Entity Code": "318"
+          },
+          "FJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJ",
+            "Primary Administrative Subdivision": "Fujian",
+            "DXCC Entity Code": "318"
+          },
+          "GD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guangdong",
+            "DXCC Entity Code": "318"
+          },
+          "GS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Gansu",
+            "DXCC Entity Code": "318"
+          },
+          "GX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GX",
+            "Primary Administrative Subdivision": "Guangxi Zhuangzu",
+            "DXCC Entity Code": "318"
+          },
+          "GZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZ",
+            "Primary Administrative Subdivision": "Guizhou",
+            "DXCC Entity Code": "318"
+          },
+          "HA.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Henan",
+            "DXCC Entity Code": "318"
+          },
+          "HB.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hubei",
+            "DXCC Entity Code": "318"
+          },
+          "HE.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hebei",
+            "DXCC Entity Code": "318"
+          },
+          "HI.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hainan",
+            "DXCC Entity Code": "318"
+          },
+          "HL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Heilongjiang",
+            "DXCC Entity Code": "318"
+          },
+          "HN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HN",
+            "Primary Administrative Subdivision": "Hunan",
+            "DXCC Entity Code": "318"
+          },
+          "JL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JL",
+            "Primary Administrative Subdivision": "Jilin",
+            "DXCC Entity Code": "318"
+          },
+          "JS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JS",
+            "Primary Administrative Subdivision": "Jiangsu",
+            "DXCC Entity Code": "318"
+          },
+          "JX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JX",
+            "Primary Administrative Subdivision": "Jiangxi",
+            "DXCC Entity Code": "318"
+          },
+          "LN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Liaoning",
+            "DXCC Entity Code": "318"
+          },
+          "NM.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Nei Mongol",
+            "DXCC Entity Code": "318"
+          },
+          "NX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NX",
+            "Primary Administrative Subdivision": "Ningxia Huizu",
+            "DXCC Entity Code": "318"
+          },
+          "QH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QH",
+            "Primary Administrative Subdivision": "Qinghai",
+            "DXCC Entity Code": "318"
+          },
+          "SC.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Sichuan",
+            "DXCC Entity Code": "318"
+          },
+          "SD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Shandong",
+            "DXCC Entity Code": "318"
+          },
+          "SH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Shanghai",
+            "DXCC Entity Code": "318"
+          },
+          "SN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Shaanxi",
+            "DXCC Entity Code": "318"
+          },
+          "SX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SX",
+            "Primary Administrative Subdivision": "Shanxi",
+            "DXCC Entity Code": "318"
+          },
+          "TJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TJ",
+            "Primary Administrative Subdivision": "Tianjin",
+            "DXCC Entity Code": "318"
+          },
+          "XJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XJ",
+            "Primary Administrative Subdivision": "Xinjiang Uygur",
+            "DXCC Entity Code": "318"
+          },
+          "XZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XZ",
+            "Primary Administrative Subdivision": "Xizang",
+            "DXCC Entity Code": "318"
+          },
+          "YN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yunnan",
+            "DXCC Entity Code": "318"
+          },
+          "ZJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZJ",
+            "Primary Administrative Subdivision": "Zhejiang",
+            "DXCC Entity Code": "318"
+          },
+          "AP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Andhra Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arunāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AS.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AS",
+            "Primary Administrative Subdivision": "Assam",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "BR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bihār",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "CH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chandīgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "CG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CG",
+            "Primary Administrative Subdivision": "Chhattīsgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "DD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DD",
+            "Primary Administrative Subdivision": "Damān and Diu",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Delhi",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dādra and Nagar Haveli",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "GA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Goa",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "GJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gujarāt",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Haryāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HP",
+            "Primary Administrative Subdivision": "Himāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "JK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JK",
+            "Primary Administrative Subdivision": "Jammu and Kashmīr",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "JH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JH",
+            "Primary Administrative Subdivision": "Jhārkhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Karnātaka",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Kerala",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "LA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Ladākh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "MP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MP",
+            "Primary Administrative Subdivision": "Madhya Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mahārāshtra",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Manipur",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "ML.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Meghālaya",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MZ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mizoram",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "NL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nāgāland",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "OD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odisha",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "PY.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PY",
+            "Primary Administrative Subdivision": "Puducherry",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "PB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Punjab",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "RJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rājasthān",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "SK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Sikkim",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tamil Nādu",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Telangāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Tripura",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UP",
+            "Primary Administrative Subdivision": "Uttar Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UK",
+            "Primary Administrative Subdivision": "Uttarākhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "WB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "West Bengal",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "12.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Chiba",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "16.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Gunma",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "14.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Ibaraki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "11.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Kanagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "13.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Saitama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "15.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Tochigi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "10.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Tokyo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "17.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Yamanashi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "20.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Aichi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "19.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Gifu",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "21.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Mie",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "18.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Shizuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "27.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Hyogo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "22.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Kyoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "24.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Nara",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "25.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Osaka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "23.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Shiga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "26.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Wakayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "35.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Hiroshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "31.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Okayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "32.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Shimane",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "34.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Tottori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "33.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Yamaguchi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "38.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Ehime",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "36.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Kagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "39.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Kochi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "37.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Tokushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "40.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Fukuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "46.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Kagoshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "43.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Kumamoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "45.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Miyazaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "42.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Nagasaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "44.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Oita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "47.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Okinawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "41.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Saga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "04.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Akita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "02.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aomori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "07.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Fukushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "03.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Iwate",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "06.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Miyagi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "05.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Yamagata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "01.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Hokkaido",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokkaido"
+          },
+          "29.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Fukui",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "30.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Ishikawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "28.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Toyama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "09.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Nagano",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "08.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Niigata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "AUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUR",
+            "Primary Administrative Subdivision": "Aurora",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "BTG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTG",
+            "Primary Administrative Subdivision": "Batangas",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "CAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAV",
+            "Primary Administrative Subdivision": "Cavite",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "LAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAG",
+            "Primary Administrative Subdivision": "Laguna",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MAD.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAD",
+            "Primary Administrative Subdivision": "Marinduque",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDC",
+            "Primary Administrative Subdivision": "Mindoro Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDR",
+            "Primary Administrative Subdivision": "Mindoro Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "PLW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PLW",
+            "Primary Administrative Subdivision": "Palawan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "QUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Quezon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "RIZ.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RIZ",
+            "Primary Administrative Subdivision": "Rizal",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ROM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROM",
+            "Primary Administrative Subdivision": "Romblon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ILN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILN",
+            "Primary Administrative Subdivision": "Ilocos Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "ILS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILS",
+            "Primary Administrative Subdivision": "Ilocos Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "LUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUN",
+            "Primary Administrative Subdivision": "La Union",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "PAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAN",
+            "Primary Administrative Subdivision": "Pangasinan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "BTN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTN",
+            "Primary Administrative Subdivision": "Batanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "CAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAG",
+            "Primary Administrative Subdivision": "Cagayan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ISA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ISA",
+            "Primary Administrative Subdivision": "Isabela",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "NUV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUV",
+            "Primary Administrative Subdivision": "Nueva Vizcaya",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "QUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUI",
+            "Primary Administrative Subdivision": "Quirino",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ABR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ABR",
+            "Primary Administrative Subdivision": "Abra",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "APA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Apayao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BEN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BEN",
+            "Primary Administrative Subdivision": "Benguet",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "IFU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IFU",
+            "Primary Administrative Subdivision": "Ifugao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "KAL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KAL",
+            "Primary Administrative Subdivision": "Kalinga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "MOU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOU",
+            "Primary Administrative Subdivision": "Mountain Province",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Bataan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "BUL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUL",
+            "Primary Administrative Subdivision": "Bulacan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "NUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUE",
+            "Primary Administrative Subdivision": "Nueva Ecija",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "PAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAM",
+            "Primary Administrative Subdivision": "Pampanga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "TAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAR",
+            "Primary Administrative Subdivision": "Tarlac",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ZMB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMB",
+            "Primary Administrative Subdivision": "Zambales",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ALB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ALB",
+            "Primary Administrative Subdivision": "Albay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Camarines Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAS",
+            "Primary Administrative Subdivision": "Camarines Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAT",
+            "Primary Administrative Subdivision": "Catanduanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "MAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAS",
+            "Primary Administrative Subdivision": "Masbate",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "SOR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOR",
+            "Primary Administrative Subdivision": "Sorsogon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "BIL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BIL",
+            "Primary Administrative Subdivision": "Biliran",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "EAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EAS",
+            "Primary Administrative Subdivision": "Eastern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "LEY.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEY",
+            "Primary Administrative Subdivision": "Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "NSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "Northern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "SLE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLE",
+            "Primary Administrative Subdivision": "Southern Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "WSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WSA",
+            "Primary Administrative Subdivision": "Western Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "AKL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AKL",
+            "Primary Administrative Subdivision": "Aklan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ANT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ANT",
+            "Primary Administrative Subdivision": "Antique",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "CAP.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAP",
+            "Primary Administrative Subdivision": "Capiz",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "GUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUI",
+            "Primary Administrative Subdivision": "Guimaras",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ILI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILI",
+            "Primary Administrative Subdivision": "Iloilo",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "NEC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NEC",
+            "Primary Administrative Subdivision": "Negros Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "BOH.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOH",
+            "Primary Administrative Subdivision": "Bohol",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "CEB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CEB",
+            "Primary Administrative Subdivision": "Cebu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "NER.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NER",
+            "Primary Administrative Subdivision": "Negros Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "SIG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIG",
+            "Primary Administrative Subdivision": "Siquijor",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "ZAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAN",
+            "Primary Administrative Subdivision": "Zamboanga del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAS",
+            "Primary Administrative Subdivision": "Zamboanga del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZSI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZSI",
+            "Primary Administrative Subdivision": "Zamboanga Sibugay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "NCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCO",
+            "Primary Administrative Subdivision": "Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUK",
+            "Primary Administrative Subdivision": "Sultan Kudarat",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAR",
+            "Primary Administrative Subdivision": "Sarangani",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SCO",
+            "Primary Administrative Subdivision": "South Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "BAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAS",
+            "Primary Administrative Subdivision": "Basilan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAS",
+            "Primary Administrative Subdivision": "Lanao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "MAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAG",
+            "Primary Administrative Subdivision": "Maguindanao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "SLU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Sulu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "TAW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAW",
+            "Primary Administrative Subdivision": "Tawi-Tawi",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAN",
+            "Primary Administrative Subdivision": "Lanao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "BUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUK",
+            "Primary Administrative Subdivision": "Bukidnon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "CAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Camiguin",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSC",
+            "Primary Administrative Subdivision": "Misamis Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSR",
+            "Primary Administrative Subdivision": "Misamis Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "COM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COM",
+            "Primary Administrative Subdivision": "Davao de Oro",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAV",
+            "Primary Administrative Subdivision": "Davao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAS",
+            "Primary Administrative Subdivision": "Davao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAO",
+            "Primary Administrative Subdivision": "Davao Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "AGN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGN",
+            "Primary Administrative Subdivision": "Agusan del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "AGS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Agusan del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUN",
+            "Primary Administrative Subdivision": "Surigao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUR",
+            "Primary Administrative Subdivision": "Surigao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "CHA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHA",
+            "Primary Administrative Subdivision": "Changhua",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "CYI.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYI",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "CYQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYQ",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HSZ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSZ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "HSQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSQ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HUA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUA",
+            "Primary Administrative Subdivision": "Hualien",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "KHH.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KHH",
+            "Primary Administrative Subdivision": "Kaohsiung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "KEE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEE",
+            "Primary Administrative Subdivision": "Keelung",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "KIN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KIN",
+            "Primary Administrative Subdivision": "Kinmen",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "LIE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LIE",
+            "Primary Administrative Subdivision": "Lienchiang",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "MIA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIA",
+            "Primary Administrative Subdivision": "Miaoli",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NAN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAN",
+            "Primary Administrative Subdivision": "Nantou",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NWT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NWT",
+            "Primary Administrative Subdivision": "New Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "PEN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEN",
+            "Primary Administrative Subdivision": "Penghu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "PIF.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIF",
+            "Primary Administrative Subdivision": "Pingtung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TXG.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TXG",
+            "Primary Administrative Subdivision": "Taichung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TNN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNN",
+            "Primary Administrative Subdivision": "Tainan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TPE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TPE",
+            "Primary Administrative Subdivision": "Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TTT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTT",
+            "Primary Administrative Subdivision": "Taitung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TAO.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAO",
+            "Primary Administrative Subdivision": "Taoyuan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "ILA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Yilan",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "YUN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUN",
+            "Primary Administrative Subdivision": "Yunlin",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "01.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Zagrebačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "02.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Krapinsko-Zagorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "03.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Sisačko-Moslavačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "04.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Karlovačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "05.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Varaždinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "06.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Koprivničko-Križevačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "07.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Bjelovarsko-Bilogorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "08.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Primorsko-Goranska županija",
+            "DXCC Entity Code": "497"
+          },
+          "09.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ličko-Senjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "10.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Virovitičko-Podravska županija",
+            "DXCC Entity Code": "497"
+          },
+          "11.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Požeško-Slavonska županija",
+            "DXCC Entity Code": "497"
+          },
+          "12.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Brodsko-Posavska županija",
+            "DXCC Entity Code": "497"
+          },
+          "13.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Zadarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "14.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Osječko-Baranjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "15.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Šibensko-Kninska županija",
+            "DXCC Entity Code": "497"
+          },
+          "16.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Vukovarsko-Srijemska županija",
+            "DXCC Entity Code": "497"
+          },
+          "17.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Splitsko-Dalmatinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "18.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Istarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "19.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Dubrovačko-Neretvanska županija",
+            "DXCC Entity Code": "497"
+          },
+          "20.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Međimurska županija",
+            "DXCC Entity Code": "497"
+          },
+          "21.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Grad Zagreb",
+            "DXCC Entity Code": "497"
+          },
+          "APA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Praha 1",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APB",
+            "Primary Administrative Subdivision": "Praha 2",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APC.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APC",
+            "Primary Administrative Subdivision": "Praha 3",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APD",
+            "Primary Administrative Subdivision": "Praha 4",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APE",
+            "Primary Administrative Subdivision": "Praha 5",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APF.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APF",
+            "Primary Administrative Subdivision": "Praha 6",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APG.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APG",
+            "Primary Administrative Subdivision": "Praha 7",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APH",
+            "Primary Administrative Subdivision": "Praha 8",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "API.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "API",
+            "Primary Administrative Subdivision": "Praha 9",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APJ",
+            "Primary Administrative Subdivision": "Praha 10",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "BBN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBN",
+            "Primary Administrative Subdivision": "Benesov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BBE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBE",
+            "Primary Administrative Subdivision": "Beroun",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKD",
+            "Primary Administrative Subdivision": "Kladno",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKO",
+            "Primary Administrative Subdivision": "Kolin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKH",
+            "Primary Administrative Subdivision": "Kutna Hora",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BME.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BME",
+            "Primary Administrative Subdivision": "Melnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BMB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BMB",
+            "Primary Administrative Subdivision": "Mlada Boleslav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BNY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BNY",
+            "Primary Administrative Subdivision": "Nymburk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPZ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPZ",
+            "Primary Administrative Subdivision": "Praha zapad",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPV",
+            "Primary Administrative Subdivision": "Praha vychod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPB",
+            "Primary Administrative Subdivision": "Pribram",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BRA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRA",
+            "Primary Administrative Subdivision": "Rakovnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "CBU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CBU",
+            "Primary Administrative Subdivision": "Ceske Budejovice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CCK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CCK",
+            "Primary Administrative Subdivision": "Cesky Krumlov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CJH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJH",
+            "Primary Administrative Subdivision": "Jindrichuv Hradec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPE",
+            "Primary Administrative Subdivision": "Pelhrimov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPI",
+            "Primary Administrative Subdivision": "Pisek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPR",
+            "Primary Administrative Subdivision": "Prachatice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CST.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CST",
+            "Primary Administrative Subdivision": "Strakonice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CTA",
+            "Primary Administrative Subdivision": "Tabor",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "DDO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DDO",
+            "Primary Administrative Subdivision": "Domazlice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DCH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DCH",
+            "Primary Administrative Subdivision": "Cheb",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKV",
+            "Primary Administrative Subdivision": "Karlovy Vary",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKL",
+            "Primary Administrative Subdivision": "Klatovy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPM",
+            "Primary Administrative Subdivision": "Plzen mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPJ",
+            "Primary Administrative Subdivision": "Plzen jih",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPS",
+            "Primary Administrative Subdivision": "Plzen sever",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DRO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DRO",
+            "Primary Administrative Subdivision": "Rokycany",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DSO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DSO",
+            "Primary Administrative Subdivision": "Sokolov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DTA",
+            "Primary Administrative Subdivision": "Tachov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "ECL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECL",
+            "Primary Administrative Subdivision": "Ceska Lipa",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EDE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EDE",
+            "Primary Administrative Subdivision": "Decin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ECH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECH",
+            "Primary Administrative Subdivision": "Chomutov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EJA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EJA",
+            "Primary Administrative Subdivision": "Jablonec n. Nisou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELI",
+            "Primary Administrative Subdivision": "Liberec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELT.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELT",
+            "Primary Administrative Subdivision": "Litomerice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELO",
+            "Primary Administrative Subdivision": "Louny",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EMO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMO",
+            "Primary Administrative Subdivision": "Most",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ETE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ETE",
+            "Primary Administrative Subdivision": "Teplice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EUL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EUL",
+            "Primary Administrative Subdivision": "Usti nad Labem",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "FHB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHB",
+            "Primary Administrative Subdivision": "Havlickuv Brod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FHK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHK",
+            "Primary Administrative Subdivision": "Hradec Kralove",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FCR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FCR",
+            "Primary Administrative Subdivision": "Chrudim",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJI",
+            "Primary Administrative Subdivision": "Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FNA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FNA",
+            "Primary Administrative Subdivision": "Nachod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FPA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FPA",
+            "Primary Administrative Subdivision": "Pardubice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FRK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FRK",
+            "Primary Administrative Subdivision": "Rychn n. Kneznou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSE",
+            "Primary Administrative Subdivision": "Semily",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSV",
+            "Primary Administrative Subdivision": "Svitavy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FTR",
+            "Primary Administrative Subdivision": "Trutnov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FUO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FUO",
+            "Primary Administrative Subdivision": "Usti nad Orlici",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "GBL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBL",
+            "Primary Administrative Subdivision": "Blansko",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBM",
+            "Primary Administrative Subdivision": "Brno mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBV",
+            "Primary Administrative Subdivision": "Brno venkov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBR",
+            "Primary Administrative Subdivision": "Breclav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GHO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GHO",
+            "Primary Administrative Subdivision": "Hodonin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJI",
+            "Primary Administrative Subdivision": "Jihlava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GKR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GKR",
+            "Primary Administrative Subdivision": "Kromeriz",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPR",
+            "Primary Administrative Subdivision": "Prostejov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTR",
+            "Primary Administrative Subdivision": "Trebic",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GUH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUH",
+            "Primary Administrative Subdivision": "Uherske Hradiste",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GVY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GVY",
+            "Primary Administrative Subdivision": "Vyskov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZL",
+            "Primary Administrative Subdivision": "Zlin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZN",
+            "Primary Administrative Subdivision": "Znojmo",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZS",
+            "Primary Administrative Subdivision": "Zdar nad Sazavou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "HBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HBR",
+            "Primary Administrative Subdivision": "Bruntal",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HFM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HFM",
+            "Primary Administrative Subdivision": "Frydek-Mistek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HJE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HJE",
+            "Primary Administrative Subdivision": "Jesenik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HKA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKA",
+            "Primary Administrative Subdivision": "Karvina",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HNJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HNJ",
+            "Primary Administrative Subdivision": "Novy Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOL",
+            "Primary Administrative Subdivision": "Olomouc",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOP.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOP",
+            "Primary Administrative Subdivision": "Opava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOS",
+            "Primary Administrative Subdivision": "Ostrava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HPR",
+            "Primary Administrative Subdivision": "Prerov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HSU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSU",
+            "Primary Administrative Subdivision": "Sumperk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HVS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HVS",
+            "Primary Administrative Subdivision": "Vsetin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "BAA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAA",
+            "Primary Administrative Subdivision": "Bratislava 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAB",
+            "Primary Administrative Subdivision": "Bratislava 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAC",
+            "Primary Administrative Subdivision": "Bratislava 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAD",
+            "Primary Administrative Subdivision": "Bratislava 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAE",
+            "Primary Administrative Subdivision": "Bratislava 5",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "MAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAL",
+            "Primary Administrative Subdivision": "Malacky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "PEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEZ",
+            "Primary Administrative Subdivision": "Pezinok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "SEN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEN",
+            "Primary Administrative Subdivision": "Senec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "DST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DST",
+            "Primary Administrative Subdivision": "Dunajska Streda",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "GAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GAL",
+            "Primary Administrative Subdivision": "Galanta",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "HLO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLO",
+            "Primary Administrative Subdivision": "Hlohovec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "PIE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIE",
+            "Primary Administrative Subdivision": "Piestany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEA",
+            "Primary Administrative Subdivision": "Senica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SKA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SKA",
+            "Primary Administrative Subdivision": "Skalica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "TRN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRN",
+            "Primary Administrative Subdivision": "Trnava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "BAN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Banovce n. Bebr.",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "ILA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Ilava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "MYJ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MYJ",
+            "Primary Administrative Subdivision": "Myjava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "NMV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NMV",
+            "Primary Administrative Subdivision": "Nove Mesto n. Vah",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAR",
+            "Primary Administrative Subdivision": "Partizanske",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PBY",
+            "Primary Administrative Subdivision": "Povazska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PRI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRI",
+            "Primary Administrative Subdivision": "Prievidza",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUC",
+            "Primary Administrative Subdivision": "Puchov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "TNC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNC",
+            "Primary Administrative Subdivision": "Trencin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "KOM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KOM",
+            "Primary Administrative Subdivision": "Komarno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "LVC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LVC",
+            "Primary Administrative Subdivision": "Levice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NIT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIT",
+            "Primary Administrative Subdivision": "Nitra",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NZA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NZA",
+            "Primary Administrative Subdivision": "Nove Zamky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "SAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAL",
+            "Primary Administrative Subdivision": "Sala",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "TOP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TOP",
+            "Primary Administrative Subdivision": "Topolcany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "ZMO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMO",
+            "Primary Administrative Subdivision": "Zlate Moravce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "BYT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BYT",
+            "Primary Administrative Subdivision": "Bytca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "CAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAD",
+            "Primary Administrative Subdivision": "Cadca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "DKU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKU",
+            "Primary Administrative Subdivision": "Dolny Kubin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "KNM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KNM",
+            "Primary Administrative Subdivision": "Kysucke N. Mesto",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "LMI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LMI",
+            "Primary Administrative Subdivision": "Liptovsky Mikulas",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "MAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAR",
+            "Primary Administrative Subdivision": "Martin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "NAM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAM",
+            "Primary Administrative Subdivision": "Namestovo",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "RUZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RUZ",
+            "Primary Administrative Subdivision": "Ruzomberok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TTE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTE",
+            "Primary Administrative Subdivision": "Turcianske Teplice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TVR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TVR",
+            "Primary Administrative Subdivision": "Tvrdosin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "ZIL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIL",
+            "Primary Administrative Subdivision": "Zilina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "BBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBY",
+            "Primary Administrative Subdivision": "Banska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BST",
+            "Primary Administrative Subdivision": "Banska Stiavnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRE",
+            "Primary Administrative Subdivision": "Brezno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "DET.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DET",
+            "Primary Administrative Subdivision": "Detva",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "KRU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KRU",
+            "Primary Administrative Subdivision": "Krupina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "LUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUC",
+            "Primary Administrative Subdivision": "Lucenec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "POL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POL",
+            "Primary Administrative Subdivision": "Poltar",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "REV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "REV",
+            "Primary Administrative Subdivision": "Revuca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "RSO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RSO",
+            "Primary Administrative Subdivision": "Rimavska Sobota",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "VKR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VKR",
+            "Primary Administrative Subdivision": "Velky Krtis",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAR",
+            "Primary Administrative Subdivision": "Zarnovica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZIH.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIH",
+            "Primary Administrative Subdivision": "Ziar nad Hronom",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZVO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZVO",
+            "Primary Administrative Subdivision": "Zvolen",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "GEL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GEL",
+            "Primary Administrative Subdivision": "Gelnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEA",
+            "Primary Administrative Subdivision": "Kosice 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEB",
+            "Primary Administrative Subdivision": "Kosice 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEC",
+            "Primary Administrative Subdivision": "Kosice 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KED",
+            "Primary Administrative Subdivision": "Kosice 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEO",
+            "Primary Administrative Subdivision": "Kosice-okolie",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "MIC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michalovce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "ROZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROZ",
+            "Primary Administrative Subdivision": "Roznava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SOB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOB",
+            "Primary Administrative Subdivision": "Sobrance",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SNV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNV",
+            "Primary Administrative Subdivision": "Spisska Nova Ves",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "TRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRE",
+            "Primary Administrative Subdivision": "Trebisov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "BAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAR",
+            "Primary Administrative Subdivision": "Bardejov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "HUM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUM",
+            "Primary Administrative Subdivision": "Humenne",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "KEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEZ",
+            "Primary Administrative Subdivision": "Kezmarok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "LEV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEV",
+            "Primary Administrative Subdivision": "Levoca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "MED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MED",
+            "Primary Administrative Subdivision": "Medzilaborce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "POP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POP",
+            "Primary Administrative Subdivision": "Poprad",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "PRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRE",
+            "Primary Administrative Subdivision": "Presov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAB",
+            "Primary Administrative Subdivision": "Sabinov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SNI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNI",
+            "Primary Administrative Subdivision": "Snina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SLU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Stara Lubovna",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "STR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STR",
+            "Primary Administrative Subdivision": "Stropkov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SVI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SVI",
+            "Primary Administrative Subdivision": "Svidnik",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "VRT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VRT",
+            "Primary Administrative Subdivision": "Vranov nad Toplou",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          }
+        }
+      },
+      "Propagation_Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Enumeration",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AS",
+            "Description": "Aircraft Scatter"
+          },
+          "AUE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUE",
+            "Description": "Aurora-E"
+          },
+          "AUR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUR",
+            "Description": "Aurora"
+          },
+          "BS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "BS",
+            "Description": "Back scatter"
+          },
+          "ECH": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ECH",
+            "Description": "EchoLink"
+          },
+          "EME": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "EME",
+            "Description": "Earth-Moon-Earth"
+          },
+          "ES": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ES",
+            "Description": "Sporadic E"
+          },
+          "F2": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "F2",
+            "Description": "F2 Reflection"
+          },
+          "FAI": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "FAI",
+            "Description": "Field Aligned Irregularities"
+          },
+          "GWAVE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "GWAVE",
+            "Description": "Ground Wave"
+          },
+          "INTERNET": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "INTERNET",
+            "Description": "Internet-assisted"
+          },
+          "ION": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ION",
+            "Description": "Ionoscatter"
+          },
+          "IRL": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "IRL",
+            "Description": "IRLP"
+          },
+          "LOS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "LOS",
+            "Description": "Line of Sight (includes transmission through obstacles such as walls)"
+          },
+          "MS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "MS",
+            "Description": "Meteor scatter"
+          },
+          "RPT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RPT",
+            "Description": "Terrestrial or atmospheric repeater or transponder"
+          },
+          "RS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RS",
+            "Description": "Rain scatter"
+          },
+          "SAT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "SAT",
+            "Description": "Satellite"
+          },
+          "TEP": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TEP",
+            "Description": "Trans-equatorial"
+          },
+          "TR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TR",
+            "Description": "Tropospheric ducting"
+          }
+        }
+      },
+      "QSL_Medium": {
+        "Header": [
+          "Enumeration Name",
+          "Medium",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CARD": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "CARD",
+            "Description": "QSO confirmation via paper QSL card"
+          },
+          "EQSL": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "EQSL",
+            "Description": "QSO confirmation via eQSL.cc"
+          },
+          "LOTW": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "LOTW",
+            "Description": "QSO confirmation via ARRL Logbook of the World"
+          }
+        }
+      },
+      "QSL_Rcvd": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "Y",
+            "Meaning": "yes (confirmed)",
+            "Description": "an incoming QSL card has been received the QSO has been confirmed by the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "an incoming QSL card has not been received the QSO has not been confirmed by the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the logging station has requested a QSL card the logging station has requested the QSO be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          },
+          "V": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "V",
+            "Meaning": "verified",
+            "Description": "DXCC award credit granted for the QSL card - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:card,DXCC_BAND:card,DXCC_MODE:card DXCC credit granted for the LoTW confirmation - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:lotw,DXCC_BAND:lotw,DXCC_MODE:lotw",
+            "Import-only": "true"
+          }
+        }
+      },
+      "QSL_Sent": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Y",
+            "Meaning": "yes",
+            "Description": "an outgoing QSL card has been sent the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "do not send an outgoing QSL card do not upload the QSO to the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the contacted station has requested a QSL card the contacted station has requested the QSO be uploaded to the online service"
+          },
+          "Q": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Q",
+            "Meaning": "queued",
+            "Description": "an outgoing QSL card has been selected to be sent a QSO has been selected to be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          }
+        }
+      },
+      "QSL_Via": {
+        "Header": [
+          "Enumeration Name",
+          "Via",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "B": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "B",
+            "Description": "bureau"
+          },
+          "D": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "D",
+            "Description": "direct"
+          },
+          "E": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "E",
+            "Description": "electronic"
+          },
+          "M": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "M",
+            "Description": "manager",
+            "Import-only": "true"
+          }
+        }
+      },
+      "QSO_Complete": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "Y",
+            "Meaning": "yes"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "N",
+            "Meaning": "no"
+          },
+          "NIL": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "NIL",
+            "Meaning": "not heard"
+          },
+          "?": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "?",
+            "Meaning": "uncertain"
+          }
+        }
+      },
+      "QSO_Download_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "Y",
+            "Description": "the QSO has been downloaded from the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "N",
+            "Description": "the QSO has not been downloaded from the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "I",
+            "Description": "ignore or invalid"
+          }
+        }
+      },
+      "QSO_Upload_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "Y",
+            "Description": "the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "N",
+            "Description": "do not upload the QSO to the online service"
+          },
+          "M": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "M",
+            "Description": "the QSO has been modified since being uploaded to the online service"
+          }
+        }
+      },
+      "Region": {
+        "Header": [
+          "Enumeration Name",
+          "Region Entity Code",
+          "DXCC Entity Code",
+          "Region",
+          "Prefix",
+          "Applicability",
+          "Start Date",
+          "End Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NONE": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "NONE",
+            "Region": "Not within a WAE or CQ region that is within a DXCC entity"
+          },
+          "IV.206": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "IV",
+            "DXCC Entity Code": "206",
+            "Region": "ITU Vienna",
+            "Prefix": "4U1V",
+            "Applicability": "CQ, WAE"
+          },
+          "AI.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "AI",
+            "DXCC Entity Code": "248",
+            "Region": "African Italy",
+            "Prefix": "IG9",
+            "Applicability": "CQ"
+          },
+          "SY.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SY",
+            "DXCC Entity Code": "248",
+            "Region": "Sicily",
+            "Prefix": "IT9",
+            "Applicability": "CQ, WAE"
+          },
+          "BI.259": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "BI",
+            "DXCC Entity Code": "259",
+            "Region": "Bear Island",
+            "Prefix": "JW/B",
+            "Applicability": "CQ, WAE"
+          },
+          "SI.279": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SI",
+            "DXCC Entity Code": "279",
+            "Region": "Shetland Islands",
+            "Prefix": "GM/S",
+            "Applicability": "CQ, WAE"
+          },
+          "KO.296": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "296",
+            "Region": "Kosovo",
+            "Prefix": "YU8",
+            "Applicability": "CQ, WAE",
+            "End Date": "2012-09-11T00:00:00Z"
+          },
+          "KO.0": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "0",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2012-09-12T00:00:00Z",
+            "End Date": "2018-01-20T00:00:00Z"
+          },
+          "KO.522": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "522",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2018-01-21T00:00:00Z"
+          },
+          "ET.390": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "ET",
+            "DXCC Entity Code": "390",
+            "Region": "European Turkey",
+            "Prefix": "TA1",
+            "Applicability": "CQ"
+          }
+        }
+      },
+      "Secondary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Secondary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Alaska Judicial District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AK,Aleutians East": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians East",
+            "Secondary Administrative Subdivision": "Aleutians East",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Aleutians Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians Islands",
+            "Secondary Administrative Subdivision": "Aleutians Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Aleutians West": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians West",
+            "Secondary Administrative Subdivision": "Aleutians West",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Anchorage": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Anchorage",
+            "Secondary Administrative Subdivision": "Anchorage",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Angoon",
+            "Secondary Administrative Subdivision": "Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Barrow": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Barrow",
+            "Secondary Administrative Subdivision": "Barrow",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Bethel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bethel",
+            "Secondary Administrative Subdivision": "Bethel",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Bristol Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bristol Bay",
+            "Secondary Administrative Subdivision": "Bristol Bay",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Cordova-McCarthy": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Cordova-McCarthy",
+            "Secondary Administrative Subdivision": "Cordova-McCarthy",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Denali": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Denali",
+            "Secondary Administrative Subdivision": "Denali",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Dillingham": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Dillingham",
+            "Secondary Administrative Subdivision": "Dillingham",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks",
+            "Secondary Administrative Subdivision": "Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Fairbanks North Star": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks North Star",
+            "Secondary Administrative Subdivision": "Fairbanks North Star",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,First Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,First Judicial District",
+            "Secondary Administrative Subdivision": "First Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Fourth Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fourth Judicial District",
+            "Secondary Administrative Subdivision": "Fourth Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Haines": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Haines",
+            "Secondary Administrative Subdivision": "Haines",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Juneau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Juneau",
+            "Secondary Administrative Subdivision": "Juneau",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kenai Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai Peninsula",
+            "Secondary Administrative Subdivision": "Kenai Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kenai-Cook Inlet": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai-Cook Inlet",
+            "Secondary Administrative Subdivision": "Kenai-Cook Inlet",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan",
+            "Secondary Administrative Subdivision": "Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan Gateway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan Gateway",
+            "Secondary Administrative Subdivision": "Ketchikan Gateway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kobuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kobuk",
+            "Secondary Administrative Subdivision": "Kobuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kodiak Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kodiak Island",
+            "Secondary Administrative Subdivision": "Kodiak Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kuskokwim": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kuskokwim",
+            "Secondary Administrative Subdivision": "Kuskokwim",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kusilvak": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kusilvak",
+            "Secondary Administrative Subdivision": "Kusilvak",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Lake and Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lake and Peninsula",
+            "Secondary Administrative Subdivision": "Lake and Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Lynn Canal-Icy Straits": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lynn Canal-Icy Straits",
+            "Secondary Administrative Subdivision": "Lynn Canal-Icy Straits",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Matanuska-Susitna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Matanuska-Susitna",
+            "Secondary Administrative Subdivision": "Matanuska-Susitna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Nome": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Nome",
+            "Secondary Administrative Subdivision": "Nome",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,North Slope": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,North Slope",
+            "Secondary Administrative Subdivision": "North Slope",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Northwest Arctic": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Northwest Arctic",
+            "Secondary Administrative Subdivision": "Northwest Arctic",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Palmer-Wasilla-Talkeetna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Palmer-Wasilla-Talkeetna",
+            "Secondary Administrative Subdivision": "Palmer-Wasilla-Talkeetna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Petersburg",
+            "Secondary Administrative Subdivision": "Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Pribilof Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Pribilof Islands",
+            "Secondary Administrative Subdivision": "Pribilof Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Prince of Wales": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales",
+            "Secondary Administrative Subdivision": "Prince of Wales",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Prince of Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Hyder",
+            "Secondary Administrative Subdivision": "Prince of Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Prince of Wales-Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Prince of Wales-Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Saint Matthew Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Saint Matthew Island",
+            "Secondary Administrative Subdivision": "Saint Matthew Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Second Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Second Judicial District",
+            "Secondary Administrative Subdivision": "Second Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Seward": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Seward",
+            "Secondary Administrative Subdivision": "Seward",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Sitka": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Sitka",
+            "Secondary Administrative Subdivision": "Sitka",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway",
+            "Secondary Administrative Subdivision": "Skagway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Yakuta": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakuta",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway-Yakutat-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakutat-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Southeast Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Southeast Fairbanks",
+            "Secondary Administrative Subdivision": "Southeast Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Third Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Third Judicial District",
+            "Secondary Administrative Subdivision": "Third Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Upper Yukon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Upper Yukon",
+            "Secondary Administrative Subdivision": "Upper Yukon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Chitina-Whittier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Chitina-Whittier",
+            "Secondary Administrative Subdivision": "Valdez-Chitina-Whittier",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Cordova": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Cordova",
+            "Secondary Administrative Subdivision": "Valdez-Cordova",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Wade Hampton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wade Hampton",
+            "Secondary Administrative Subdivision": "Wade Hampton",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wales-Hyder",
+            "Secondary Administrative Subdivision": "Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell",
+            "Secondary Administrative Subdivision": "Wrangell",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell-Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell-Petersburg",
+            "Secondary Administrative Subdivision": "Wrangell-Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Yakutat": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yakutat",
+            "Secondary Administrative Subdivision": "Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Yukon-Koyukuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yukon-Koyukuk",
+            "Secondary Administrative Subdivision": "Yukon-Koyukuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          }
+        }
+      },
+      "Secondary_Administrative_Subdivision_Alt": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "DXCC Entity Code",
+          "Region",
+          "District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NZ_Regions:Northland/Far North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Far North",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Far North"
+          },
+          "NZ_Regions:Northland/Whangarei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Whangarei",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Whangarei"
+          },
+          "NZ_Regions:Northland/Kaipara": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Kaipara",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Kaipara"
+          },
+          "NZ_Regions:Auckland/Rodney": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Rodney",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Rodney"
+          },
+          "NZ_Regions:Auckland/North Shore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/North Shore",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "North Shore"
+          },
+          "NZ_Regions:Auckland/Waitakere": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Waitakere",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Waitakere"
+          },
+          "NZ_Regions:Auckland/Auckland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Auckland",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Auckland"
+          },
+          "NZ_Regions:Auckland/Manukau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Manukau",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Manukau"
+          },
+          "NZ_Regions:Auckland/Papakura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Papakura",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Papakura"
+          },
+          "NZ_Regions:Auckland/Franklin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Franklin",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Franklin"
+          },
+          "NZ_Regions:Waikato/Thames-Coromandel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Thames-Coromandel",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Thames-Coromandel"
+          },
+          "NZ_Regions:Waikato/Hauraki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hauraki",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hauraki"
+          },
+          "NZ_Regions:Waikato/Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waikato"
+          },
+          "NZ_Regions:Waikato/Matamata Piako": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Matamata Piako",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Matamata Piako"
+          },
+          "NZ_Regions:Waikato/Hamilton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hamilton",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hamilton"
+          },
+          "NZ_Regions:Waikato/Waipa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waipa",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waipa"
+          },
+          "NZ_Regions:Waikato/Otorohanga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Otorohanga",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Otorohanga"
+          },
+          "NZ_Regions:Waikato/South Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/South Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "South Waikato"
+          },
+          "NZ_Regions:Waikato/Waitomo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waitomo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waitomo"
+          },
+          "NZ_Regions:Waikato/Taupo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Taupo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Taupo"
+          },
+          "NZ_Regions:Bay of Plenty/Western Bay of Plenty": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Western Bay of Plenty",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Western Bay of Plenty"
+          },
+          "NZ_Regions:Bay of Plenty/Tauranga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Tauranga",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Tauranga"
+          },
+          "NZ_Regions:Bay of Plenty/Rotorua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Rotorua",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Rotorua"
+          },
+          "NZ_Regions:Bay of Plenty/Kawerau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Kawerau",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Kawerau"
+          },
+          "NZ_Regions:Bay of Plenty/Whakatane": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Whakatane",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Whakatane"
+          },
+          "NZ_Regions:Bay of Plenty/Opotiki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Opotiki",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Opotiki"
+          },
+          "NZ_Regions:Gisborne/Gisborne": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Gisborne/Gisborne",
+            "DXCC Entity Code": "170",
+            "Region": "Gisborne",
+            "District": "Gisborne"
+          },
+          "NZ_Regions:Hawkes Bay/Wairoa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Wairoa",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Wairoa"
+          },
+          "NZ_Regions:Hawkes Bay/Hastings": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Hastings",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Hastings"
+          },
+          "NZ_Regions:Hawkes Bay/Napier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Napier",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Napier"
+          },
+          "NZ_Regions:Hawkes Bay/Central Hawkes Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Central Hawkes Bay",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Central Hawkes Bay"
+          },
+          "NZ_Regions:Taranaki/New Plymouth": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/New Plymouth",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "New Plymouth"
+          },
+          "NZ_Regions:Taranaki/Stratford": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/Stratford",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "Stratford"
+          },
+          "NZ_Regions:Taranaki/South Taranaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/South Taranaki",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "South Taranaki"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Ruapehu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Ruapehu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Ruapehu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Wanganui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Wanganui",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Wanganui"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Rangitikei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Rangitikei",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Rangitikei"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Manawatu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Manawatu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Manawatu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Palmerston North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Palmerston North",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Palmerston North"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Horowhenua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Horowhenua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Horowhenua"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Tararua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Tararua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Tararua"
+          },
+          "NZ_Regions:Wellington/Masterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Masterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Masterton"
+          },
+          "NZ_Regions:Wellington/Carterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Carterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Carterton"
+          },
+          "NZ_Regions:Wellington/South Wairarapa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/South Wairarapa",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "South Wairarapa"
+          },
+          "NZ_Regions:Wellington/Kapiti Coast": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Kapiti Coast",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Kapiti Coast"
+          },
+          "NZ_Regions:Wellington/Porirua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Porirua",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Porirua"
+          },
+          "NZ_Regions:Wellington/Upper Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Upper Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Upper Hutt"
+          },
+          "NZ_Regions:Wellington/Lower Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Lower Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Lower Hutt"
+          },
+          "NZ_Regions:Wellington/Wellington": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Wellington",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Wellington"
+          },
+          "NZ_Regions:Nelson/Nelson": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Nelson/Nelson",
+            "DXCC Entity Code": "170",
+            "Region": "Nelson",
+            "District": "Nelson"
+          },
+          "NZ_Regions:Marlborough/Marlborough": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Marlborough/Marlborough",
+            "DXCC Entity Code": "170",
+            "Region": "Marlborough",
+            "District": "Marlborough"
+          },
+          "NZ_Regions:Tasman/Tasman": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Tasman/Tasman",
+            "DXCC Entity Code": "170",
+            "Region": "Tasman",
+            "District": "Tasman"
+          },
+          "NZ_Regions:West Coast/Buller": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Buller",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Buller"
+          },
+          "NZ_Regions:West Coast/Grey": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Grey",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Grey"
+          },
+          "NZ_Regions:West Coast/Westland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Westland",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Westland"
+          },
+          "NZ_Regions:Canterbury/Kaikoura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Kaikoura",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Kaikoura"
+          },
+          "NZ_Regions:Canterbury/Hurunui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Hurunui",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Hurunui"
+          },
+          "NZ_Regions:Canterbury/Selwyn": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Selwyn",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Selwyn"
+          },
+          "NZ_Regions:Canterbury/Waimakariri": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimakariri",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimakariri"
+          },
+          "NZ_Regions:Canterbury/Christchurch": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Christchurch",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Christchurch"
+          },
+          "NZ_Regions:Canterbury/Banks Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Banks Peninsula",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Banks Peninsula"
+          },
+          "NZ_Regions:Canterbury/Ashburton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Ashburton",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Ashburton"
+          },
+          "NZ_Regions:Canterbury/Mackenzie": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Mackenzie",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Mackenzie"
+          },
+          "NZ_Regions:Canterbury/Timaru": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Timaru",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Timaru"
+          },
+          "NZ_Regions:Canterbury/Waimate": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimate",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimate"
+          },
+          "NZ_Regions:Otago/Waitaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Waitaki",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Waitaki"
+          },
+          "NZ_Regions:Otago/Queenstown-Lakes": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Queenstown-Lakes",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Queenstown-Lakes"
+          },
+          "NZ_Regions:Otago/Central Otago": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Central Otago",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Central Otago"
+          },
+          "NZ_Regions:Otago/Dunedin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Dunedin",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Dunedin"
+          },
+          "NZ_Regions:Otago/Clutha": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Clutha",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Clutha"
+          },
+          "NZ_Regions:Southland/Gore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Gore",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Gore"
+          },
+          "NZ_Regions:Southland/Southland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Southland",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Southland"
+          },
+          "NZ_Regions:Southland/Invercargill": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Invercargill",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Invercargill"
+          }
+        }
+      },
+      "Submode": {
+        "Header": [
+          "Enumeration Name",
+          "Submode",
+          "Mode",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "8PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125",
+            "Mode": "PSK"
+          },
+          "8PSK125F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125F",
+            "Mode": "PSK"
+          },
+          "8PSK125FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125FL",
+            "Mode": "PSK"
+          },
+          "8PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250",
+            "Mode": "PSK"
+          },
+          "8PSK250F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250F",
+            "Mode": "PSK"
+          },
+          "8PSK250FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250FL",
+            "Mode": "PSK"
+          },
+          "8PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500",
+            "Mode": "PSK"
+          },
+          "8PSK500F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500F",
+            "Mode": "PSK"
+          },
+          "8PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000",
+            "Mode": "PSK"
+          },
+          "8PSK1000F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000F",
+            "Mode": "PSK"
+          },
+          "8PSK1200F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1200F",
+            "Mode": "PSK"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Submode",
+            "Submode": "AMTORFEC",
+            "Mode": "TOR"
+          },
+          "ASCI": {
+            "Enumeration Name": "Submode",
+            "Submode": "ASCI",
+            "Mode": "RTTY"
+          },
+          "C4FM": {
+            "Enumeration Name": "Submode",
+            "Submode": "C4FM",
+            "Mode": "DIGITALVOICE",
+            "Description": "C4FM 4-level FSK See the Propagation_Mode enumeration section for examples of representing C4FM voice transmissions."
+          },
+          "CHIP64": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP64",
+            "Mode": "CHIP"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP128",
+            "Mode": "CHIP"
+          },
+          "DMR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DMR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Mobile Radio See the Propagation_Mode enumeration section for examples of representing DMR voice transmissions."
+          },
+          "DOM-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM-M",
+            "Mode": "DOMINO"
+          },
+          "DOM4": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM4",
+            "Mode": "DOMINO"
+          },
+          "DOM5": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM5",
+            "Mode": "DOMINO"
+          },
+          "DOM8": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM8",
+            "Mode": "DOMINO"
+          },
+          "DOM11": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM11",
+            "Mode": "DOMINO"
+          },
+          "DOM16": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM16",
+            "Mode": "DOMINO"
+          },
+          "DOM22": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM22",
+            "Mode": "DOMINO"
+          },
+          "DOM44": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM44",
+            "Mode": "DOMINO"
+          },
+          "DOM88": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM88",
+            "Mode": "DOMINO"
+          },
+          "DOMINOEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOEX",
+            "Mode": "DOMINO"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOF",
+            "Mode": "DOMINO"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DSTAR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Smart Technologies for Amateur Radio See the Propagation_Mode enumeration section for examples of representing DSTAR voice transmissions."
+          },
+          "FMHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FMHELL",
+            "Mode": "HELL"
+          },
+          "FREEDATA": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDATA",
+            "Mode": "DYNAMIC",
+            "Description": "Data communications leveraging Codec2 HF modems"
+          },
+          "FREEDV": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDV",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital voice mode for HF radio implemented with open source"
+          },
+          "FSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSK31",
+            "Mode": "PSK"
+          },
+          "FSKH105": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH105",
+            "Mode": "HELL"
+          },
+          "FSKH245": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH245",
+            "Mode": "HELL"
+          },
+          "FSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKHELL",
+            "Mode": "HELL"
+          },
+          "FSQCALL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSQCALL",
+            "Mode": "MFSK",
+            "Description": "FSQCall protocol used with FSQ (Fast Simple QSO) transmission mode"
+          },
+          "FST4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software"
+          },
+          "FST4W": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4W",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software that is for quasi-beacon transmissions of WSPR-style messages"
+          },
+          "FT2": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT2",
+            "Mode": "MFSK"
+          },
+          "FT4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT4",
+            "Mode": "MFSK",
+            "Description": "FT4 is a digital mode designed specifically for radio contesting"
+          },
+          "GTOR": {
+            "Enumeration Name": "Submode",
+            "Submode": "GTOR",
+            "Mode": "TOR"
+          },
+          "HELL80": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELL80",
+            "Mode": "HELL"
+          },
+          "HELLX5": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX5",
+            "Mode": "HELL"
+          },
+          "HELLX9": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX9",
+            "Mode": "HELL"
+          },
+          "HFSK": {
+            "Enumeration Name": "Submode",
+            "Submode": "HFSK",
+            "Mode": "HELL"
+          },
+          "ISCAT-A": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-A",
+            "Mode": "ISCAT"
+          },
+          "ISCAT-B": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-B",
+            "Mode": "ISCAT"
+          },
+          "JS8": {
+            "Enumeration Name": "Submode",
+            "Submode": "JS8",
+            "Mode": "MFSK",
+            "Description": "Jordan Sherer designed 8-FSK modulation"
+          },
+          "JT4A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4A",
+            "Mode": "JT4"
+          },
+          "JT4B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4B",
+            "Mode": "JT4"
+          },
+          "JT4C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4C",
+            "Mode": "JT4"
+          },
+          "JT4D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4D",
+            "Mode": "JT4"
+          },
+          "JT4E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4E",
+            "Mode": "JT4"
+          },
+          "JT4F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4F",
+            "Mode": "JT4"
+          },
+          "JT4G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4G",
+            "Mode": "JT4"
+          },
+          "JT9-1": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-1",
+            "Mode": "JT9"
+          },
+          "JT9-2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-2",
+            "Mode": "JT9"
+          },
+          "JT9-5": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-5",
+            "Mode": "JT9"
+          },
+          "JT9-10": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-10",
+            "Mode": "JT9"
+          },
+          "JT9-30": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-30",
+            "Mode": "JT9"
+          },
+          "JT9A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9A",
+            "Mode": "JT9"
+          },
+          "JT9B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9B",
+            "Mode": "JT9"
+          },
+          "JT9C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9C",
+            "Mode": "JT9"
+          },
+          "JT9D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9D",
+            "Mode": "JT9"
+          },
+          "JT9E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E",
+            "Mode": "JT9"
+          },
+          "JT9E FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E FAST",
+            "Mode": "JT9"
+          },
+          "JT9F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F",
+            "Mode": "JT9"
+          },
+          "JT9F FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F FAST",
+            "Mode": "JT9"
+          },
+          "JT9G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G",
+            "Mode": "JT9"
+          },
+          "JT9G FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G FAST",
+            "Mode": "JT9"
+          },
+          "JT9H": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H",
+            "Mode": "JT9"
+          },
+          "JT9H FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H FAST",
+            "Mode": "JT9"
+          },
+          "JT65A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65A",
+            "Mode": "JT65"
+          },
+          "JT65B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B",
+            "Mode": "JT65"
+          },
+          "JT65B2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B2",
+            "Mode": "JT65"
+          },
+          "JT65C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C",
+            "Mode": "JT65"
+          },
+          "JT65C2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C2",
+            "Mode": "JT65"
+          },
+          "JTMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "JTMS",
+            "Mode": "MFSK"
+          },
+          "LSB": {
+            "Enumeration Name": "Submode",
+            "Submode": "LSB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, lower-sideband, suppressed-carrier"
+          },
+          "M17": {
+            "Enumeration Name": "Submode",
+            "Submode": "M17",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital radio protocol using the Codec 2 voice encoder"
+          },
+          "MFSK4": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK4",
+            "Mode": "MFSK"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK8",
+            "Mode": "MFSK"
+          },
+          "MFSK11": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK11",
+            "Mode": "MFSK"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK16",
+            "Mode": "MFSK"
+          },
+          "MFSK22": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK22",
+            "Mode": "MFSK"
+          },
+          "MFSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK31",
+            "Mode": "MFSK"
+          },
+          "MFSK32": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK32",
+            "Mode": "MFSK"
+          },
+          "MFSK64": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64",
+            "Mode": "MFSK"
+          },
+          "MFSK64L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64L",
+            "Mode": "MFSK"
+          },
+          "MFSK128": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128",
+            "Mode": "MFSK"
+          },
+          "MFSK128L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128L",
+            "Mode": "MFSK"
+          },
+          "NAVTEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "NAVTEX",
+            "Mode": "TOR"
+          },
+          "OLIVIA 4/125": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/125",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 4/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/1000",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 32/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 32/1000",
+            "Mode": "OLIVIA"
+          },
+          "OPERA-BEACON": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-BEACON",
+            "Mode": "OPERA"
+          },
+          "OPERA-QSO": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-QSO",
+            "Mode": "OPERA"
+          },
+          "PAC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC2",
+            "Mode": "PAC"
+          },
+          "PAC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC3",
+            "Mode": "PAC"
+          },
+          "PAC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC4",
+            "Mode": "PAC"
+          },
+          "PAX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAX2",
+            "Mode": "PAX"
+          },
+          "PCW": {
+            "Enumeration Name": "Submode",
+            "Submode": "PCW",
+            "Mode": "CW",
+            "Description": "Coherent CW"
+          },
+          "PSK10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK10",
+            "Mode": "PSK"
+          },
+          "PSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK31",
+            "Mode": "PSK"
+          },
+          "PSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63",
+            "Mode": "PSK"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63F",
+            "Mode": "PSK"
+          },
+          "PSK63RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC10",
+            "Mode": "PSK"
+          },
+          "PSK63RC20": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC20",
+            "Mode": "PSK"
+          },
+          "PSK63RC32": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC32",
+            "Mode": "PSK"
+          },
+          "PSK63RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC4",
+            "Mode": "PSK"
+          },
+          "PSK63RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC5",
+            "Mode": "PSK"
+          },
+          "PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125",
+            "Mode": "PSK"
+          },
+          "PSK125RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC10",
+            "Mode": "PSK"
+          },
+          "PSK125RC12": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC12",
+            "Mode": "PSK"
+          },
+          "PSK125RC16": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC16",
+            "Mode": "PSK"
+          },
+          "PSK125RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC4",
+            "Mode": "PSK"
+          },
+          "PSK125RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC5",
+            "Mode": "PSK"
+          },
+          "PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250",
+            "Mode": "PSK"
+          },
+          "PSK250RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC2",
+            "Mode": "PSK"
+          },
+          "PSK250RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC3",
+            "Mode": "PSK"
+          },
+          "PSK250RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC5",
+            "Mode": "PSK"
+          },
+          "PSK250RC6": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC6",
+            "Mode": "PSK"
+          },
+          "PSK250RC7": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC7",
+            "Mode": "PSK"
+          },
+          "PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500",
+            "Mode": "PSK"
+          },
+          "PSK500RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC2",
+            "Mode": "PSK"
+          },
+          "PSK500RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC3",
+            "Mode": "PSK"
+          },
+          "PSK500RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC4",
+            "Mode": "PSK"
+          },
+          "PSK800RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK800RC2",
+            "Mode": "PSK"
+          },
+          "PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000",
+            "Mode": "PSK"
+          },
+          "PSK1000RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000RC2",
+            "Mode": "PSK"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM10",
+            "Mode": "PSK"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM31",
+            "Mode": "PSK"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM50",
+            "Mode": "PSK"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKFEC31",
+            "Mode": "PSK"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKHELL",
+            "Mode": "HELL"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK31",
+            "Mode": "PSK"
+          },
+          "Q65": {
+            "Enumeration Name": "Submode",
+            "Submode": "Q65",
+            "Mode": "MFSK"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK63",
+            "Mode": "PSK"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK125",
+            "Mode": "PSK"
+          },
+          "QPSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK250",
+            "Mode": "PSK"
+          },
+          "QPSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK500",
+            "Mode": "PSK"
+          },
+          "QRA64A": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64A",
+            "Mode": "QRA64"
+          },
+          "QRA64B": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64B",
+            "Mode": "QRA64"
+          },
+          "QRA64C": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64C",
+            "Mode": "QRA64"
+          },
+          "QRA64D": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64D",
+            "Mode": "QRA64"
+          },
+          "QRA64E": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64E",
+            "Mode": "QRA64"
+          },
+          "RIBBIT_PIX": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_PIX",
+            "Mode": "OFDM",
+            "Description": "Images transmitted using Ribbit"
+          },
+          "RIBBIT_SMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_SMS",
+            "Mode": "OFDM",
+            "Description": "Short text messages transmitted using Ribbit"
+          },
+          "ROS-EME": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-EME",
+            "Mode": "ROS"
+          },
+          "ROS-HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-HF",
+            "Mode": "ROS"
+          },
+          "ROS-MF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-MF",
+            "Mode": "ROS"
+          },
+          "SCAMP_FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_FAST",
+            "Mode": "FSK",
+            "Description": "SCAMP fast FSK"
+          },
+          "SCAMP_OO": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off keying"
+          },
+          "SCAMP_OO_SLW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO_SLW",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off slow keying"
+          },
+          "SCAMP_SLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_SLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP slow FSK"
+          },
+          "SCAMP_VSLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_VSLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP very slow FSK"
+          },
+          "SIM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "SIM31",
+            "Mode": "PSK"
+          },
+          "SITORB": {
+            "Enumeration Name": "Submode",
+            "Submode": "SITORB",
+            "Mode": "TOR"
+          },
+          "SLOWHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "SLOWHELL",
+            "Mode": "HELL"
+          },
+          "THOR-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR-M",
+            "Mode": "THOR"
+          },
+          "THOR4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR4",
+            "Mode": "THOR"
+          },
+          "THOR5": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR5",
+            "Mode": "THOR"
+          },
+          "THOR8": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR8",
+            "Mode": "THOR"
+          },
+          "THOR11": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR11",
+            "Mode": "THOR"
+          },
+          "THOR16": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR16",
+            "Mode": "THOR"
+          },
+          "THOR22": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR22",
+            "Mode": "THOR"
+          },
+          "THOR25X4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR25X4",
+            "Mode": "THOR"
+          },
+          "THOR50X1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X1",
+            "Mode": "THOR"
+          },
+          "THOR50X2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X2",
+            "Mode": "THOR"
+          },
+          "THOR100": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR100",
+            "Mode": "THOR"
+          },
+          "THRBX": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX",
+            "Mode": "THRB"
+          },
+          "THRBX1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX1",
+            "Mode": "THRB"
+          },
+          "THRBX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX2",
+            "Mode": "THRB"
+          },
+          "THRBX4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX4",
+            "Mode": "THRB"
+          },
+          "THROB1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB1",
+            "Mode": "THRB"
+          },
+          "THROB2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB2",
+            "Mode": "THRB"
+          },
+          "THROB4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB4",
+            "Mode": "THRB"
+          },
+          "USB": {
+            "Enumeration Name": "Submode",
+            "Submode": "USB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, upper-sideband, suppressed-carrier"
+          },
+          "VARA HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA HF",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for HF"
+          },
+          "VARA SATELLITE": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA SATELLITE",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for satellite operations"
+          },
+          "VARA FM 1200": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 1200",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          },
+          "VARA FM 9600": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 9600",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          }
+        }
+      }
+    },
+    "Fields": {
+      "Header": [
+        "Field Name",
+        "Data Type",
+        "Enumeration",
+        "Description",
+        "Header Field",
+        "Minimum Value",
+        "Maximum Value",
+        "Import-only",
+        "Comments"
+      ],
+      "Records": {
+        "ADIF_VER": {
+          "Field Name": "ADIF_VER",
+          "Data Type": "String",
+          "Description": "Identifies the version of ADIF used in this file in the format X.Y.Z where ● X is an integer designating the ADIF epoch. ● Y is an integer between 0 and 9 designating the major version. ● Z is an integer between 0 and 9 designating the minor version.",
+          "Header Field": "true"
+        },
+        "CREATED_TIMESTAMP": {
+          "Field Name": "CREATED_TIMESTAMP",
+          "Data Type": "String",
+          "Description": "Identifies the UTC date and time that the file was created in the format of 15 characters YYYYMMDD HHMMSS where YYYYMMDD is a Date data type. HHMMSS is a 6 character Time data type.",
+          "Header Field": "true"
+        },
+        "PROGRAMID": {
+          "Field Name": "PROGRAMID",
+          "Data Type": "String",
+          "Description": "Identifies the name of the logger, converter, or utility that created or processed this ADIF content. To help avoid name clashes, the ADIF PROGRAMID Register provides a voluntary list of PROGRAMID values.",
+          "Header Field": "true"
+        },
+        "PROGRAMVERSION": {
+          "Field Name": "PROGRAMVERSION",
+          "Data Type": "String",
+          "Description": "Identifies the version of the logger, converter, or utility that created or processed this ADIF file.",
+          "Header Field": "true"
+        },
+        "USERDEFn": {
+          "Field Name": "USERDEFn",
+          "Data Type": "String",
+          "Description": "Specifies the name and optional enumeration or range of the nth user-defined field, where n is a positive integer. The name of a user-defined field may not ● be an ADIF Field name. ● contain ○ a comma. ○ a colon. ○ an open-angle-bracket or close-angle-bracket character. ○ an open-curly-bracket or close-curly-bracket character. ● begin or end with a space character.",
+          "Header Field": "true"
+        },
+        "ADDRESS": {
+          "Field Name": "ADDRESS",
+          "Data Type": "MultilineString",
+          "Description": "the contacted station\u0027s complete mailing address: full name, street address, city, postal code, and country"
+        },
+        "ADDRESS_INTL": {
+          "Field Name": "ADDRESS_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "the contacted station\u0027s complete mailing address: full name, street address, city, postal code, and country"
+        },
+        "AGE": {
+          "Field Name": "AGE",
+          "Data Type": "Number",
+          "Description": "the contacted station\u0027s operator\u0027s age in years in the range 0 to 120 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "120"
+        },
+        "ALTITUDE": {
+          "Field Name": "ALTITUDE",
+          "Data Type": "Number",
+          "Description": "the height of the contacted station in meters relative to Mean Sea Level (MSL). For example 1.5 km is \u003CALTITUDE:4\u003E1500 and 10.5 m is \u003CALTITUDE:4\u003E10.5"
+        },
+        "ANT_AZ": {
+          "Field Name": "ANT_AZ",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s antenna azimuth, in degrees with a value between 0 to 360 (inclusive). Values outside this range are import-only and must be normalized for export (e.g. 370 is exported as 10). True north is 0 degrees with values increasing in a clockwise direction.",
+          "Minimum Value": "0",
+          "Maximum Value": "360"
+        },
+        "ANT_EL": {
+          "Field Name": "ANT_EL",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s antenna elevation, in degrees with a value between -90 to 90 (inclusive). Values outside this range are import-only and must be normalized for export (e.g. 100 is exported as 80). The horizon is 0 degrees with values increasing as the angle moves in an upward direction.",
+          "Minimum Value": "-90",
+          "Maximum Value": "90"
+        },
+        "ANT_PATH": {
+          "Field Name": "ANT_PATH",
+          "Data Type": "Enumeration",
+          "Enumeration": "Ant_Path",
+          "Description": "the signal path"
+        },
+        "ARRL_SECT": {
+          "Field Name": "ARRL_SECT",
+          "Data Type": "Enumeration",
+          "Enumeration": "ARRL_Section",
+          "Description": "the contacted station\u0027s ARRL section"
+        },
+        "AWARD_SUBMITTED": {
+          "Field Name": "AWARD_SUBMITTED",
+          "Data Type": "SponsoredAwardList",
+          "Enumeration": "Sponsored_Award",
+          "Description": "the list of awards submitted to a sponsor. note that this field might not be used in a QSO record. It might be used to convey information about a user\u0027s \u0022Award Account\u0022 between an award sponsor and the user. For example, AA6YQ might submit a request for awards by sending the following: \u003CCALL:5\u003EAA6YQ \u003CAWARD_SUBMITTED:64\u003EADIF_CENTURY_BASIC,ADIF_CENTURY_SILVER,ADIF_SPECTRUM_100-160m"
+        },
+        "AWARD_GRANTED": {
+          "Field Name": "AWARD_GRANTED",
+          "Data Type": "SponsoredAwardList",
+          "Enumeration": "Sponsored_Award",
+          "Description": "the list of awards granted by a sponsor. note that this field might not be used in a QSO record. It might be used to convey information about a user\u0027s \u0022Award Account\u0022 between an award sponsor and the user. For example, in response to a request \u0022send me a list of the awards granted to AA6YQ\u0022, this might be received: \u003CCALL:5\u003EAA6YQ \u003CAWARD_GRANTED:64\u003EADIF_CENTURY_BASIC,ADIF_CENTURY_SILVER,ADIF_SPECTRUM_100-160m"
+        },
+        "A_INDEX": {
+          "Field Name": "A_INDEX",
+          "Data Type": "Number",
+          "Description": "the geomagnetic A index at the time of the QSO in the range 0 to 400 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "400"
+        },
+        "BAND": {
+          "Field Name": "BAND",
+          "Data Type": "Enumeration",
+          "Enumeration": "Band",
+          "Description": "QSO Band"
+        },
+        "BAND_RX": {
+          "Field Name": "BAND_RX",
+          "Data Type": "Enumeration",
+          "Enumeration": "Band",
+          "Description": "in a split frequency QSO, the logging station\u0027s receiving band"
+        },
+        "CALL": {
+          "Field Name": "CALL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s callsign"
+        },
+        "CHECK": {
+          "Field Name": "CHECK",
+          "Data Type": "String",
+          "Description": "contest check (e.g. for ARRL Sweepstakes)"
+        },
+        "CLASS": {
+          "Field Name": "CLASS",
+          "Data Type": "String",
+          "Description": "contest class (e.g. for ARRL Field Day)"
+        },
+        "CLUBLOG_QSO_UPLOAD_DATE": {
+          "Field Name": "CLUBLOG_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the Club Log online service"
+        },
+        "CLUBLOG_QSO_UPLOAD_STATUS": {
+          "Field Name": "CLUBLOG_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the Club Log online service"
+        },
+        "CNTY": {
+          "Field Name": "CNTY",
+          "Data Type": "Enumeration",
+          "Enumeration": "Secondary_Administrative_Subdivision[DXCC]",
+          "Description": "the contacted station\u0027s Secondary Administrative Subdivision (e.g. US county, JA Gun), in the specified format"
+        },
+        "CNTY_ALT": {
+          "Field Name": "CNTY_ALT",
+          "Data Type": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of Secondary Administrative Subdivision Alt codes for the contacted station See the Data Type for details."
+        },
+        "COMMENT": {
+          "Field Name": "COMMENT",
+          "Data Type": "String",
+          "Description": "comment field for QSO for a message to be incorporated in a paper or electronic QSL for the contacted station\u0027s operator, use the QSLMSG field recommended use: information of interest to the contacted station\u0027s operator"
+        },
+        "COMMENT_INTL": {
+          "Field Name": "COMMENT_INTL",
+          "Data Type": "IntlString",
+          "Description": "comment field for QSO for a message to be incorporated in a paper or electronic QSL for the contacted station\u0027s operator, use the QSLMSG_INTL field recommended use: information of interest to the contacted station\u0027s operator"
+        },
+        "CONT": {
+          "Field Name": "CONT",
+          "Data Type": "Enumeration",
+          "Enumeration": "Continent",
+          "Description": "the contacted station\u0027s Continent"
+        },
+        "CONTACTED_OP": {
+          "Field Name": "CONTACTED_OP",
+          "Data Type": "String",
+          "Description": "the callsign of the individual operating the contacted station"
+        },
+        "CONTEST_ID": {
+          "Field Name": "CONTEST_ID",
+          "Data Type": "String",
+          "Enumeration": "Contest_ID",
+          "Description": "QSO Contest Identifier use enumeration values for interoperability"
+        },
+        "COUNTRY": {
+          "Field Name": "COUNTRY",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s DXCC entity name"
+        },
+        "COUNTRY_INTL": {
+          "Field Name": "COUNTRY_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s DXCC entity name"
+        },
+        "CQZ": {
+          "Field Name": "CQZ",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s CQ Zone in the range 1 to 40 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "40"
+        },
+        "CREDIT_SUBMITTED": {
+          "Field Name": "CREDIT_SUBMITTED",
+          "Data Type": "CreditList,AwardList",
+          "Enumeration": "Credit,Award",
+          "Description": "the list of credits sought for this QSO Use of data type AwardList and enumeration Award are import-only"
+        },
+        "CREDIT_GRANTED": {
+          "Field Name": "CREDIT_GRANTED",
+          "Data Type": "CreditList,AwardList",
+          "Enumeration": "Credit,Award",
+          "Description": "the list of credits granted to this QSO Use of data type AwardList and enumeration Award are import-only"
+        },
+        "DARC_DOK": {
+          "Field Name": "DARC_DOK",
+          "Data Type": "Enumeration",
+          "Description": "the contacted station\u0027s DARC DOK (District Location Code) A DOK comprises letters and numbers, e.g. \u003CDARC_DOK:3\u003EA01 Note that DARC provides two different lists - one for DOKs and one for Special DOKs."
+        },
+        "DCL_QSLRDATE": {
+          "Field Name": "DCL_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from DCL (only valid if DCL_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "DCL_QSLSDATE": {
+          "Field Name": "DCL_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to DCL (only valid if DCL_QSL_SENT is Y, Q, or I)"
+        },
+        "DCL_QSL_RCVD": {
+          "Field Name": "DCL_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "DCL QSL received status Default Value: N"
+        },
+        "DCL_QSL_SENT": {
+          "Field Name": "DCL_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "DCL QSL sent status Default Value: N"
+        },
+        "DISTANCE": {
+          "Field Name": "DISTANCE",
+          "Data Type": "Number",
+          "Description": "the distance between the logging station and the contacted station in kilometers via the specified signal path with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "DXCC": {
+          "Field Name": "DXCC",
+          "Data Type": "Enumeration",
+          "Enumeration": "DXCC_Entity_Code",
+          "Description": "the contacted station\u0027s DXCC Entity Code \u003CDXCC:1\u003E0 means that the contacted station is known not to be within a DXCC entity."
+        },
+        "EMAIL": {
+          "Field Name": "EMAIL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s email address"
+        },
+        "EQ_CALL": {
+          "Field Name": "EQ_CALL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s owner\u0027s callsign"
+        },
+        "EQSL_AG": {
+          "Field Name": "EQSL_AG",
+          "Data Type": "Enumeration",
+          "Enumeration": "EQSL_AG",
+          "Description": "indicates whether the QSO is known to be \u0022Authenticity Guaranteed\u0022 by eQSL Default value: U"
+        },
+        "EQSL_QSLRDATE": {
+          "Field Name": "EQSL_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from eQSL.cc (only valid if EQSL_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "EQSL_QSLSDATE": {
+          "Field Name": "EQSL_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to eQSL.cc (only valid if EQSL_QSL_SENT is Y, Q, or I)"
+        },
+        "EQSL_QSL_RCVD": {
+          "Field Name": "EQSL_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "eQSL.cc QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:42\u003ECQWAZ:eqsl,CQWAZ_BAND:eqsl,CQWAZ_MODE:eqsl Default Value: N"
+        },
+        "EQSL_QSL_SENT": {
+          "Field Name": "EQSL_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "eQSL.cc QSL sent status Default Value: N"
+        },
+        "FISTS": {
+          "Field Name": "FISTS",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s FISTS CW Club member number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "FISTS_CC": {
+          "Field Name": "FISTS_CC",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s FISTS CW Club Century Certificate (CC) number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "FORCE_INIT": {
+          "Field Name": "FORCE_INIT",
+          "Data Type": "Boolean",
+          "Description": "new EME \u0022initial\u0022"
+        },
+        "FREQ": {
+          "Field Name": "FREQ",
+          "Data Type": "Number",
+          "Description": "QSO frequency in Megahertz"
+        },
+        "FREQ_RX": {
+          "Field Name": "FREQ_RX",
+          "Data Type": "Number",
+          "Description": "in a split frequency QSO, the logging station\u0027s receiving frequency in Megahertz"
+        },
+        "GRIDSQUARE": {
+          "Field Name": "GRIDSQUARE",
+          "Data Type": "GridSquare",
+          "Description": "the contacted station\u0027s 2-character, 4-character, 6-character, or 8-character Maidenhead Grid Square For 10 or 12 character locators, store the first 8 characters in GRIDSQUARE and the additional 2 or 4 characters in the GRIDSQUARE_EXT field"
+        },
+        "GRIDSQUARE_EXT": {
+          "Field Name": "GRIDSQUARE_EXT",
+          "Data Type": "GridSquareExt",
+          "Description": "for a contacted station\u0027s 10-character Maidenhead locator, supplements the GRIDSQUARE field by containing characters 9 and 10. For a contacted station\u0027s 12-character Maidenhead locator, supplements the GRIDSQUARE field by containing characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0 to 9. On export, the field length must be 2 or 4. On import, if the field length is greater than 4, the additional characters must be ignored. Example of exporting the 10-character locator FN01MH42BQ: \u003CGRIDSQUARE:8\u003EFN01MH42 \u003CGRIDSQUARE_EXT:2\u003EBQ"
+        },
+        "GUEST_OP": {
+          "Field Name": "GUEST_OP",
+          "Data Type": "String",
+          "Description": "import-only: use OPERATOR instead",
+          "Import-only": "true"
+        },
+        "HAMLOGEU_QSO_UPLOAD_DATE": {
+          "Field Name": "HAMLOGEU_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HAMLOG.EU online service"
+        },
+        "HAMLOGEU_QSO_UPLOAD_STATUS": {
+          "Field Name": "HAMLOGEU_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HAMLOG.EU online service"
+        },
+        "HAMQTH_QSO_UPLOAD_DATE": {
+          "Field Name": "HAMQTH_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HamQTH.com online service"
+        },
+        "HAMQTH_QSO_UPLOAD_STATUS": {
+          "Field Name": "HAMQTH_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HamQTH.com online service"
+        },
+        "HRDLOG_QSO_UPLOAD_DATE": {
+          "Field Name": "HRDLOG_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HRDLog.net online service"
+        },
+        "HRDLOG_QSO_UPLOAD_STATUS": {
+          "Field Name": "HRDLOG_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HRDLog.net online service"
+        },
+        "IOTA": {
+          "Field Name": "IOTA",
+          "Data Type": "IOTARefNo",
+          "Description": "the contacted station\u0027s IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "IOTA_ISLAND_ID": {
+          "Field Name": "IOTA_ISLAND_ID",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s IOTA Island Identifier, an 8-digit integer in the range 1 to 99999999 [leading zeroes optional]",
+          "Minimum Value": "1",
+          "Maximum Value": "99999999"
+        },
+        "ITUZ": {
+          "Field Name": "ITUZ",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s ITU zone in the range 1 to 90 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "90"
+        },
+        "K_INDEX": {
+          "Field Name": "K_INDEX",
+          "Data Type": "Integer",
+          "Description": "the geomagnetic K index at the time of the QSO in the range 0 to 9 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "9"
+        },
+        "LAT": {
+          "Field Name": "LAT",
+          "Data Type": "Location",
+          "Description": "the contacted station\u0027s latitude"
+        },
+        "LON": {
+          "Field Name": "LON",
+          "Data Type": "Location",
+          "Description": "the contacted station\u0027s longitude"
+        },
+        "LOTW_QSLRDATE": {
+          "Field Name": "LOTW_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from ARRL Logbook of the World (only valid if LOTW_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "LOTW_QSLSDATE": {
+          "Field Name": "LOTW_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to ARRL Logbook of the World (only valid if LOTW_QSL_SENT is Y, Q, or I)"
+        },
+        "LOTW_QSL_RCVD": {
+          "Field Name": "LOTW_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "ARRL Logbook of the World QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:39\u003EDXCC:lotw,DXCC_BAND:lotw,DXCC_MODE:lotw Default Value: N"
+        },
+        "LOTW_QSL_SENT": {
+          "Field Name": "LOTW_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "ARRL Logbook of the World QSL sent status Default Value: N"
+        },
+        "MAX_BURSTS": {
+          "Field Name": "MAX_BURSTS",
+          "Data Type": "Number",
+          "Description": "maximum length of meteor scatter bursts heard by the logging station, in seconds with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "MODE": {
+          "Field Name": "MODE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Mode",
+          "Description": "QSO Mode"
+        },
+        "MORSE_KEY_INFO": {
+          "Field Name": "MORSE_KEY_INFO",
+          "Data Type": "String",
+          "Description": "details of the contacted station\u0027s Morse key (e.g. make, model, etc). Example: \u003CMORSE_KEY_INFO:16\u003EBegali Sculpture"
+        },
+        "MORSE_KEY_TYPE": {
+          "Field Name": "MORSE_KEY_TYPE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Morse_Key_Type",
+          "Description": "the contacted station\u0027s Morse key type (e.g. straight key, bug, etc). Example for a dual-lever paddle: \u003CMORSE_KEY_TYPE:2\u003EDP"
+        },
+        "MS_SHOWER": {
+          "Field Name": "MS_SHOWER",
+          "Data Type": "String",
+          "Description": "For Meteor Scatter QSOs, the name of the meteor shower in progress"
+        },
+        "MY_ALTITUDE": {
+          "Field Name": "MY_ALTITUDE",
+          "Data Type": "Number",
+          "Description": "the height of the logging station in meters relative to Mean Sea Level (MSL). For example 1.5 km is \u003CMY_ALTITUDE:4\u003E1500 and 10.5 m is \u003CMY_ALTITUDE:4\u003E10.5"
+        },
+        "MY_ANTENNA": {
+          "Field Name": "MY_ANTENNA",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s antenna"
+        },
+        "MY_ANTENNA_INTL": {
+          "Field Name": "MY_ANTENNA_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s antenna"
+        },
+        "MY_ARRL_SECT": {
+          "Field Name": "MY_ARRL_SECT",
+          "Data Type": "Enumeration",
+          "Enumeration": "ARRL_Section",
+          "Description": "the logging station\u0027s ARRL section"
+        },
+        "MY_CITY": {
+          "Field Name": "MY_CITY",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s city"
+        },
+        "MY_CITY_INTL": {
+          "Field Name": "MY_CITY_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s city"
+        },
+        "MY_CNTY": {
+          "Field Name": "MY_CNTY",
+          "Data Type": "Enumeration",
+          "Enumeration": "Secondary_Administrative_Subdivision[MY_DXCC]",
+          "Description": "the logging station\u0027s Secondary Administrative Subdivision (e.g. US county, JA Gun), in the specified format"
+        },
+        "MY_CNTY_ALT": {
+          "Field Name": "MY_CNTY_ALT",
+          "Data Type": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of Secondary Administrative Subdivision Alt codes for the logging station See the Data Type for details."
+        },
+        "MY_COUNTRY": {
+          "Field Name": "MY_COUNTRY",
+          "Data Type": "String",
+          "Enumeration": "Country",
+          "Description": "the logging station\u0027s DXCC entity name"
+        },
+        "MY_COUNTRY_INTL": {
+          "Field Name": "MY_COUNTRY_INTL",
+          "Data Type": "IntlString",
+          "Enumeration": "Country",
+          "Description": "the logging station\u0027s DXCC entity name"
+        },
+        "MY_CQ_ZONE": {
+          "Field Name": "MY_CQ_ZONE",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s CQ Zone in the range 1 to 40 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "40"
+        },
+        "MY_DARC_DOK": {
+          "Field Name": "MY_DARC_DOK",
+          "Data Type": "Enumeration",
+          "Description": "the logging station\u0027s DARC DOK (District Location Code) A DOK comprises letters and numbers, e.g. \u003CMY_DARC_DOK:3\u003EA01 Note that DARC provides two different lists - one for DOKs and one for Special DOKs."
+        },
+        "MY_DXCC": {
+          "Field Name": "MY_DXCC",
+          "Data Type": "Enumeration",
+          "Enumeration": "DXCC_Entity_Code",
+          "Description": "the logging station\u0027s DXCC Entity Code \u003CMY_DXCC:1\u003E0 means that the logging station is known not to be within a DXCC entity."
+        },
+        "MY_FISTS": {
+          "Field Name": "MY_FISTS",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s FISTS CW Club member number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "MY_GRIDSQUARE": {
+          "Field Name": "MY_GRIDSQUARE",
+          "Data Type": "GridSquare",
+          "Description": "the logging station\u0027s 2-character, 4-character, 6-character, or 8-character Maidenhead Grid Square For 10 or 12 character locators, store the first 8 characters in MY_GRIDSQUARE and the additional 2 or 4 characters in the MY_GRIDSQUARE_EXT field"
+        },
+        "MY_GRIDSQUARE_EXT": {
+          "Field Name": "MY_GRIDSQUARE_EXT",
+          "Data Type": "GridSquareExt",
+          "Description": "for a logging station\u0027s 10-character Maidenhead locator, supplements the MY_GRIDSQUARE field by containing characters 9 and 10. For a logging station\u0027s 12-character Maidenhead locator, supplements the MY_GRIDSQUARE field by containing characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0 to 9. On export, the field length must be 2 or 4. On import, if the field length is greater than 4, the additional characters must be ignored. Example of exporting the 10-character locator FN01MH42BQ: \u003CMY_GRIDSQUARE:8\u003EFN01MH42 \u003CMY_GRIDSQUARE_EXT:2\u003EBQ"
+        },
+        "MY_IOTA": {
+          "Field Name": "MY_IOTA",
+          "Data Type": "IOTARefNo",
+          "Description": "the logging station\u0027s IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "MY_IOTA_ISLAND_ID": {
+          "Field Name": "MY_IOTA_ISLAND_ID",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s IOTA Island Identifier, an 8-digit integer in the range 1 to 99999999 [leading zeroes optional]",
+          "Minimum Value": "1",
+          "Maximum Value": "99999999"
+        },
+        "MY_ITU_ZONE": {
+          "Field Name": "MY_ITU_ZONE",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s ITU zone in the range 1 to 90 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "90"
+        },
+        "MY_LAT": {
+          "Field Name": "MY_LAT",
+          "Data Type": "Location",
+          "Description": "the logging station\u0027s latitude"
+        },
+        "MY_LON": {
+          "Field Name": "MY_LON",
+          "Data Type": "Location",
+          "Description": "the logging station\u0027s longitude"
+        },
+        "MY_MORSE_KEY_INFO": {
+          "Field Name": "MY_MORSE_KEY_INFO",
+          "Data Type": "String",
+          "Description": "details of the logging station\u0027s Morse key (e.g. make, model, etc). Example: \u003CMY_MORSE_KEY_INFO:16\u003EBegali Sculpture"
+        },
+        "MY_MORSE_KEY_TYPE": {
+          "Field Name": "MY_MORSE_KEY_TYPE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Morse_Key_Type",
+          "Description": "the logging station\u0027s Morse key type (e.g. straight key, bug, etc). Example for a dual-lever paddle: \u003CMORSE_KEY_TYPE:2\u003EDP"
+        },
+        "MY_NAME": {
+          "Field Name": "MY_NAME",
+          "Data Type": "String",
+          "Description": "the logging operator\u0027s name"
+        },
+        "MY_NAME_INTL": {
+          "Field Name": "MY_NAME_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging operator\u0027s name"
+        },
+        "MY_POSTAL_CODE": {
+          "Field Name": "MY_POSTAL_CODE",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s postal code"
+        },
+        "MY_POSTAL_CODE_INTL": {
+          "Field Name": "MY_POSTAL_CODE_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s postal code"
+        },
+        "MY_POTA_REF": {
+          "Field Name": "MY_POTA_REF",
+          "Data Type": "POTARefList",
+          "Description": "a comma-delimited list of one or more of the logging station\u0027s POTA (Parks on the Air) reference(s). Examples: \u003CMY_POTA_REF:6\u003EK-0059 \u003CMY_POTA_REF:7\u003EK-10000 \u003CMY_POTA_REF:40\u003EK-0817,K-4566,K-4576,K-4573,K-4578@US-WY"
+        },
+        "MY_RIG": {
+          "Field Name": "MY_RIG",
+          "Data Type": "String",
+          "Description": "description of the logging station\u0027s equipment"
+        },
+        "MY_RIG_INTL": {
+          "Field Name": "MY_RIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "description of the logging station\u0027s equipment"
+        },
+        "MY_SIG": {
+          "Field Name": "MY_SIG",
+          "Data Type": "String",
+          "Description": "special interest activity or event"
+        },
+        "MY_SIG_INTL": {
+          "Field Name": "MY_SIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "special interest activity or event"
+        },
+        "MY_SIG_INFO": {
+          "Field Name": "MY_SIG_INFO",
+          "Data Type": "String",
+          "Description": "special interest activity or event information"
+        },
+        "MY_SIG_INFO_INTL": {
+          "Field Name": "MY_SIG_INFO_INTL",
+          "Data Type": "IntlString",
+          "Description": "special interest activity or event information"
+        },
+        "MY_SOTA_REF": {
+          "Field Name": "MY_SOTA_REF",
+          "Data Type": "SOTARef",
+          "Description": "the logging station\u0027s International SOTA Reference."
+        },
+        "MY_STATE": {
+          "Field Name": "MY_STATE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Primary_Administrative_Subdivision[MY_DXCC]",
+          "Description": "the code for the logging station\u0027s Primary Administrative Subdivision (e.g. US State, JA Island, VE Province)"
+        },
+        "MY_STREET": {
+          "Field Name": "MY_STREET",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s street"
+        },
+        "MY_STREET_INTL": {
+          "Field Name": "MY_STREET_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s street"
+        },
+        "MY_USACA_COUNTIES": {
+          "Field Name": "MY_USACA_COUNTIES",
+          "Data Type": "SecondarySubdivisionList",
+          "Description": "two US counties in the case where the logging station is located on a border between two counties, representing counties that the contacted station may claim for the CQ Magazine USA-CA award program. E.g. MA,Franklin:MA,Hampshire"
+        },
+        "MY_VUCC_GRIDS": {
+          "Field Name": "MY_VUCC_GRIDS",
+          "Data Type": "GridSquareList",
+          "Description": "two or four adjacent Maidenhead grid locators, each four or six characters long, representing the logging station\u0027s grid squares that the contacted station may claim for the ARRL VUCC award program. E.g. EM98,FM08,EM97,FM07"
+        },
+        "MY_WWFF_REF": {
+          "Field Name": "MY_WWFF_REF",
+          "Data Type": "WWFFRef",
+          "Description": "the logging station\u0027s WWFF (World Wildlife Flora \u0026 Fauna) reference"
+        },
+        "NAME": {
+          "Field Name": "NAME",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s operator\u0027s name"
+        },
+        "NAME_INTL": {
+          "Field Name": "NAME_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s operator\u0027s name"
+        },
+        "NOTES": {
+          "Field Name": "NOTES",
+          "Data Type": "MultilineString",
+          "Description": "QSO notes recommended use: information of interest to the logging station\u0027s operator"
+        },
+        "NOTES_INTL": {
+          "Field Name": "NOTES_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "QSO notes recommended use: information of interest to the logging station\u0027s operator"
+        },
+        "NR_BURSTS": {
+          "Field Name": "NR_BURSTS",
+          "Data Type": "Integer",
+          "Description": "the number of meteor scatter bursts heard by the logging station with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "NR_PINGS": {
+          "Field Name": "NR_PINGS",
+          "Data Type": "Integer",
+          "Description": "the number of meteor scatter pings heard by the logging station with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "OPERATOR": {
+          "Field Name": "OPERATOR",
+          "Data Type": "String",
+          "Description": "the logging operator\u0027s callsign if STATION_CALLSIGN is absent, OPERATOR shall be treated as both the logging station\u0027s callsign and the logging operator\u0027s callsign"
+        },
+        "OWNER_CALLSIGN": {
+          "Field Name": "OWNER_CALLSIGN",
+          "Data Type": "String",
+          "Description": "the callsign of the owner of the station used to log the contact (the callsign of the OPERATOR\u0027s host) if OWNER_CALLSIGN is absent, STATION_CALLSIGN shall be treated as both the logging station\u0027s callsign and the callsign of the owner of the station"
+        },
+        "PFX": {
+          "Field Name": "PFX",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s WPX prefix"
+        },
+        "POTA_REF": {
+          "Field Name": "POTA_REF",
+          "Data Type": "POTARefList",
+          "Description": "a comma-delimited list of one or more of the contacted station\u0027s POTA (Parks on the Air) reference(s). Examples: \u003CPOTA_REF:6\u003EK-5033 \u003CPOTA_REF:13\u003EVE-5082@CA-AB \u003CPOTA_REF:40\u003EK-0817,K-4566,K-4576,K-4573,K-4578@US-WY"
+        },
+        "PRECEDENCE": {
+          "Field Name": "PRECEDENCE",
+          "Data Type": "String",
+          "Description": "contest precedence (e.g. for ARRL Sweepstakes)"
+        },
+        "PROP_MODE": {
+          "Field Name": "PROP_MODE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Propagation_Mode",
+          "Description": "QSO propagation mode"
+        },
+        "PUBLIC_KEY": {
+          "Field Name": "PUBLIC_KEY",
+          "Data Type": "String",
+          "Description": "public encryption key"
+        },
+        "QRZCOM_QSO_DOWNLOAD_DATE": {
+          "Field Name": "QRZCOM_QSO_DOWNLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "date QSO downloaded from QRZ.COM logbook"
+        },
+        "QRZCOM_QSO_DOWNLOAD_STATUS": {
+          "Field Name": "QRZCOM_QSO_DOWNLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Download_Status",
+          "Description": "QRZ.COM logbook QSO download status"
+        },
+        "QRZCOM_QSO_UPLOAD_DATE": {
+          "Field Name": "QRZCOM_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the QRZ.COM online service"
+        },
+        "QRZCOM_QSO_UPLOAD_STATUS": {
+          "Field Name": "QRZCOM_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the QRZ.COM online service"
+        },
+        "QSLMSG": {
+          "Field Name": "QSLMSG",
+          "Data Type": "MultilineString",
+          "Description": "a message for the contacted station\u0027s operator to be incorporated in a paper or electronic QSL"
+        },
+        "QSLMSG_INTL": {
+          "Field Name": "QSLMSG_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "a message for the contacted station\u0027s operator to be incorporated in a paper or electronic QSL"
+        },
+        "QSLMSG_RCVD": {
+          "Field Name": "QSLMSG_RCVD",
+          "Data Type": "MultilineString",
+          "Description": "a message addressed to the logging station\u0027s operator incorporated in a paper or electronic QSL"
+        },
+        "QSLRDATE": {
+          "Field Name": "QSLRDATE",
+          "Data Type": "Date",
+          "Description": "QSL received date (only valid if QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "QSLSDATE": {
+          "Field Name": "QSLSDATE",
+          "Data Type": "Date",
+          "Description": "QSL sent date (only valid if QSL_SENT is Y, Q, or I)"
+        },
+        "QSL_RCVD": {
+          "Field Name": "QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:39\u003EDXCC:card,DXCC_BAND:card,DXCC_MODE:card Default Value: N"
+        },
+        "QSL_RCVD_VIA": {
+          "Field Name": "QSL_RCVD_VIA",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Via",
+          "Description": "if QSL_RCVD is set to \u0027Y\u0027 or \u0027V\u0027, the means by which the QSL was received by the logging station; otherwise, the means by which the logging station requested or intends to request that the QSL be conveyed. (Note: \u0027V\u0027 is import-only) use of M (manager) is import-only"
+        },
+        "QSL_SENT": {
+          "Field Name": "QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "QSL sent status Default Value: N"
+        },
+        "QSL_SENT_VIA": {
+          "Field Name": "QSL_SENT_VIA",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Via",
+          "Description": "if QSL_SENT is set to \u0027Y\u0027, the means by which the QSL was sent by the logging station; otherwise, the means by which the logging station intends to convey the QSL use of M (manager) is import-only"
+        },
+        "QSL_VIA": {
+          "Field Name": "QSL_VIA",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s QSL route"
+        },
+        "QSO_COMPLETE": {
+          "Field Name": "QSO_COMPLETE",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Complete",
+          "Description": "indicates whether the QSO was complete from the perspective of the logging station Y - yes N - no NIL - not heard ? - uncertain"
+        },
+        "QSO_DATE": {
+          "Field Name": "QSO_DATE",
+          "Data Type": "Date",
+          "Description": "date on which the QSO started"
+        },
+        "QSO_DATE_OFF": {
+          "Field Name": "QSO_DATE_OFF",
+          "Data Type": "Date",
+          "Description": "date on which the QSO ended"
+        },
+        "QSO_RANDOM": {
+          "Field Name": "QSO_RANDOM",
+          "Data Type": "Boolean",
+          "Description": "indicates whether the QSO was random or scheduled"
+        },
+        "QTH": {
+          "Field Name": "QTH",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s city"
+        },
+        "QTH_INTL": {
+          "Field Name": "QTH_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s city"
+        },
+        "REGION": {
+          "Field Name": "REGION",
+          "Data Type": "Enumeration",
+          "Enumeration": "Region",
+          "Description": "the contacted station\u0027s WAE or CQ entity contained within a DXCC entity. the value None indicates that the WAE or CQ entity is the DXCC entity in the DXCC field. nothing can be inferred from the absence of the REGION field"
+        },
+        "RIG": {
+          "Field Name": "RIG",
+          "Data Type": "MultilineString",
+          "Description": "description of the contacted station\u0027s equipment"
+        },
+        "RIG_INTL": {
+          "Field Name": "RIG_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "description of the contacted station\u0027s equipment"
+        },
+        "RST_RCVD": {
+          "Field Name": "RST_RCVD",
+          "Data Type": "String",
+          "Description": "signal report from the contacted station"
+        },
+        "RST_SENT": {
+          "Field Name": "RST_SENT",
+          "Data Type": "String",
+          "Description": "signal report sent to the contacted station"
+        },
+        "RX_PWR": {
+          "Field Name": "RX_PWR",
+          "Data Type": "Number",
+          "Description": "the contacted station\u0027s transmitter power in Watts with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "SAT_MODE": {
+          "Field Name": "SAT_MODE",
+          "Data Type": "String",
+          "Description": "satellite mode - a code representing the satellite\u0027s uplink band and downlink band"
+        },
+        "SAT_NAME": {
+          "Field Name": "SAT_NAME",
+          "Data Type": "String",
+          "Description": "name of satellite"
+        },
+        "SFI": {
+          "Field Name": "SFI",
+          "Data Type": "Integer",
+          "Description": "the solar flux at the time of the QSO in the range 0 to 300 (inclusive).",
+          "Minimum Value": "0",
+          "Maximum Value": "300"
+        },
+        "SIG": {
+          "Field Name": "SIG",
+          "Data Type": "String",
+          "Description": "the name of the contacted station\u0027s special activity or interest group"
+        },
+        "SIG_INTL": {
+          "Field Name": "SIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "the name of the contacted station\u0027s special activity or interest group"
+        },
+        "SIG_INFO": {
+          "Field Name": "SIG_INFO",
+          "Data Type": "String",
+          "Description": "information associated with the contacted station\u0027s activity or interest group"
+        },
+        "SIG_INFO_INTL": {
+          "Field Name": "SIG_INFO_INTL",
+          "Data Type": "IntlString",
+          "Description": "information associated with the contacted station\u0027s activity or interest group"
+        },
+        "SILENT_KEY": {
+          "Field Name": "SILENT_KEY",
+          "Data Type": "Boolean",
+          "Description": "\u0027Y\u0027 indicates that the contacted station\u0027s operator is now a Silent Key."
+        },
+        "SKCC": {
+          "Field Name": "SKCC",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s Straight Key Century Club (SKCC) member information"
+        },
+        "SOTA_REF": {
+          "Field Name": "SOTA_REF",
+          "Data Type": "SOTARef",
+          "Description": "the contacted station\u0027s International SOTA Reference."
+        },
+        "SRX": {
+          "Field Name": "SRX",
+          "Data Type": "Integer",
+          "Description": "contest QSO received serial number with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "SRX_STRING": {
+          "Field Name": "SRX_STRING",
+          "Data Type": "String",
+          "Description": "contest QSO received information use Cabrillo format to convey contest information for which ADIF fields are not specified in the event of a conflict between information in a dedicated contest field and this field, information in the dedicated contest field shall prevail"
+        },
+        "STATE": {
+          "Field Name": "STATE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Primary_Administrative_Subdivision[DXCC]",
+          "Description": "the code for the contacted station\u0027s Primary Administrative Subdivision (e.g. US State, JA Island, VE Province)"
+        },
+        "STATION_CALLSIGN": {
+          "Field Name": "STATION_CALLSIGN",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s callsign (the callsign used over the air) if STATION_CALLSIGN is absent, OPERATOR shall be treated as both the logging station\u0027s callsign and the logging operator\u0027s callsign"
+        },
+        "STX": {
+          "Field Name": "STX",
+          "Data Type": "Integer",
+          "Description": "contest QSO transmitted serial number with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "STX_STRING": {
+          "Field Name": "STX_STRING",
+          "Data Type": "String",
+          "Description": "contest QSO transmitted information use Cabrillo format to convey contest information for which ADIF fields are not specified in the event of a conflict between information in a dedicated contest field and this field, information in the dedicated contest field shall prevail"
+        },
+        "SUBMODE": {
+          "Field Name": "SUBMODE",
+          "Data Type": "String",
+          "Enumeration": "Submode[MODE]",
+          "Description": "QSO Submode use enumeration values for interoperability"
+        },
+        "SWL": {
+          "Field Name": "SWL",
+          "Data Type": "Boolean",
+          "Description": "indicates that the QSO information pertains to an SWL report"
+        },
+        "TEN_TEN": {
+          "Field Name": "TEN_TEN",
+          "Data Type": "PositiveInteger",
+          "Description": "Ten-Ten number with a value greater than 0",
+          "Minimum Value": "1"
+        },
+        "TIME_OFF": {
+          "Field Name": "TIME_OFF",
+          "Data Type": "Time",
+          "Description": "HHMM or HHMMSS in UTC in the absence of \u003CQSO_DATE_OFF\u003E, the QSO duration is less than 24 hours. For example, the following is a QSO starting at 14 July 2020 23:55 and finishing at 15 July 2020 01:00: \u003CQSO_DATE:8\u003E20200714 \u003CTIME_ON:4\u003E2355 \u003CTIME_OFF:4\u003E0100"
+        },
+        "TIME_ON": {
+          "Field Name": "TIME_ON",
+          "Data Type": "Time",
+          "Description": "HHMM or HHMMSS in UTC"
+        },
+        "TX_PWR": {
+          "Field Name": "TX_PWR",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s power in Watts with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "UKSMG": {
+          "Field Name": "UKSMG",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s UKSMG member number with a value greater than 0",
+          "Minimum Value": "1"
+        },
+        "USACA_COUNTIES": {
+          "Field Name": "USACA_COUNTIES",
+          "Data Type": "SecondarySubdivisionList",
+          "Description": "two US counties in the case where the contacted station is located on a border between two counties, representing counties credited to the QSO for the CQ Magazine USA-CA award program. E.g. MA,Franklin:MA,Hampshire"
+        },
+        "VE_PROV": {
+          "Field Name": "VE_PROV",
+          "Data Type": "String",
+          "Description": "import-only: use STATE instead",
+          "Import-only": "true"
+        },
+        "VUCC_GRIDS": {
+          "Field Name": "VUCC_GRIDS",
+          "Data Type": "GridSquareList",
+          "Description": "two or four adjacent Maidenhead grid locators, each four or six characters long, representing the contacted station\u0027s grid squares credited to the QSO for the ARRL VUCC award program. E.g. EM98,FM08,EM97,FM07"
+        },
+        "WEB": {
+          "Field Name": "WEB",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s URL"
+        },
+        "WWFF_REF": {
+          "Field Name": "WWFF_REF",
+          "Data Type": "WWFFRef",
+          "Description": "the contacted station\u0027s WWFF (World Wildlife Flora \u0026 Fauna) reference"
+        }
+      }
+    }
+  }
+}

--- a/src/adif_mcp/resources/spec/317/datatypes.json
+++ b/src/adif_mcp/resources/spec/317/datatypes.json
@@ -1,0 +1,147 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:32Z",
+    "DataTypes": {
+      "Header": [
+        "Data Type Name",
+        "Data Type Indicator",
+        "Description",
+        "Minimum Value",
+        "Maximum Value",
+        "Import-only",
+        "Comments"
+      ],
+      "Records": {
+        "AwardList": {
+          "Data Type Name": "AwardList",
+          "Description": "a comma-delimited list of members of the Award enumeration",
+          "Import-only": "true"
+        },
+        "CreditList": {
+          "Data Type Name": "CreditList",
+          "Description": "a comma-delimited list where each list item is either: A member of the Credit enumeration. A member of the Credit enumeration followed by a colon and an ampersand-delimited list of members of the QSL_Medium enumeration. For example IOTA,WAS:LOTW\u0026CARD,DXCC:CARD"
+        },
+        "SponsoredAwardList": {
+          "Data Type Name": "SponsoredAwardList",
+          "Description": "a comma-delimited list of members of the Sponsored_Award enumeration"
+        },
+        "Boolean": {
+          "Data Type Name": "Boolean",
+          "Data Type Indicator": "B",
+          "Description": "if True, the single ASCII character Y or y if False, the single ASCII character N or n"
+        },
+        "Digit": {
+          "Data Type Name": "Digit",
+          "Description": "an ASCII character whose code lies in the range of 48 through 57, inclusive"
+        },
+        "Integer": {
+          "Data Type Name": "Integer",
+          "Description": "a sequence of one or more Digits representing a decimal integer, optionally preceded by a minus sign (ASCII code 45). Leading zeroes are allowed."
+        },
+        "Number": {
+          "Data Type Name": "Number",
+          "Data Type Indicator": "N",
+          "Description": "a sequence of one or more Digits representing a decimal number, optionally preceded by a minus sign (ASCII code 45) and optionally including a single decimal point (ASCII code 46)"
+        },
+        "PositiveInteger": {
+          "Data Type Name": "PositiveInteger",
+          "Description": "an unsigned sequence of one or more Digits representing a decimal integer that has a value greater than 0. Leading zeroes are allowed.",
+          "Minimum Value": "1"
+        },
+        "Character": {
+          "Data Type Name": "Character",
+          "Description": "an ASCII character whose code lies in the range of 32 through 126, inclusive"
+        },
+        "IntlCharacter": {
+          "Data Type Name": "IntlCharacter",
+          "Description": "a Unicode character (encoded with UTF-8) excluding line break CR (code 13) and LF (code 10) characters"
+        },
+        "Date": {
+          "Data Type Name": "Date",
+          "Data Type Indicator": "D",
+          "Description": "8 Digits representing a UTC date in YYYYMMDD format, where YYYY is a 4-Digit year specifier, where 1930 \u003C= YYYY MM is a 2-Digit month specifier, where 1 \u003C= MM \u003C= 12 [use leading zeroes] DD is a 2-Digit day specifier, where 1 \u003C= DD \u003C= DaysInMonth(MM) [use leading zeroes]"
+        },
+        "Time": {
+          "Data Type Name": "Time",
+          "Data Type Indicator": "T",
+          "Description": "6 Digits representing a UTC time in HHMMSS format or 4 Digits representing a time in HHMM format, where HH is a 2-Digit hour specifier, where 0 \u003C= HH \u003C= 23 [use leading zeroes] MM is a 2-Digit minute specifier, where 0 \u003C= MM \u003C= 59 [use leading zeroes] SS is a 2-Digit second specifier, where 0 \u003C= SS \u003C= 59 [use leading zeroes]"
+        },
+        "IOTARefNo": {
+          "Data Type Name": "IOTARefNo",
+          "Description": "IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "String": {
+          "Data Type Name": "String",
+          "Data Type Indicator": "S",
+          "Description": "a sequence of Characters"
+        },
+        "IntlString": {
+          "Data Type Name": "IntlString",
+          "Data Type Indicator": "I",
+          "Description": "a sequence of International Characters. Fields of type IntlString must only be used in ADX files"
+        },
+        "MultilineString": {
+          "Data Type Name": "MultilineString",
+          "Data Type Indicator": "M",
+          "Description": "a sequence of Characters and line-breaks, where a line break is an ASCII CR (code 13) followed immediately by an ASCII LF (code 10)"
+        },
+        "IntlMultilineString": {
+          "Data Type Name": "IntlMultilineString",
+          "Data Type Indicator": "G",
+          "Description": "a sequence of International Characters and line breaks. Fields of type IntlMultilineString must only be used in ADX files"
+        },
+        "Enumeration": {
+          "Data Type Name": "Enumeration",
+          "Data Type Indicator": "E",
+          "Description": "an explicit list of legal case-insensitive values represented in ASCII set forth in set notation, e.g. {A, B, C, D}, or defined in a table, from which a single value may be selected."
+        },
+        "GridSquare": {
+          "Data Type Name": "GridSquare",
+          "Description": "a case-insensitive 2-character, 4-character, 6-character, or 8-character Maidenhead locator. Specific fields impose additional restrictions on the number of characters; see the field descriptions for the allowed numbers of characters."
+        },
+        "GridSquareExt": {
+          "Data Type Name": "GridSquareExt",
+          "Description": "For a 10-character Maidenhead locator, contains characters 9 and 10. For a 12-character Maidenhead locator, contains characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0-9."
+        },
+        "GridSquareList": {
+          "Data Type Name": "GridSquareList",
+          "Description": "a comma-delimited list of GridSquare items"
+        },
+        "Location": {
+          "Data Type Name": "Location",
+          "Data Type Indicator": "L",
+          "Description": "a sequence of 11 characters representing a latitude or longitude in XDDD MM.MMM format, where X is a directional Character from the set {E, W, N, S} DDD is a 3-Digit degrees specifier, where 0 \u003C= DDD \u003C= 180 [use leading zeroes] There is a single space character in between DDD and MM.MMM MM.MMM is an unsigned Number minutes specifier with its decimal point in the third position, where 00.000 \u003C= MM.MMM \u003C= 59.999 [use leading and trailing zeroes]"
+        },
+        "POTARef": {
+          "Data Type Name": "POTARef",
+          "Description": "a sequence of case-insensitive Characters representing a Parks on the Air park reference in the form xxxx-nnnnn[@yyyyyy] comprising 6 to 17 characters where: xxxx is the POTA national program and is 1 to 4 characters in length, typically the default callsign prefix of the national program (rather than the DX entity) nnnnn represents the unique number within the national program and is either 4 or 5 characters in length (use the exact format listed on the POTA website) yyyyyy **Optional** is the 4 to 6 character ISO 3166-2 code to differentiate which state/province/prefecture/primary administration location the contact represents, in the case that the park reference spans more than one location (such as a trail). Examples of the POTARef Data Type: ReferenceLocation K-5033Golden Hill State Forest K-10000 5-digit park numbers are reserved for future use VE-5082@CA-ABThe Great Trail of Canada (the Canadian Trailway) National Scenic Trail, within Alberta, Canada 8P-0012Chancery Lane Swamp National Park VK-0556Pieman River State Reserve K-4562@US-CAPacific Crest Trail, within California, USA Additional Notes on POTARef: A browsable and searchable list of all park references is available. A complete CSV file is available (generated nightly). For more information, visit the Parks on the Air documentation website."
+        },
+        "POTARefList": {
+          "Data Type Name": "POTARefList",
+          "Description": "a comma-delimited list of one or more POTARef items."
+        },
+        "SecondarySubdivisionList": {
+          "Data Type Name": "SecondarySubdivisionList",
+          "Description": "a colon-delimited list of two or more members of the Secondary_Administrative_Subdivision enumeration. E.g.: MA,Franklin:MA,Hampshire"
+        },
+        "SecondaryAdministrativeSubdivisionListAlt": {
+          "Data Type Name": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of one or more members of a Secondary_Administrative_Subdivision_Alt enumeration in the form: enumeration-name:enumeration-code Where there is more than one locality represented by the enumeration-code, they are separated by slash (/) characters. Only one of each enumeration-name valid for the DXCC entity concerned can appear in the list. Examples: \u003CCNTY_ALT:28\u003ENZ_Regions:Hawkes Bay/Wairoa \u003CMY_CNTY_ALT:52\u003ENZ_Islands:North Island;NZ_Regions:Hawkes Bay/Wairoa The first example shows the enumeration-name NZ_Regions with the region Hawkes Bay and the district Wairoa. For the purposes of illustration, the second example includes a non-existent subdivision with two available enumeration-codes, NZ_Islands:North Island and NZ_Islands:South Island. The example shows: the enumeration-name NZ_Islands with the island North Island the enumeration-name NZ_Regions with the region Hawkes Bay and the district Wairoa"
+        },
+        "SOTARef": {
+          "Data Type Name": "SOTARef",
+          "Description": "a sequence of Characters representing an International SOTA Reference. The sequence comprises: an ITU prefix if applicable, a SOTA subdivision a / Character a SOTA Reference Number Examples: W2/WE-003 G/LD-003"
+        },
+        "WWFFRef": {
+          "Data Type Name": "WWFFRef",
+          "Description": "a sequence of case-insensitive Characters representing an International WWFF (World Wildlife Flora \u0026 Fauna) reference in the form xxFF-nnnn comprising 8 to 11 characters where: xx is the WWFF national program and is 1 to 4 characters in length. FF- is two F characters followed by a dash character. nnnn represents the unique number within the national program and is 4 characters in length with leading zeros. Examples: KFF-4655 3DAFF-0002"
+        }
+      }
+    },
+    "Enumerations": null,
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations.json
+++ b/src/adif_mcp/resources/spec/317/enumerations.json
@@ -1,0 +1,21358 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:32Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Ant_Path": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "G": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "G",
+            "Meaning": "grayline"
+          },
+          "O": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "O",
+            "Meaning": "other"
+          },
+          "S": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "S",
+            "Meaning": "short path"
+          },
+          "L": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "L",
+            "Meaning": "long path"
+          }
+        }
+      },
+      "ARRL_Section": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Section Name",
+          "DXCC Entity Code",
+          "From Date",
+          "Deleted Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AL",
+            "Section Name": "Alabama",
+            "DXCC Entity Code": "291"
+          },
+          "AK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AK",
+            "Section Name": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AB",
+            "Section Name": "Alberta",
+            "DXCC Entity Code": "1"
+          },
+          "AR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AR",
+            "Section Name": "Arkansas",
+            "DXCC Entity Code": "291"
+          },
+          "AZ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AZ",
+            "Section Name": "Arizona",
+            "DXCC Entity Code": "291"
+          },
+          "BC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "BC",
+            "Section Name": "British Columbia",
+            "DXCC Entity Code": "1"
+          },
+          "CO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CO",
+            "Section Name": "Colorado",
+            "DXCC Entity Code": "291"
+          },
+          "CT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CT",
+            "Section Name": "Connecticut",
+            "DXCC Entity Code": "291"
+          },
+          "DE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "DE",
+            "Section Name": "Delaware",
+            "DXCC Entity Code": "291"
+          },
+          "EB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EB",
+            "Section Name": "East Bay",
+            "DXCC Entity Code": "291"
+          },
+          "EMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EMA",
+            "Section Name": "Eastern Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "ENY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ENY",
+            "Section Name": "Eastern New York",
+            "DXCC Entity Code": "291"
+          },
+          "EPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EPA",
+            "Section Name": "Eastern Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "EWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EWA",
+            "Section Name": "Eastern Washington",
+            "DXCC Entity Code": "291"
+          },
+          "GA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GA",
+            "Section Name": "Georgia",
+            "DXCC Entity Code": "291"
+          },
+          "GH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GH",
+            "Section Name": "Golden Horseshoe",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "GTA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GTA",
+            "Section Name": "Greater Toronto Area",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by GH"
+          },
+          "ID": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ID",
+            "Section Name": "Idaho",
+            "DXCC Entity Code": "291"
+          },
+          "IL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IL",
+            "Section Name": "Illinois",
+            "DXCC Entity Code": "291"
+          },
+          "IN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IN",
+            "Section Name": "Indiana",
+            "DXCC Entity Code": "291"
+          },
+          "IA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IA",
+            "Section Name": "Iowa",
+            "DXCC Entity Code": "291"
+          },
+          "KS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KS",
+            "Section Name": "Kansas",
+            "DXCC Entity Code": "291"
+          },
+          "KY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KY",
+            "Section Name": "Kentucky",
+            "DXCC Entity Code": "291"
+          },
+          "LAX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LAX",
+            "Section Name": "Los Angeles",
+            "DXCC Entity Code": "291"
+          },
+          "LA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LA",
+            "Section Name": "Louisiana",
+            "DXCC Entity Code": "291"
+          },
+          "ME": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ME",
+            "Section Name": "Maine",
+            "DXCC Entity Code": "291"
+          },
+          "MB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MB",
+            "Section Name": "Manitoba",
+            "DXCC Entity Code": "1"
+          },
+          "MAR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MAR",
+            "Section Name": "Maritime",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by NB and NS"
+          },
+          "MDC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MDC",
+            "Section Name": "Maryland-DC",
+            "DXCC Entity Code": "291"
+          },
+          "MI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MI",
+            "Section Name": "Michigan",
+            "DXCC Entity Code": "291"
+          },
+          "MN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MN",
+            "Section Name": "Minnesota",
+            "DXCC Entity Code": "291"
+          },
+          "MS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MS",
+            "Section Name": "Mississippi",
+            "DXCC Entity Code": "291"
+          },
+          "MO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MO",
+            "Section Name": "Missouri",
+            "DXCC Entity Code": "291"
+          },
+          "MT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MT",
+            "Section Name": "Montana",
+            "DXCC Entity Code": "291"
+          },
+          "NE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NE",
+            "Section Name": "Nebraska",
+            "DXCC Entity Code": "291"
+          },
+          "NV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NV",
+            "Section Name": "Nevada",
+            "DXCC Entity Code": "291"
+          },
+          "NB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NB",
+            "Section Name": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "NH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NH",
+            "Section Name": "New Hampshire",
+            "DXCC Entity Code": "291"
+          },
+          "NM": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NM",
+            "Section Name": "New Mexico",
+            "DXCC Entity Code": "291"
+          },
+          "NLI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NLI",
+            "Section Name": "New York City-Long Island",
+            "DXCC Entity Code": "291"
+          },
+          "NL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NL",
+            "Section Name": "Newfoundland/Labrador",
+            "DXCC Entity Code": "1"
+          },
+          "NC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NC",
+            "Section Name": "North Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "ND": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ND",
+            "Section Name": "North Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "NTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NTX",
+            "Section Name": "North Texas",
+            "DXCC Entity Code": "291"
+          },
+          "NFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NFL",
+            "Section Name": "Northern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "NNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNJ",
+            "Section Name": "Northern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "NNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNY",
+            "Section Name": "Northern New York",
+            "DXCC Entity Code": "291"
+          },
+          "NT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "From Date": "2003-11-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by TER"
+          },
+          "NWT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NWT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2003-11-01T00:00:00Z",
+            "Comments": "replaced by NT"
+          },
+          "NS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NS",
+            "Section Name": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "OH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OH",
+            "Section Name": "Ohio",
+            "DXCC Entity Code": "291"
+          },
+          "OK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OK",
+            "Section Name": "Oklahoma",
+            "DXCC Entity Code": "291"
+          },
+          "ON": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ON",
+            "Section Name": "Ontario",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2012-09-01T00:00:00Z",
+            "Comments": "replaced by GTA, ONE, ONN, and ONS"
+          },
+          "ONE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONE",
+            "Section Name": "Ontario East",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONN",
+            "Section Name": "Ontario North",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONS",
+            "Section Name": "Ontario South",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ORG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ORG",
+            "Section Name": "Orange",
+            "DXCC Entity Code": "291"
+          },
+          "OR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OR",
+            "Section Name": "Oregon",
+            "DXCC Entity Code": "291"
+          },
+          "PAC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PAC",
+            "Section Name": "Pacific",
+            "DXCC Entity Code": "9,20,103,110,123,138,166,174,197,297,515"
+          },
+          "PE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PE",
+            "Section Name": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "From Date": "2020-04-01T00:00:00Z"
+          },
+          "PR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PR",
+            "Section Name": "Puerto Rico",
+            "DXCC Entity Code": "43,202"
+          },
+          "QC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "QC",
+            "Section Name": "Quebec",
+            "DXCC Entity Code": "1"
+          },
+          "RI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "RI",
+            "Section Name": "Rhode Island",
+            "DXCC Entity Code": "291"
+          },
+          "SV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SV",
+            "Section Name": "Sacramento Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SDG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SDG",
+            "Section Name": "San Diego",
+            "DXCC Entity Code": "291"
+          },
+          "SF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SF",
+            "Section Name": "San Francisco",
+            "DXCC Entity Code": "291"
+          },
+          "SJV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SJV",
+            "Section Name": "San Joaquin Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SB",
+            "Section Name": "Santa Barbara",
+            "DXCC Entity Code": "291"
+          },
+          "SCV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SCV",
+            "Section Name": "Santa Clara Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SK",
+            "Section Name": "Saskatchewan",
+            "DXCC Entity Code": "1"
+          },
+          "SC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SC",
+            "Section Name": "South Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "SD": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SD",
+            "Section Name": "South Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "STX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "STX",
+            "Section Name": "South Texas",
+            "DXCC Entity Code": "291"
+          },
+          "SFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SFL",
+            "Section Name": "Southern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "SNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SNJ",
+            "Section Name": "Southern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "TN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TN",
+            "Section Name": "Tennessee",
+            "DXCC Entity Code": "291"
+          },
+          "TER": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TER",
+            "Section Name": "Territories",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "VI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VI",
+            "Section Name": "US Virgin Islands",
+            "DXCC Entity Code": "105,182,285"
+          },
+          "UT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "UT",
+            "Section Name": "Utah",
+            "DXCC Entity Code": "291"
+          },
+          "VT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VT",
+            "Section Name": "Vermont",
+            "DXCC Entity Code": "291"
+          },
+          "VA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VA",
+            "Section Name": "Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WCF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WCF",
+            "Section Name": "West Central Florida",
+            "DXCC Entity Code": "291"
+          },
+          "WTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WTX",
+            "Section Name": "West Texas",
+            "DXCC Entity Code": "291"
+          },
+          "WV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WV",
+            "Section Name": "West Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WMA",
+            "Section Name": "Western Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "WNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WNY",
+            "Section Name": "Western New York",
+            "DXCC Entity Code": "291"
+          },
+          "WPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WPA",
+            "Section Name": "Western Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "WWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WWA",
+            "Section Name": "Western Washington",
+            "DXCC Entity Code": "291"
+          },
+          "WI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WI",
+            "Section Name": "Wisconsin",
+            "DXCC Entity Code": "291"
+          },
+          "WY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WY",
+            "Section Name": "Wyoming",
+            "DXCC Entity Code": "291"
+          }
+        }
+      },
+      "Award": {
+        "Header": [
+          "Enumeration Name",
+          "Award",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AJA": {
+            "Enumeration Name": "Award",
+            "Award": "AJA",
+            "Import-only": "true"
+          },
+          "CQDX": {
+            "Enumeration Name": "Award",
+            "Award": "CQDX",
+            "Import-only": "true"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Award",
+            "Award": "CQDXFIELD",
+            "Import-only": "true"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_MIXED",
+            "Import-only": "true"
+          },
+          "CQWAZ_CW": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_CW",
+            "Import-only": "true"
+          },
+          "CQWAZ_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_PHONE",
+            "Import-only": "true"
+          },
+          "CQWAZ_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_RTTY",
+            "Import-only": "true"
+          },
+          "CQWAZ_160m": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_160m",
+            "Import-only": "true"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Award",
+            "Award": "CQWPX",
+            "Import-only": "true"
+          },
+          "DARC_DOK": {
+            "Enumeration Name": "Award",
+            "Award": "DARC_DOK",
+            "Import-only": "true"
+          },
+          "DXCC": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC",
+            "Import-only": "true"
+          },
+          "DXCC_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_MIXED",
+            "Import-only": "true"
+          },
+          "DXCC_CW": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_CW",
+            "Import-only": "true"
+          },
+          "DXCC_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_PHONE",
+            "Import-only": "true"
+          },
+          "DXCC_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_RTTY",
+            "Import-only": "true"
+          },
+          "IOTA": {
+            "Enumeration Name": "Award",
+            "Award": "IOTA",
+            "Import-only": "true"
+          },
+          "JCC": {
+            "Enumeration Name": "Award",
+            "Award": "JCC",
+            "Import-only": "true"
+          },
+          "JCG": {
+            "Enumeration Name": "Award",
+            "Award": "JCG",
+            "Import-only": "true"
+          },
+          "MARATHON": {
+            "Enumeration Name": "Award",
+            "Award": "MARATHON",
+            "Import-only": "true"
+          },
+          "RDA": {
+            "Enumeration Name": "Award",
+            "Award": "RDA",
+            "Import-only": "true"
+          },
+          "WAB": {
+            "Enumeration Name": "Award",
+            "Award": "WAB",
+            "Import-only": "true"
+          },
+          "WAC": {
+            "Enumeration Name": "Award",
+            "Award": "WAC",
+            "Import-only": "true"
+          },
+          "WAE": {
+            "Enumeration Name": "Award",
+            "Award": "WAE",
+            "Import-only": "true"
+          },
+          "WAIP": {
+            "Enumeration Name": "Award",
+            "Award": "WAIP",
+            "Import-only": "true"
+          },
+          "WAJA": {
+            "Enumeration Name": "Award",
+            "Award": "WAJA",
+            "Import-only": "true"
+          },
+          "WAS": {
+            "Enumeration Name": "Award",
+            "Award": "WAS",
+            "Import-only": "true"
+          },
+          "WAZ": {
+            "Enumeration Name": "Award",
+            "Award": "WAZ",
+            "Import-only": "true"
+          },
+          "USACA": {
+            "Enumeration Name": "Award",
+            "Award": "USACA",
+            "Import-only": "true"
+          },
+          "VUCC": {
+            "Enumeration Name": "Award",
+            "Award": "VUCC",
+            "Import-only": "true"
+          }
+        }
+      },
+      "Award_Sponsor": {
+        "Header": [
+          "Enumeration Name",
+          "Sponsor",
+          "Sponsoring Organization",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "ADIF_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ADIF_",
+            "Sponsoring Organization": "ADIF Development Group"
+          },
+          "ARI_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARI_",
+            "Sponsoring Organization": "ARI - l\u0027Associazione Radioamatori Italiani"
+          },
+          "ARRL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARRL_",
+            "Sponsoring Organization": "ARRL - American Radio Relay League"
+          },
+          "CQ_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "CQ_",
+            "Sponsoring Organization": "CQ Magazine"
+          },
+          "DARC_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "DARC_",
+            "Sponsoring Organization": "DARC - Deutscher Amateur-Radio-Club e.V."
+          },
+          "EQSL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "EQSL_",
+            "Sponsoring Organization": "eQSL"
+          },
+          "IARU_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "IARU_",
+            "Sponsoring Organization": "IARU - International Amateur Radio Union"
+          },
+          "JARL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "JARL_",
+            "Sponsoring Organization": "JARL - Japan Amateur Radio League"
+          },
+          "RSGB_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "RSGB_",
+            "Sponsoring Organization": "RSGB - Radio Society of Great Britain"
+          },
+          "TAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "TAG_",
+            "Sponsoring Organization": "TAG - Tambov award group"
+          },
+          "WABAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "WABAG_",
+            "Sponsoring Organization": "WAB - Worked all Britain"
+          }
+        }
+      },
+      "Band": {
+        "Header": [
+          "Enumeration Name",
+          "Band",
+          "Lower Freq (MHz)",
+          "Upper Freq (MHz)",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "2190m": {
+            "Enumeration Name": "Band",
+            "Band": "2190m",
+            "Lower Freq (MHz)": ".1357",
+            "Upper Freq (MHz)": ".1378"
+          },
+          "630m": {
+            "Enumeration Name": "Band",
+            "Band": "630m",
+            "Lower Freq (MHz)": ".472",
+            "Upper Freq (MHz)": ".479"
+          },
+          "560m": {
+            "Enumeration Name": "Band",
+            "Band": "560m",
+            "Lower Freq (MHz)": ".501",
+            "Upper Freq (MHz)": ".504"
+          },
+          "160m": {
+            "Enumeration Name": "Band",
+            "Band": "160m",
+            "Lower Freq (MHz)": "1.8",
+            "Upper Freq (MHz)": "2.0"
+          },
+          "80m": {
+            "Enumeration Name": "Band",
+            "Band": "80m",
+            "Lower Freq (MHz)": "3.5",
+            "Upper Freq (MHz)": "4.0"
+          },
+          "60m": {
+            "Enumeration Name": "Band",
+            "Band": "60m",
+            "Lower Freq (MHz)": "5.06",
+            "Upper Freq (MHz)": "5.45"
+          },
+          "40m": {
+            "Enumeration Name": "Band",
+            "Band": "40m",
+            "Lower Freq (MHz)": "7.0",
+            "Upper Freq (MHz)": "7.3"
+          },
+          "30m": {
+            "Enumeration Name": "Band",
+            "Band": "30m",
+            "Lower Freq (MHz)": "10.1",
+            "Upper Freq (MHz)": "10.15"
+          },
+          "20m": {
+            "Enumeration Name": "Band",
+            "Band": "20m",
+            "Lower Freq (MHz)": "14.0",
+            "Upper Freq (MHz)": "14.35"
+          },
+          "17m": {
+            "Enumeration Name": "Band",
+            "Band": "17m",
+            "Lower Freq (MHz)": "18.068",
+            "Upper Freq (MHz)": "18.168"
+          },
+          "15m": {
+            "Enumeration Name": "Band",
+            "Band": "15m",
+            "Lower Freq (MHz)": "21.0",
+            "Upper Freq (MHz)": "21.45"
+          },
+          "12m": {
+            "Enumeration Name": "Band",
+            "Band": "12m",
+            "Lower Freq (MHz)": "24.890",
+            "Upper Freq (MHz)": "24.99"
+          },
+          "10m": {
+            "Enumeration Name": "Band",
+            "Band": "10m",
+            "Lower Freq (MHz)": "28.0",
+            "Upper Freq (MHz)": "29.7"
+          },
+          "8m": {
+            "Enumeration Name": "Band",
+            "Band": "8m",
+            "Lower Freq (MHz)": "40",
+            "Upper Freq (MHz)": "45"
+          },
+          "6m": {
+            "Enumeration Name": "Band",
+            "Band": "6m",
+            "Lower Freq (MHz)": "50",
+            "Upper Freq (MHz)": "54"
+          },
+          "5m": {
+            "Enumeration Name": "Band",
+            "Band": "5m",
+            "Lower Freq (MHz)": "54.000001",
+            "Upper Freq (MHz)": "69.9"
+          },
+          "4m": {
+            "Enumeration Name": "Band",
+            "Band": "4m",
+            "Lower Freq (MHz)": "70",
+            "Upper Freq (MHz)": "71"
+          },
+          "2m": {
+            "Enumeration Name": "Band",
+            "Band": "2m",
+            "Lower Freq (MHz)": "144",
+            "Upper Freq (MHz)": "148"
+          },
+          "1.25m": {
+            "Enumeration Name": "Band",
+            "Band": "1.25m",
+            "Lower Freq (MHz)": "222",
+            "Upper Freq (MHz)": "225"
+          },
+          "70cm": {
+            "Enumeration Name": "Band",
+            "Band": "70cm",
+            "Lower Freq (MHz)": "420",
+            "Upper Freq (MHz)": "450"
+          },
+          "33cm": {
+            "Enumeration Name": "Band",
+            "Band": "33cm",
+            "Lower Freq (MHz)": "902",
+            "Upper Freq (MHz)": "928"
+          },
+          "23cm": {
+            "Enumeration Name": "Band",
+            "Band": "23cm",
+            "Lower Freq (MHz)": "1240",
+            "Upper Freq (MHz)": "1300"
+          },
+          "13cm": {
+            "Enumeration Name": "Band",
+            "Band": "13cm",
+            "Lower Freq (MHz)": "2300",
+            "Upper Freq (MHz)": "2450"
+          },
+          "9cm": {
+            "Enumeration Name": "Band",
+            "Band": "9cm",
+            "Lower Freq (MHz)": "3300",
+            "Upper Freq (MHz)": "3500"
+          },
+          "6cm": {
+            "Enumeration Name": "Band",
+            "Band": "6cm",
+            "Lower Freq (MHz)": "5650",
+            "Upper Freq (MHz)": "5925"
+          },
+          "3cm": {
+            "Enumeration Name": "Band",
+            "Band": "3cm",
+            "Lower Freq (MHz)": "10000",
+            "Upper Freq (MHz)": "10500"
+          },
+          "1.25cm": {
+            "Enumeration Name": "Band",
+            "Band": "1.25cm",
+            "Lower Freq (MHz)": "24000",
+            "Upper Freq (MHz)": "24250"
+          },
+          "6mm": {
+            "Enumeration Name": "Band",
+            "Band": "6mm",
+            "Lower Freq (MHz)": "47000",
+            "Upper Freq (MHz)": "47200"
+          },
+          "4mm": {
+            "Enumeration Name": "Band",
+            "Band": "4mm",
+            "Lower Freq (MHz)": "75500",
+            "Upper Freq (MHz)": "81000"
+          },
+          "2.5mm": {
+            "Enumeration Name": "Band",
+            "Band": "2.5mm",
+            "Lower Freq (MHz)": "119980",
+            "Upper Freq (MHz)": "123000"
+          },
+          "2mm": {
+            "Enumeration Name": "Band",
+            "Band": "2mm",
+            "Lower Freq (MHz)": "134000",
+            "Upper Freq (MHz)": "149000"
+          },
+          "1mm": {
+            "Enumeration Name": "Band",
+            "Band": "1mm",
+            "Lower Freq (MHz)": "241000",
+            "Upper Freq (MHz)": "250000"
+          },
+          "submm": {
+            "Enumeration Name": "Band",
+            "Band": "submm",
+            "Lower Freq (MHz)": "300000",
+            "Upper Freq (MHz)": "7500000"
+          }
+        }
+      },
+      "Contest_ID": {
+        "Header": [
+          "Enumeration Name",
+          "Contest-ID",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "070-160M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-160M-SPRINT",
+            "Description": "PODXS Great Pumpkin Sprint"
+          },
+          "070-3-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-3-DAY",
+            "Description": "PODXS Three Day Weekend"
+          },
+          "070-31-FLAVORS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-31-FLAVORS",
+            "Description": "PODXS 31 Flavors"
+          },
+          "070-40M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-40M-SPRINT",
+            "Description": "PODXS 40m Firecracker Sprint"
+          },
+          "070-80M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-80M-SPRINT",
+            "Description": "PODXS 80m Jay Hudak Memorial Sprint"
+          },
+          "070-PSKFEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-PSKFEST",
+            "Description": "PODXS PSKFest"
+          },
+          "070-ST-PATS-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-ST-PATS-DAY",
+            "Description": "PODXS St. Patricks Day"
+          },
+          "070-VALENTINE-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-VALENTINE-SPRINT",
+            "Description": "PODXS Valentine Sprint"
+          },
+          "10-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "10-RTTY",
+            "Description": "Ten-Meter RTTY Contest (2011 onwards)"
+          },
+          "1010-OPEN-SEASON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "1010-OPEN-SEASON",
+            "Description": "Open Season Ten Meter QSO Party"
+          },
+          "7QP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "7QP",
+            "Description": "7th-Area QSO Party"
+          },
+          "AL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AL-QSO-PARTY",
+            "Description": "Alabama QSO Party"
+          },
+          "ALL-ASIAN-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-CW",
+            "Description": "JARL All Asian DX Contest (CW)"
+          },
+          "ALL-ASIAN-DX-PHONE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-PHONE",
+            "Description": "JARL All Asian DX Contest (PHONE)"
+          },
+          "ANARTS-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANARTS-RTTY",
+            "Description": "ANARTS WW RTTY"
+          },
+          "ANATOLIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANATOLIAN-RTTY",
+            "Description": "Anatolian WW RTTY"
+          },
+          "AP-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AP-SPRINT",
+            "Description": "Asia - Pacific Sprint"
+          },
+          "AR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AR-QSO-PARTY",
+            "Description": "Arkansas QSO Party"
+          },
+          "ARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-DX",
+            "Description": "ARI DX Contest"
+          },
+          "ARI-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-EME",
+            "Description": "ARI Italian EME Trophy"
+          },
+          "ARI-IAC-13CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-13CM",
+            "Description": "ARI Italian Activity Contest (13cm\u002B)"
+          },
+          "ARI-IAC-23CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-23CM",
+            "Description": "ARI Italian Activity Contest (23cm)"
+          },
+          "ARI-IAC-6M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-6M",
+            "Description": "ARI Italian Activity Contest (6m)"
+          },
+          "ARI-IAC-UHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-UHF",
+            "Description": "ARI Italian Activity Contest (UHF)"
+          },
+          "ARI-IAC-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-VHF",
+            "Description": "ARI Italian Activity Contest (VHF)"
+          },
+          "ARRL-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10",
+            "Description": "ARRL 10 Meter Contest"
+          },
+          "ARRL-10-GHZ": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10-GHZ",
+            "Description": "ARRL 10 GHz and Up Contest"
+          },
+          "ARRL-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-160",
+            "Description": "ARRL 160 Meter Contest"
+          },
+          "ARRL-222": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-222",
+            "Description": "ARRL 222 MHz and Up Distance Contest"
+          },
+          "ARRL-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DIGI",
+            "Description": "ARRL International Digital Contest"
+          },
+          "ARRL-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-CW",
+            "Description": "ARRL International DX Contest (CW)"
+          },
+          "ARRL-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-SSB",
+            "Description": "ARRL International DX Contest (Phone)"
+          },
+          "ARRL-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-EME",
+            "Description": "ARRL EME contest"
+          },
+          "ARRL-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-FIELD-DAY",
+            "Description": "ARRL Field Day"
+          },
+          "ARRL-RR-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-CW",
+            "Description": "ARRL Rookie Roundup (CW)"
+          },
+          "ARRL-RR-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-RTTY",
+            "Description": "ARRL Rookie Roundup (RTTY)"
+          },
+          "ARRL-RR-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-SSB",
+            "Description": "ARRL Rookie Roundup (Phone)"
+          },
+          "ARRL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RTTY",
+            "Description": "ARRL RTTY Round-Up"
+          },
+          "ARRL-SCR": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SCR",
+            "Description": "ARRL School Club Roundup"
+          },
+          "ARRL-SS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-CW",
+            "Description": "ARRL November Sweepstakes (CW)"
+          },
+          "ARRL-SS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-SSB",
+            "Description": "ARRL November Sweepstakes (Phone)"
+          },
+          "ARRL-UHF-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-UHF-AUG",
+            "Description": "ARRL August UHF Contest"
+          },
+          "ARRL-VHF-JAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JAN",
+            "Description": "ARRL January VHF Sweepstakes"
+          },
+          "ARRL-VHF-JUN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JUN",
+            "Description": "ARRL June VHF QSO Party"
+          },
+          "ARRL-VHF-SEP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-SEP",
+            "Description": "ARRL September VHF QSO Party"
+          },
+          "AZ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AZ-QSO-PARTY",
+            "Description": "Arizona QSO Party"
+          },
+          "BANGGAI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BANGGAI-DX",
+            "Description": "ORARI Banggai DX Contest"
+          },
+          "BARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-RTTY",
+            "Description": "BARTG Spring RTTY Contest"
+          },
+          "BARTG-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-SPRINT",
+            "Description": "BARTG Sprint Contest"
+          },
+          "BC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BC-QSO-PARTY",
+            "Description": "British Columbia QSO Party"
+          },
+          "BEKASI-MERDEKA-CONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BEKASI-MERDEKA-CONTEST",
+            "Description": "ORARI Bekasi Merdeka Contest"
+          },
+          "CA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CA-QSO-PARTY",
+            "Description": "California QSO Party"
+          },
+          "CIS-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CIS-DX",
+            "Description": "CIS DX Contest"
+          },
+          "CO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CO-QSO-PARTY",
+            "Description": "Colorado QSO Party"
+          },
+          "CQ-160-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-CW",
+            "Description": "CQ WW 160 Meter DX Contest (CW)"
+          },
+          "CQ-160-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-SSB",
+            "Description": "CQ WW 160 Meter DX Contest (SSB)"
+          },
+          "CQ-M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-M",
+            "Description": "CQ-M International DX Contest"
+          },
+          "CQ-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-VHF",
+            "Description": "CQ World-Wide VHF Contest"
+          },
+          "CQ-WPX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-CW",
+            "Description": "CQ WW WPX Contest (CW)"
+          },
+          "CQ-WPX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-RTTY",
+            "Description": "CQ/RJ WW RTTY WPX Contest"
+          },
+          "CQ-WPX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-SSB",
+            "Description": "CQ WW WPX Contest (SSB)"
+          },
+          "CQ-WW-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-CW",
+            "Description": "CQ WW DX Contest (CW)"
+          },
+          "CQ-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-RTTY",
+            "Description": "CQ/RJ WW RTTY DX Contest"
+          },
+          "CQ-WW-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-SSB",
+            "Description": "CQ WW DX Contest (SSB)"
+          },
+          "CT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CT-QSO-PARTY",
+            "Description": "Connecticut QSO Party"
+          },
+          "CVA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-CW",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CVA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-SSB",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CWOPS-CW-OPEN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CW-OPEN",
+            "Description": "CWops CW Open Competition"
+          },
+          "CWOPS-CWT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CWT",
+            "Description": "CWops Mini-CWT Test"
+          },
+          "DARC-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-10",
+            "Description": "DARC 10m Contest"
+          },
+          "DARC-CWA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-CWA",
+            "Description": "DARC CW Trainee Contest"
+          },
+          "DARC-FT4": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-FT4",
+            "Description": "DARC FT4 Contest"
+          },
+          "DARC-HELL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-HELL",
+            "Description": "DARC Hell Contest"
+          },
+          "DARC-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-MICROWAVE",
+            "Description": "DARC Microwave Contest"
+          },
+          "DARC-TRAINEE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-TRAINEE",
+            "Description": "DARC Trainee Contest"
+          },
+          "DARC-UKW-SPRING": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-SPRING",
+            "Description": "DARC UKW Spring Contest"
+          },
+          "DARC-UKW-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-FIELD-DAY",
+            "Description": "DARC UKW Summer Contest"
+          },
+          "DARC-VHF-UHF-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-VHF-UHF-MICROWAVE",
+            "Description": "DARC VHF-, UHF-, Microwave Contest (May)"
+          },
+          "DARC-WAEDC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-CW",
+            "Description": "WAE DX Contest (CW)"
+          },
+          "DARC-WAEDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-RTTY",
+            "Description": "WAE DX Contest (RTTY)"
+          },
+          "DARC-WAEDC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-SSB",
+            "Description": "WAE DX Contest (SSB)"
+          },
+          "DARC-WAG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAG",
+            "Description": "DARC Worked All Germany"
+          },
+          "DE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DE-QSO-PARTY",
+            "Description": "Delaware QSO Party"
+          },
+          "DL-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DL-DX-RTTY",
+            "Description": "DL-DX RTTY Contest"
+          },
+          "DMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DMC-RTTY",
+            "Description": "DMC RTTY Contest"
+          },
+          "EA-CNCW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-CNCW",
+            "Description": "Concurso Nacional de Telegrafía"
+          },
+          "EA-DME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-DME",
+            "Description": "Municipios Españoles"
+          },
+          "EA-MAJESTAD-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-CW",
+            "Description": "His Majesty The King of Spain CW Contest (2022 and later)"
+          },
+          "EA-MAJESTAD-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-SSB",
+            "Description": "His Majesty The King of Spain SSB Contest (2022 and later)"
+          },
+          "EA-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-PSK63",
+            "Description": "EA PSK63"
+          },
+          "EA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest",
+            "Import-only": "true"
+          },
+          "EA-SMRE-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-CW",
+            "Description": "Su Majestad El Rey de España - CW (2021 and earlier)"
+          },
+          "EA-SMRE-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-SSB",
+            "Description": "Su Majestad El Rey de España - SSB (2021 and earlier)"
+          },
+          "EA-VHF-ATLANTIC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-ATLANTIC",
+            "Description": "Atlántico V-UHF"
+          },
+          "EA-VHF-COM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COM",
+            "Description": "Combinado de V-UHF"
+          },
+          "EA-VHF-COSTA-SOL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COSTA-SOL",
+            "Description": "Costa del Sol V-UHF"
+          },
+          "EA-VHF-EA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA",
+            "Description": "Nacional VHF"
+          },
+          "EA-VHF-EA1RCS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA1RCS",
+            "Description": "Segovia EA1RCS V-UHF"
+          },
+          "EA-VHF-QSL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-QSL",
+            "Description": "QSL V-UHF \u0026 50MHz"
+          },
+          "EA-VHF-SADURNI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-SADURNI",
+            "Description": "Sant Sadurni V-UHF"
+          },
+          "EA-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-WW-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest"
+          },
+          "EASTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EASTER",
+            "Description": "DARC Easter Contest"
+          },
+          "EPC-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EPC-PSK63",
+            "Description": "PSK63 QSO Party"
+          },
+          "EU SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU SPRINT",
+            "Description": "EU Sprint"
+          },
+          "EU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-HF",
+            "Description": "EU HF Championship"
+          },
+          "EU-PSK-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-PSK-DX",
+            "Description": "EU PSK DX Contest"
+          },
+          "EUCW160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EUCW160M",
+            "Description": "European CW Association 160m CW Party"
+          },
+          "FALL SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FALL SPRINT",
+            "Description": "FISTS Fall Sprint"
+          },
+          "FL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FL-QSO-PARTY",
+            "Description": "Florida QSO Party"
+          },
+          "GA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "GA-QSO-PARTY",
+            "Description": "Georgia QSO Party"
+          },
+          "HA-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HA-DX",
+            "Description": "Hungarian DX Contest"
+          },
+          "HELVETIA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HELVETIA",
+            "Description": "Helvetia Contest"
+          },
+          "HI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HI-QSO-PARTY",
+            "Description": "Hawaiian QSO Party"
+          },
+          "HOLYLAND": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HOLYLAND",
+            "Description": "IARC Holyland Contest"
+          },
+          "IA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IA-QSO-PARTY",
+            "Description": "Iowa QSO Party"
+          },
+          "IARU-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-FIELD-DAY",
+            "Description": "DARC IARU Region 1 Field Day"
+          },
+          "IARU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-HF",
+            "Description": "IARU HF World Championship"
+          },
+          "ICWC-MST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ICWC-MST",
+            "Description": "ICWC Medium Speed Test"
+          },
+          "ID-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ID-QSO-PARTY",
+            "Description": "Idaho QSO Party"
+          },
+          "IL QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IL QSO PARTY",
+            "Description": "Illinois QSO Party"
+          },
+          "IN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IN-QSO-PARTY",
+            "Description": "Indiana QSO Party"
+          },
+          "JARTS-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JARTS-WW-RTTY",
+            "Description": "JARTS WW RTTY"
+          },
+          "JIDX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-CW",
+            "Description": "Japan International DX Contest (CW)"
+          },
+          "JIDX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-SSB",
+            "Description": "Japan International DX Contest (SSB)"
+          },
+          "JT-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JT-DX-RTTY",
+            "Description": "Mongolian RTTY DX Contest"
+          },
+          "K1USN-SSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SSO",
+            "Description": "K1USN Slow Speed Open"
+          },
+          "K1USN-SST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SST",
+            "Description": "K1USN Slow Speed Test"
+          },
+          "KS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KS-QSO-PARTY",
+            "Description": "Kansas QSO Party"
+          },
+          "KY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KY-QSO-PARTY",
+            "Description": "Kentucky QSO Party"
+          },
+          "LA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LA-QSO-PARTY",
+            "Description": "Louisiana QSO Party"
+          },
+          "LDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LDC-RTTY",
+            "Description": "DRCG Long Distance Contest (RTTY)"
+          },
+          "LZ DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LZ DX",
+            "Description": "LZ DX Contest"
+          },
+          "MAR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MAR-QSO-PARTY",
+            "Description": "Maritimes QSO Party"
+          },
+          "MD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MD-QSO-PARTY",
+            "Description": "Maryland QSO Party"
+          },
+          "ME-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ME-QSO-PARTY",
+            "Description": "Maine QSO Party"
+          },
+          "MI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MI-QSO-PARTY",
+            "Description": "Michigan QSO Party"
+          },
+          "MIDATLANTIC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MIDATLANTIC-QSO-PARTY",
+            "Description": "Mid-Atlantic QSO Party"
+          },
+          "MN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MN-QSO-PARTY",
+            "Description": "Minnesota QSO Party"
+          },
+          "MO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MO-QSO-PARTY",
+            "Description": "Missouri QSO Party"
+          },
+          "MS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MS-QSO-PARTY",
+            "Description": "Mississippi QSO Party"
+          },
+          "MT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MT-QSO-PARTY",
+            "Description": "Montana QSO Party"
+          },
+          "NA-SPRINT-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-CW",
+            "Description": "North America Sprint (CW)"
+          },
+          "NA-SPRINT-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-RTTY",
+            "Description": "North America Sprint (RTTY)"
+          },
+          "NA-SPRINT-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-SSB",
+            "Description": "North America Sprint (Phone)"
+          },
+          "NAQP-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-CW",
+            "Description": "North America QSO Party (CW)"
+          },
+          "NAQP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-RTTY",
+            "Description": "North America QSO Party (RTTY)"
+          },
+          "NAQP-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-SSB",
+            "Description": "North America QSO Party (Phone)"
+          },
+          "NAVAL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAVAL",
+            "Description": "International Naval Contest (INC)"
+          },
+          "NC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NC-QSO-PARTY",
+            "Description": "North Carolina QSO Party"
+          },
+          "ND-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ND-QSO-PARTY",
+            "Description": "North Dakota QSO Party"
+          },
+          "NE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NE-QSO-PARTY",
+            "Description": "Nebraska QSO Party"
+          },
+          "NEQP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NEQP",
+            "Description": "New England QSO Party"
+          },
+          "NH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NH-QSO-PARTY",
+            "Description": "New Hampshire QSO Party"
+          },
+          "NJ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NJ-QSO-PARTY",
+            "Description": "New Jersey QSO Party"
+          },
+          "NM-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NM-QSO-PARTY",
+            "Description": "New Mexico QSO Party"
+          },
+          "NRAU-BALTIC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-CW",
+            "Description": "NRAU-Baltic Contest (CW)"
+          },
+          "NRAU-BALTIC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-SSB",
+            "Description": "NRAU-Baltic Contest (SSB)"
+          },
+          "NV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NV-QSO-PARTY",
+            "Description": "Nevada QSO Party"
+          },
+          "NY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NY-QSO-PARTY",
+            "Description": "New York QSO Party"
+          },
+          "OCEANIA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-CW",
+            "Description": "Oceania DX Contest (CW)"
+          },
+          "OCEANIA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-SSB",
+            "Description": "Oceania DX Contest (SSB)"
+          },
+          "OH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OH-QSO-PARTY",
+            "Description": "Ohio QSO Party"
+          },
+          "OK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-DX-RTTY",
+            "Description": "Czech Radio Club OK DX Contest"
+          },
+          "OK-OM-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-OM-DX",
+            "Description": "Czech Radio Club OK-OM DX Contest"
+          },
+          "OK-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-QSO-PARTY",
+            "Description": "Oklahoma QSO Party"
+          },
+          "OMISS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OMISS-QSO-PARTY",
+            "Description": "Old Man International Sideband Society QSO Party"
+          },
+          "ON-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ON-QSO-PARTY",
+            "Description": "Ontario QSO Party"
+          },
+          "OR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OR-QSO-PARTY",
+            "Description": "Oregon QSO Party"
+          },
+          "ORARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ORARI-DX",
+            "Description": "ORARI DX Contest"
+          },
+          "PA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PA-QSO-PARTY",
+            "Description": "Pennsylvania QSO Party"
+          },
+          "PACC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PACC",
+            "Description": "Dutch PACC Contest"
+          },
+          "PCC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PCC",
+            "Description": "PCCPro CW Contest"
+          },
+          "PSK-DEATHMATCH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PSK-DEATHMATCH",
+            "Description": "MDXA PSK DeathMatch (2005-2010)"
+          },
+          "QC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "QC-QSO-PARTY",
+            "Description": "Quebec QSO Party"
+          },
+          "RAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC",
+            "Description": "Canadian Amateur Radio Society Contest",
+            "Import-only": "true"
+          },
+          "RAC-CANADA-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-DAY",
+            "Description": "RAC Canada Day Contest"
+          },
+          "RAC-CANADA-WINTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-WINTER",
+            "Description": "RAC Canada Winter Contest"
+          },
+          "RDAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDAC",
+            "Description": "Russian District Award Contest"
+          },
+          "RDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDXC",
+            "Description": "Russian DX Contest"
+          },
+          "REF-160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-160M",
+            "Description": "Reseau des Emetteurs Francais 160m Contest"
+          },
+          "REF-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-CW",
+            "Description": "Reseau des Emetteurs Francais Contest (CW)"
+          },
+          "REF-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-SSB",
+            "Description": "Reseau des Emetteurs Francais Contest (SSB)"
+          },
+          "REP-PORTUGAL-DAY-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REP-PORTUGAL-DAY-HF",
+            "Description": "Rede dos Emissores Portugueses Portugal Day HF Contest"
+          },
+          "RI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RI-QSO-PARTY",
+            "Description": "Rhode Island QSO Party"
+          },
+          "RSGB-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-160",
+            "Description": "1.8MHz Contest"
+          },
+          "RSGB-21/28-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-CW",
+            "Description": "21/28 MHz Contest (CW)"
+          },
+          "RSGB-21/28-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-SSB",
+            "Description": "21/28 MHz Contest (SSB)"
+          },
+          "RSGB-80M-CC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-80M-CC",
+            "Description": "80m Club Championships"
+          },
+          "RSGB-AFS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-CW",
+            "Description": "Affiliated Societies Team Contest (CW)"
+          },
+          "RSGB-AFS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-SSB",
+            "Description": "Affiliated Societies Team Contest (SSB)"
+          },
+          "RSGB-CLUB-CALLS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-CLUB-CALLS",
+            "Description": "Club Calls"
+          },
+          "RSGB-COMMONWEALTH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-COMMONWEALTH",
+            "Description": "Commonwealth Contest"
+          },
+          "RSGB-IOTA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-IOTA",
+            "Description": "IOTA Contest"
+          },
+          "RSGB-LOW-POWER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-LOW-POWER",
+            "Description": "Low Power Field Day"
+          },
+          "RSGB-NFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-NFD",
+            "Description": "National Field Day"
+          },
+          "RSGB-ROPOCO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-ROPOCO",
+            "Description": "RoPoCo"
+          },
+          "RSGB-SSB-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-SSB-FD",
+            "Description": "SSB Field Day"
+          },
+          "RUSSIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RUSSIAN-RTTY",
+            "Description": "Russian Radio RTTY Worldwide Contest"
+          },
+          "SAC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-CW",
+            "Description": "Scandinavian Activity Contest (CW)"
+          },
+          "SAC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-SSB",
+            "Description": "Scandinavian Activity Contest (SSB)"
+          },
+          "SARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SARTG-RTTY",
+            "Description": "SARTG WW RTTY"
+          },
+          "SC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SC-QSO-PARTY",
+            "Description": "South Carolina QSO Party"
+          },
+          "SCC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SCC-RTTY",
+            "Description": "SCC RTTY Championship"
+          },
+          "SD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SD-QSO-PARTY",
+            "Description": "South Dakota QSO Party"
+          },
+          "SHORTRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SHORTRY",
+            "Description": "DARC RTTY Short Contest"
+          },
+          "SMP-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-AUG",
+            "Description": "SSA Portabeltest"
+          },
+          "SMP-MAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-MAY",
+            "Description": "SSA Portabeltest"
+          },
+          "SP-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SP-DX-RTTY",
+            "Description": "PRC SPDX Contest (RTTY)"
+          },
+          "SPAR-WINTER-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPAR-WINTER-FD",
+            "Description": "SPAR Winter Field Day(2016 and earlier)"
+          },
+          "SPDXCONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPDXCONTEST",
+            "Description": "SP DX Contest"
+          },
+          "SPRING SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPRING SPRINT",
+            "Description": "FISTS Spring Sprint"
+          },
+          "SR-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SR-MARATHON",
+            "Description": "Scottish-Russian Marathon"
+          },
+          "STEW-PERRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "STEW-PERRY",
+            "Description": "Stew Perry Topband Distance Challenge"
+          },
+          "SUMMER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SUMMER SPRINT",
+            "Description": "FISTS Summer Sprint"
+          },
+          "TARA-GRID-DIP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-GRID-DIP",
+            "Description": "TARA Grid Dip PSK-RTTY Shindig"
+          },
+          "TARA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RTTY",
+            "Description": "TARA RTTY Mêlée"
+          },
+          "TARA-RUMBLE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RUMBLE",
+            "Description": "TARA Rumble PSK Contest"
+          },
+          "TARA-SKIRMISH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-SKIRMISH",
+            "Description": "TARA Skirmish Digital Prefix Contest"
+          },
+          "TEN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TEN-RTTY",
+            "Description": "Ten-Meter RTTY Contest (before 2011)"
+          },
+          "TMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TMC-RTTY",
+            "Description": "The Makrothen Contest"
+          },
+          "TN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TN-QSO-PARTY",
+            "Description": "Tennessee QSO Party"
+          },
+          "TX-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TX-QSO-PARTY",
+            "Description": "Texas QSO Party"
+          },
+          "UBA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-CW",
+            "Description": "UBA Contest (CW)"
+          },
+          "UBA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-SSB",
+            "Description": "UBA Contest (SSB)"
+          },
+          "UK-DX-BPSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-BPSK63",
+            "Description": "European PSK Club BPSK63 Contest"
+          },
+          "UK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-RTTY",
+            "Description": "UK DX RTTY Contest"
+          },
+          "UKR-CHAMP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKR-CHAMP-RTTY",
+            "Description": "Open Ukraine RTTY Championship"
+          },
+          "UKRAINIAN DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKRAINIAN DX",
+            "Description": "Ukrainian DX"
+          },
+          "UKSMG-6M-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-6M-MARATHON",
+            "Description": "UKSMG 6m Marathon"
+          },
+          "UKSMG-SUMMER-ES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-SUMMER-ES",
+            "Description": "UKSMG Summer Es Contest"
+          },
+          "URE-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "URE-DX",
+            "Description": "Ukrainian DX Contest",
+            "Import-only": "true"
+          },
+          "US-COUNTIES-QSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "US-COUNTIES-QSO",
+            "Description": "Mobile Amateur Awards Club"
+          },
+          "UT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UT-QSO-PARTY",
+            "Description": "Utah QSO Party"
+          },
+          "VA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VA-QSO-PARTY",
+            "Description": "Virginia QSO Party"
+          },
+          "VENEZ-IND-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VENEZ-IND-DAY",
+            "Description": "RCV Venezuelan Independence Day Contest"
+          },
+          "VIRGINIA QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VIRGINIA QSO PARTY",
+            "Description": "Virginia QSO Party",
+            "Import-only": "true"
+          },
+          "VOLTA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VOLTA-RTTY",
+            "Description": "Alessandro Volta RTTY DX Contest"
+          },
+          "VT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VT-QSO-PARTY",
+            "Description": "Vermont QSO Party"
+          },
+          "WA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WA-QSO-PARTY",
+            "Description": "Washington QSO Party"
+          },
+          "WFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WFD",
+            "Description": "Winter Field Day (2017 and later)"
+          },
+          "WI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WI-QSO-PARTY",
+            "Description": "Wisconsin QSO Party"
+          },
+          "WIA-HARRY ANGEL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-HARRY ANGEL",
+            "Description": "WIA Harry Angel Memorial 80m Sprint"
+          },
+          "WIA-JMMFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-JMMFD",
+            "Description": "WIA John Moyle Memorial Field Day"
+          },
+          "WIA-OCDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-OCDX",
+            "Description": "WIA Oceania DX (OCDX) Contest"
+          },
+          "WIA-REMEMBRANCE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-REMEMBRANCE",
+            "Description": "WIA Remembrance Day"
+          },
+          "WIA-ROSS HULL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-ROSS HULL",
+            "Description": "WIA Ross Hull Memorial VHF/UHF Contest"
+          },
+          "WIA-TRANS TASMAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-TRANS TASMAN",
+            "Description": "WIA Trans Tasman Low Bands Challenge"
+          },
+          "WIA-VHF/UHF FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VHF/UHF FD",
+            "Description": "WIA VHF UHF Field Days"
+          },
+          "WIA-VK SHIRES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VK SHIRES",
+            "Description": "WIA VK Shires"
+          },
+          "WINTER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WINTER SPRINT",
+            "Description": "FISTS Winter Sprint"
+          },
+          "WV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WV-QSO-PARTY",
+            "Description": "West Virginia QSO Party"
+          },
+          "WW-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WW-DIGI",
+            "Description": "World Wide Digi DX Contest"
+          },
+          "WY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WY-QSO-PARTY",
+            "Description": "Wyoming QSO Party"
+          },
+          "XE-INTL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "XE-INTL-RTTY",
+            "Description": "Mexico International Contest (RTTY)"
+          },
+          "YOHFDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YOHFDX",
+            "Description": "YODX HF contest"
+          },
+          "YUDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YUDXC",
+            "Description": "YU DX Contest"
+          }
+        }
+      },
+      "Continent": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Continent",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "NA",
+            "Continent": "North America"
+          },
+          "SA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "SA",
+            "Continent": "South America"
+          },
+          "EU": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "EU",
+            "Continent": "Europe"
+          },
+          "AF": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AF",
+            "Continent": "Africa"
+          },
+          "OC": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "OC",
+            "Continent": "Oceania"
+          },
+          "AS": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AS",
+            "Continent": "Asia"
+          },
+          "AN": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AN",
+            "Continent": "Antarctica"
+          }
+        }
+      },
+      "Credit": {
+        "Header": [
+          "Enumeration Name",
+          "Credit For",
+          "Sponsor",
+          "Award",
+          "Facet",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CQDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mixed"
+          },
+          "CQDX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Band"
+          },
+          "CQDX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mode"
+          },
+          "CQDX_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mobile"
+          },
+          "CQDX_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "QRP"
+          },
+          "CQDX_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Satellite"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mixed"
+          },
+          "CQDXFIELD_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Band"
+          },
+          "CQDXFIELD_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mode"
+          },
+          "CQDXFIELD_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mobile"
+          },
+          "CQDXFIELD_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "QRP"
+          },
+          "CQDXFIELD_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MIXED",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mixed"
+          },
+          "CQWAZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Band"
+          },
+          "CQWAZ_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mode"
+          },
+          "CQWAZ_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_EME",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "EME"
+          },
+          "CQWAZ_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mobile"
+          },
+          "CQWAZ_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "QRP"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mixed"
+          },
+          "CQWPX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Band"
+          },
+          "CQWPX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mode"
+          },
+          "DXCC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mixed"
+          },
+          "DXCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Band"
+          },
+          "DXCC_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_MODE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mode"
+          },
+          "DXCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Satellite"
+          },
+          "EAUSTRALIA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EAUSTRALIA",
+            "Sponsor": "eQSL",
+            "Award": "eAustralia",
+            "Facet": "Mixed"
+          },
+          "ECANADA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECANADA",
+            "Sponsor": "eQSL",
+            "Award": "eCanada",
+            "Facet": "Mixed"
+          },
+          "ECOUNTY_STATE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECOUNTY_STATE",
+            "Sponsor": "eQSL",
+            "Award": "eCounty",
+            "Facet": "State"
+          },
+          "EDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX",
+            "Sponsor": "eQSL",
+            "Award": "eDX",
+            "Facet": "Mixed"
+          },
+          "EDX100": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mixed"
+          },
+          "EDX100_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Band"
+          },
+          "EDX100_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mode"
+          },
+          "EECHOLINK50": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EECHOLINK50",
+            "Sponsor": "eQSL",
+            "Award": "eEcholink50",
+            "Facet": "Echolink"
+          },
+          "EGRID_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Band"
+          },
+          "EGRID_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Satellite"
+          },
+          "EPFX300": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mixed"
+          },
+          "EPFX300_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300_MODE",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mode"
+          },
+          "EWAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mixed"
+          },
+          "EWAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Band"
+          },
+          "EWAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mode"
+          },
+          "EWAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Satellite"
+          },
+          "EZ40": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mixed"
+          },
+          "EZ40_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mode"
+          },
+          "FFMA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "FFMA",
+            "Sponsor": "ARRL",
+            "Award": "Fred Fish Memorial Award (FFMA)",
+            "Facet": "Mixed"
+          },
+          "IOTA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_BASIC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_BASIC",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_CONT": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_CONT",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Continent"
+          },
+          "IOTA_GROUP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_GROUP",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Group"
+          },
+          "RDA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "RDA",
+            "Sponsor": "TAG",
+            "Award": "Russian Districts Award (RDA)",
+            "Facet": "Mixed"
+          },
+          "USACA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "USACA",
+            "Sponsor": "CQ Magazine",
+            "Award": "United States of America Counties (USA-CA)",
+            "Facet": "Mixed"
+          },
+          "VUCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Band"
+          },
+          "VUCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Satellite"
+          },
+          "WAB": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAB",
+            "Sponsor": "WAB AG",
+            "Award": "Worked All Britain (WAB)",
+            "Facet": "Mixed"
+          },
+          "WAC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Mixed"
+          },
+          "WAC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC_BAND",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Band"
+          },
+          "WAE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mixed"
+          },
+          "WAE_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_BAND",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Band"
+          },
+          "WAE_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_MODE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mode"
+          },
+          "WAIP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mixed"
+          },
+          "WAIP_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_BAND",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Band"
+          },
+          "WAIP_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_MODE",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mode"
+          },
+          "WAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mixed"
+          },
+          "WAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_BAND",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Band"
+          },
+          "WAS_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_EME",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "EME"
+          },
+          "WAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_MODE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mode"
+          },
+          "WAS_NOVICE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_NOVICE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Novice"
+          },
+          "WAS_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_QRP",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "QRP"
+          },
+          "WAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Satellite"
+          },
+          "WITUZ": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Mixed"
+          },
+          "WITUZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ_BAND",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Band"
+          }
+        }
+      },
+      "DXCC_Entity_Code": {
+        "Header": [
+          "Enumeration Name",
+          "Entity Code",
+          "Entity Name",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "0": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "0",
+            "Entity Name": "None (the contacted station is known to not be within a DXCC entity)"
+          },
+          "1": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "1",
+            "Entity Name": "CANADA"
+          },
+          "2": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "2",
+            "Entity Name": "ABU AIL IS.",
+            "Deleted": "true"
+          },
+          "3": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "3",
+            "Entity Name": "AFGHANISTAN"
+          },
+          "4": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "4",
+            "Entity Name": "AGALEGA \u0026 ST. BRANDON IS."
+          },
+          "5": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "5",
+            "Entity Name": "ALAND IS."
+          },
+          "6": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "6",
+            "Entity Name": "ALASKA"
+          },
+          "7": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "7",
+            "Entity Name": "ALBANIA"
+          },
+          "8": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "8",
+            "Entity Name": "ALDABRA",
+            "Deleted": "true"
+          },
+          "9": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "9",
+            "Entity Name": "AMERICAN SAMOA"
+          },
+          "10": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "10",
+            "Entity Name": "AMSTERDAM \u0026 ST. PAUL IS."
+          },
+          "11": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "11",
+            "Entity Name": "ANDAMAN \u0026 NICOBAR IS."
+          },
+          "12": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "12",
+            "Entity Name": "ANGUILLA"
+          },
+          "13": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "13",
+            "Entity Name": "ANTARCTICA"
+          },
+          "14": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "14",
+            "Entity Name": "ARMENIA"
+          },
+          "15": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "15",
+            "Entity Name": "ASIATIC RUSSIA"
+          },
+          "16": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "16",
+            "Entity Name": "NEW ZEALAND SUBANTARCTIC ISLANDS"
+          },
+          "17": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "17",
+            "Entity Name": "AVES I."
+          },
+          "18": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "18",
+            "Entity Name": "AZERBAIJAN"
+          },
+          "19": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "19",
+            "Entity Name": "BAJO NUEVO",
+            "Deleted": "true"
+          },
+          "20": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "20",
+            "Entity Name": "BAKER \u0026 HOWLAND IS."
+          },
+          "21": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "21",
+            "Entity Name": "BALEARIC IS."
+          },
+          "22": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "22",
+            "Entity Name": "PALAU"
+          },
+          "23": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "23",
+            "Entity Name": "BLENHEIM REEF",
+            "Deleted": "true"
+          },
+          "24": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "24",
+            "Entity Name": "BOUVET"
+          },
+          "25": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "25",
+            "Entity Name": "BRITISH NORTH BORNEO",
+            "Deleted": "true"
+          },
+          "26": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "26",
+            "Entity Name": "BRITISH SOMALILAND",
+            "Deleted": "true"
+          },
+          "27": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "27",
+            "Entity Name": "BELARUS"
+          },
+          "28": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "28",
+            "Entity Name": "CANAL ZONE",
+            "Deleted": "true"
+          },
+          "29": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "29",
+            "Entity Name": "CANARY IS."
+          },
+          "30": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "30",
+            "Entity Name": "CELEBE \u0026 MOLUCCA IS.",
+            "Deleted": "true"
+          },
+          "31": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "31",
+            "Entity Name": "C. KIRIBATI (BRITISH PHOENIX IS.)"
+          },
+          "32": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "32",
+            "Entity Name": "CEUTA \u0026 MELILLA"
+          },
+          "33": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "33",
+            "Entity Name": "CHAGOS IS."
+          },
+          "34": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "34",
+            "Entity Name": "CHATHAM IS."
+          },
+          "35": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "35",
+            "Entity Name": "CHRISTMAS I."
+          },
+          "36": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "36",
+            "Entity Name": "CLIPPERTON I."
+          },
+          "37": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "37",
+            "Entity Name": "COCOS I."
+          },
+          "38": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "38",
+            "Entity Name": "COCOS (KEELING) IS."
+          },
+          "39": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "39",
+            "Entity Name": "COMOROS",
+            "Deleted": "true"
+          },
+          "40": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "40",
+            "Entity Name": "CRETE"
+          },
+          "41": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "41",
+            "Entity Name": "CROZET I."
+          },
+          "42": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "42",
+            "Entity Name": "DAMAO, DIU",
+            "Deleted": "true"
+          },
+          "43": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "43",
+            "Entity Name": "DESECHEO I."
+          },
+          "44": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "44",
+            "Entity Name": "DESROCHES",
+            "Deleted": "true"
+          },
+          "45": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "45",
+            "Entity Name": "DODECANESE"
+          },
+          "46": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "46",
+            "Entity Name": "EAST MALAYSIA"
+          },
+          "47": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "47",
+            "Entity Name": "EASTER I."
+          },
+          "48": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "48",
+            "Entity Name": "E. KIRIBATI (LINE IS.)"
+          },
+          "49": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "49",
+            "Entity Name": "EQUATORIAL GUINEA"
+          },
+          "50": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "50",
+            "Entity Name": "MEXICO"
+          },
+          "51": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "51",
+            "Entity Name": "ERITREA"
+          },
+          "52": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "52",
+            "Entity Name": "ESTONIA"
+          },
+          "53": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "53",
+            "Entity Name": "ETHIOPIA"
+          },
+          "54": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "54",
+            "Entity Name": "EUROPEAN RUSSIA"
+          },
+          "55": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "55",
+            "Entity Name": "FARQUHAR",
+            "Deleted": "true"
+          },
+          "56": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "56",
+            "Entity Name": "FERNANDO DE NORONHA"
+          },
+          "57": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "57",
+            "Entity Name": "FRENCH EQUATORIAL AFRICA",
+            "Deleted": "true"
+          },
+          "58": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "58",
+            "Entity Name": "FRENCH INDO-CHINA",
+            "Deleted": "true"
+          },
+          "59": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "59",
+            "Entity Name": "FRENCH WEST AFRICA",
+            "Deleted": "true"
+          },
+          "60": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "60",
+            "Entity Name": "BAHAMAS"
+          },
+          "61": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "61",
+            "Entity Name": "FRANZ JOSEF LAND"
+          },
+          "62": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "62",
+            "Entity Name": "BARBADOS"
+          },
+          "63": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "63",
+            "Entity Name": "FRENCH GUIANA"
+          },
+          "64": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "64",
+            "Entity Name": "BERMUDA"
+          },
+          "65": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "65",
+            "Entity Name": "BRITISH VIRGIN IS."
+          },
+          "66": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "66",
+            "Entity Name": "BELIZE"
+          },
+          "67": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "67",
+            "Entity Name": "FRENCH INDIA",
+            "Deleted": "true"
+          },
+          "68": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "68",
+            "Entity Name": "KUWAIT/SAUDI ARABIA NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "69": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "69",
+            "Entity Name": "CAYMAN IS."
+          },
+          "70": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "70",
+            "Entity Name": "CUBA"
+          },
+          "71": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "71",
+            "Entity Name": "GALAPAGOS IS."
+          },
+          "72": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "72",
+            "Entity Name": "DOMINICAN REPUBLIC"
+          },
+          "74": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "74",
+            "Entity Name": "EL SALVADOR"
+          },
+          "75": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "75",
+            "Entity Name": "GEORGIA"
+          },
+          "76": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "76",
+            "Entity Name": "GUATEMALA"
+          },
+          "77": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "77",
+            "Entity Name": "GRENADA"
+          },
+          "78": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "78",
+            "Entity Name": "HAITI"
+          },
+          "79": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "79",
+            "Entity Name": "GUADELOUPE"
+          },
+          "80": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "80",
+            "Entity Name": "HONDURAS"
+          },
+          "81": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "81",
+            "Entity Name": "GERMANY",
+            "Deleted": "true"
+          },
+          "82": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "82",
+            "Entity Name": "JAMAICA"
+          },
+          "84": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "84",
+            "Entity Name": "MARTINIQUE"
+          },
+          "85": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "85",
+            "Entity Name": "BONAIRE, CURACAO",
+            "Deleted": "true"
+          },
+          "86": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "86",
+            "Entity Name": "NICARAGUA"
+          },
+          "88": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "88",
+            "Entity Name": "PANAMA"
+          },
+          "89": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "89",
+            "Entity Name": "TURKS \u0026 CAICOS IS."
+          },
+          "90": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "90",
+            "Entity Name": "TRINIDAD \u0026 TOBAGO"
+          },
+          "91": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "91",
+            "Entity Name": "ARUBA"
+          },
+          "93": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "93",
+            "Entity Name": "GEYSER REEF",
+            "Deleted": "true"
+          },
+          "94": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "94",
+            "Entity Name": "ANTIGUA \u0026 BARBUDA"
+          },
+          "95": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "95",
+            "Entity Name": "DOMINICA"
+          },
+          "96": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "96",
+            "Entity Name": "MONTSERRAT"
+          },
+          "97": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "97",
+            "Entity Name": "ST. LUCIA"
+          },
+          "98": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "98",
+            "Entity Name": "ST. VINCENT"
+          },
+          "99": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "99",
+            "Entity Name": "GLORIOSO IS."
+          },
+          "100": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "100",
+            "Entity Name": "ARGENTINA"
+          },
+          "101": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "101",
+            "Entity Name": "GOA",
+            "Deleted": "true"
+          },
+          "102": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "102",
+            "Entity Name": "GOLD COAST, TOGOLAND",
+            "Deleted": "true"
+          },
+          "103": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "103",
+            "Entity Name": "GUAM"
+          },
+          "104": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "104",
+            "Entity Name": "BOLIVIA"
+          },
+          "105": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "105",
+            "Entity Name": "GUANTANAMO BAY"
+          },
+          "106": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "106",
+            "Entity Name": "GUERNSEY"
+          },
+          "107": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "107",
+            "Entity Name": "GUINEA"
+          },
+          "108": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "108",
+            "Entity Name": "BRAZIL"
+          },
+          "109": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "109",
+            "Entity Name": "GUINEA-BISSAU"
+          },
+          "110": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "110",
+            "Entity Name": "HAWAII"
+          },
+          "111": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "111",
+            "Entity Name": "HEARD I."
+          },
+          "112": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "112",
+            "Entity Name": "CHILE"
+          },
+          "113": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "113",
+            "Entity Name": "IFNI",
+            "Deleted": "true"
+          },
+          "114": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "114",
+            "Entity Name": "ISLE OF MAN"
+          },
+          "115": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "115",
+            "Entity Name": "ITALIAN SOMALILAND",
+            "Deleted": "true"
+          },
+          "116": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "116",
+            "Entity Name": "COLOMBIA"
+          },
+          "117": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "117",
+            "Entity Name": "ITU HQ"
+          },
+          "118": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "118",
+            "Entity Name": "JAN MAYEN"
+          },
+          "119": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "119",
+            "Entity Name": "JAVA",
+            "Deleted": "true"
+          },
+          "120": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "120",
+            "Entity Name": "ECUADOR"
+          },
+          "122": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "122",
+            "Entity Name": "JERSEY"
+          },
+          "123": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "123",
+            "Entity Name": "JOHNSTON I."
+          },
+          "124": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "124",
+            "Entity Name": "JUAN DE NOVA, EUROPA"
+          },
+          "125": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "125",
+            "Entity Name": "JUAN FERNANDEZ IS."
+          },
+          "126": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "126",
+            "Entity Name": "KALININGRAD"
+          },
+          "127": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "127",
+            "Entity Name": "KAMARAN IS.",
+            "Deleted": "true"
+          },
+          "128": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "128",
+            "Entity Name": "KARELO-FINNISH REPUBLIC",
+            "Deleted": "true"
+          },
+          "129": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "129",
+            "Entity Name": "GUYANA"
+          },
+          "130": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "130",
+            "Entity Name": "KAZAKHSTAN"
+          },
+          "131": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "131",
+            "Entity Name": "KERGUELEN IS."
+          },
+          "132": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "132",
+            "Entity Name": "PARAGUAY"
+          },
+          "133": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "133",
+            "Entity Name": "KERMADEC IS."
+          },
+          "134": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "134",
+            "Entity Name": "KINGMAN REEF",
+            "Deleted": "true"
+          },
+          "135": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "135",
+            "Entity Name": "KYRGYZSTAN"
+          },
+          "136": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "136",
+            "Entity Name": "PERU"
+          },
+          "137": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "137",
+            "Entity Name": "REPUBLIC OF KOREA"
+          },
+          "138": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "138",
+            "Entity Name": "KURE I."
+          },
+          "139": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "139",
+            "Entity Name": "KURIA MURIA I.",
+            "Deleted": "true"
+          },
+          "140": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "140",
+            "Entity Name": "SURINAME"
+          },
+          "141": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "141",
+            "Entity Name": "FALKLAND IS."
+          },
+          "142": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "142",
+            "Entity Name": "LAKSHADWEEP IS."
+          },
+          "143": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "143",
+            "Entity Name": "LAOS"
+          },
+          "144": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "144",
+            "Entity Name": "URUGUAY"
+          },
+          "145": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "145",
+            "Entity Name": "LATVIA"
+          },
+          "146": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "146",
+            "Entity Name": "LITHUANIA"
+          },
+          "147": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "147",
+            "Entity Name": "LORD HOWE I."
+          },
+          "148": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "148",
+            "Entity Name": "VENEZUELA"
+          },
+          "149": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "149",
+            "Entity Name": "AZORES"
+          },
+          "150": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "150",
+            "Entity Name": "AUSTRALIA"
+          },
+          "151": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "151",
+            "Entity Name": "MALYJ VYSOTSKIJ I.",
+            "Deleted": "true"
+          },
+          "152": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "152",
+            "Entity Name": "MACAO"
+          },
+          "153": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "153",
+            "Entity Name": "MACQUARIE I."
+          },
+          "154": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "154",
+            "Entity Name": "YEMEN ARAB REPUBLIC",
+            "Deleted": "true"
+          },
+          "155": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "155",
+            "Entity Name": "MALAYA",
+            "Deleted": "true"
+          },
+          "157": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "157",
+            "Entity Name": "NAURU"
+          },
+          "158": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "158",
+            "Entity Name": "VANUATU"
+          },
+          "159": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "159",
+            "Entity Name": "MALDIVES"
+          },
+          "160": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "160",
+            "Entity Name": "TONGA"
+          },
+          "161": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "161",
+            "Entity Name": "MALPELO I."
+          },
+          "162": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "162",
+            "Entity Name": "NEW CALEDONIA"
+          },
+          "163": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "163",
+            "Entity Name": "PAPUA NEW GUINEA"
+          },
+          "164": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "164",
+            "Entity Name": "MANCHURIA",
+            "Deleted": "true"
+          },
+          "165": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "165",
+            "Entity Name": "MAURITIUS"
+          },
+          "166": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "166",
+            "Entity Name": "MARIANA IS."
+          },
+          "167": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "167",
+            "Entity Name": "MARKET REEF"
+          },
+          "168": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "168",
+            "Entity Name": "MARSHALL IS."
+          },
+          "169": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "169",
+            "Entity Name": "MAYOTTE"
+          },
+          "170": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "170",
+            "Entity Name": "NEW ZEALAND"
+          },
+          "171": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "171",
+            "Entity Name": "MELLISH REEF"
+          },
+          "172": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "172",
+            "Entity Name": "PITCAIRN I."
+          },
+          "173": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "173",
+            "Entity Name": "MICRONESIA"
+          },
+          "174": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "174",
+            "Entity Name": "MIDWAY I."
+          },
+          "175": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "175",
+            "Entity Name": "FRENCH POLYNESIA"
+          },
+          "176": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "176",
+            "Entity Name": "FIJI"
+          },
+          "177": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "177",
+            "Entity Name": "MINAMI TORISHIMA"
+          },
+          "178": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "178",
+            "Entity Name": "MINERVA REEF",
+            "Deleted": "true"
+          },
+          "179": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "179",
+            "Entity Name": "MOLDOVA"
+          },
+          "180": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "180",
+            "Entity Name": "MOUNT ATHOS"
+          },
+          "181": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "181",
+            "Entity Name": "MOZAMBIQUE"
+          },
+          "182": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "182",
+            "Entity Name": "NAVASSA I."
+          },
+          "183": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "183",
+            "Entity Name": "NETHERLANDS BORNEO",
+            "Deleted": "true"
+          },
+          "184": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "184",
+            "Entity Name": "NETHERLANDS NEW GUINEA",
+            "Deleted": "true"
+          },
+          "185": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "185",
+            "Entity Name": "SOLOMON IS."
+          },
+          "186": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "186",
+            "Entity Name": "NEWFOUNDLAND, LABRADOR",
+            "Deleted": "true"
+          },
+          "187": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "187",
+            "Entity Name": "NIGER"
+          },
+          "188": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "188",
+            "Entity Name": "NIUE"
+          },
+          "189": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "189",
+            "Entity Name": "NORFOLK I."
+          },
+          "190": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "190",
+            "Entity Name": "SAMOA"
+          },
+          "191": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "191",
+            "Entity Name": "NORTH COOK IS."
+          },
+          "192": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "192",
+            "Entity Name": "OGASAWARA"
+          },
+          "193": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "193",
+            "Entity Name": "OKINAWA (RYUKYU IS.)",
+            "Deleted": "true"
+          },
+          "194": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "194",
+            "Entity Name": "OKINO TORI-SHIMA",
+            "Deleted": "true"
+          },
+          "195": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "195",
+            "Entity Name": "ANNOBON I."
+          },
+          "196": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "196",
+            "Entity Name": "PALESTINE",
+            "Deleted": "true"
+          },
+          "197": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "197",
+            "Entity Name": "PALMYRA \u0026 JARVIS IS."
+          },
+          "198": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "198",
+            "Entity Name": "PAPUA TERRITORY",
+            "Deleted": "true"
+          },
+          "199": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "199",
+            "Entity Name": "PETER 1 I."
+          },
+          "200": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "200",
+            "Entity Name": "PORTUGUESE TIMOR",
+            "Deleted": "true"
+          },
+          "201": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "201",
+            "Entity Name": "PRINCE EDWARD \u0026 MARION IS."
+          },
+          "202": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "202",
+            "Entity Name": "PUERTO RICO"
+          },
+          "203": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "203",
+            "Entity Name": "ANDORRA"
+          },
+          "204": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "204",
+            "Entity Name": "REVILLAGIGEDO"
+          },
+          "205": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "205",
+            "Entity Name": "ASCENSION I."
+          },
+          "206": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "206",
+            "Entity Name": "AUSTRIA"
+          },
+          "207": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "207",
+            "Entity Name": "RODRIGUES I."
+          },
+          "208": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "208",
+            "Entity Name": "RUANDA-URUNDI",
+            "Deleted": "true"
+          },
+          "209": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "209",
+            "Entity Name": "BELGIUM"
+          },
+          "210": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "210",
+            "Entity Name": "SAAR",
+            "Deleted": "true"
+          },
+          "211": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "211",
+            "Entity Name": "SABLE I."
+          },
+          "212": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "212",
+            "Entity Name": "BULGARIA"
+          },
+          "213": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "213",
+            "Entity Name": "SAINT MARTIN"
+          },
+          "214": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "214",
+            "Entity Name": "CORSICA"
+          },
+          "215": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "215",
+            "Entity Name": "CYPRUS"
+          },
+          "216": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "216",
+            "Entity Name": "SAN ANDRES \u0026 PROVIDENCIA"
+          },
+          "217": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "217",
+            "Entity Name": "SAN FELIX \u0026 SAN AMBROSIO"
+          },
+          "218": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "218",
+            "Entity Name": "CZECHOSLOVAKIA",
+            "Deleted": "true"
+          },
+          "219": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "219",
+            "Entity Name": "SAO TOME \u0026 PRINCIPE"
+          },
+          "220": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "220",
+            "Entity Name": "SARAWAK",
+            "Deleted": "true"
+          },
+          "221": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "221",
+            "Entity Name": "DENMARK"
+          },
+          "222": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "222",
+            "Entity Name": "FAROE IS."
+          },
+          "223": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "223",
+            "Entity Name": "ENGLAND"
+          },
+          "224": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "224",
+            "Entity Name": "FINLAND"
+          },
+          "225": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "225",
+            "Entity Name": "SARDINIA"
+          },
+          "226": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "226",
+            "Entity Name": "SAUDI ARABIA/IRAQ NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "227": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "227",
+            "Entity Name": "FRANCE"
+          },
+          "228": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "228",
+            "Entity Name": "SERRANA BANK \u0026 RONCADOR CAY",
+            "Deleted": "true"
+          },
+          "229": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "229",
+            "Entity Name": "GERMAN DEMOCRATIC REPUBLIC",
+            "Deleted": "true"
+          },
+          "230": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "230",
+            "Entity Name": "FEDERAL REPUBLIC OF GERMANY"
+          },
+          "231": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "231",
+            "Entity Name": "SIKKIM",
+            "Deleted": "true"
+          },
+          "232": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "232",
+            "Entity Name": "SOMALIA"
+          },
+          "233": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "233",
+            "Entity Name": "GIBRALTAR"
+          },
+          "234": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "234",
+            "Entity Name": "SOUTH COOK IS."
+          },
+          "235": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "235",
+            "Entity Name": "SOUTH GEORGIA I."
+          },
+          "236": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "236",
+            "Entity Name": "GREECE"
+          },
+          "237": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "237",
+            "Entity Name": "GREENLAND"
+          },
+          "238": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "238",
+            "Entity Name": "SOUTH ORKNEY IS."
+          },
+          "239": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "239",
+            "Entity Name": "HUNGARY"
+          },
+          "240": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "240",
+            "Entity Name": "SOUTH SANDWICH IS."
+          },
+          "241": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "241",
+            "Entity Name": "SOUTH SHETLAND IS."
+          },
+          "242": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "242",
+            "Entity Name": "ICELAND"
+          },
+          "243": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "243",
+            "Entity Name": "PEOPLE\u0027S DEMOCRATIC REP. OF YEMEN",
+            "Deleted": "true"
+          },
+          "244": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "244",
+            "Entity Name": "SOUTHERN SUDAN",
+            "Deleted": "true"
+          },
+          "245": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "245",
+            "Entity Name": "IRELAND"
+          },
+          "246": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "246",
+            "Entity Name": "SOVEREIGN MILITARY ORDER OF MALTA"
+          },
+          "247": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "247",
+            "Entity Name": "SPRATLY IS."
+          },
+          "248": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "248",
+            "Entity Name": "ITALY"
+          },
+          "249": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "249",
+            "Entity Name": "ST. KITTS \u0026 NEVIS"
+          },
+          "250": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "250",
+            "Entity Name": "ST. HELENA"
+          },
+          "251": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "251",
+            "Entity Name": "LIECHTENSTEIN"
+          },
+          "252": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "252",
+            "Entity Name": "ST. PAUL I."
+          },
+          "253": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "253",
+            "Entity Name": "ST. PETER \u0026 ST. PAUL ROCKS"
+          },
+          "254": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "254",
+            "Entity Name": "LUXEMBOURG"
+          },
+          "255": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "255",
+            "Entity Name": "ST. MAARTEN, SABA, ST. EUSTATIUS",
+            "Deleted": "true"
+          },
+          "256": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "256",
+            "Entity Name": "MADEIRA IS."
+          },
+          "257": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "257",
+            "Entity Name": "MALTA"
+          },
+          "258": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "258",
+            "Entity Name": "SUMATRA",
+            "Deleted": "true"
+          },
+          "259": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "259",
+            "Entity Name": "SVALBARD"
+          },
+          "260": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "260",
+            "Entity Name": "MONACO"
+          },
+          "261": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "261",
+            "Entity Name": "SWAN IS.",
+            "Deleted": "true"
+          },
+          "262": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "262",
+            "Entity Name": "TAJIKISTAN"
+          },
+          "263": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "263",
+            "Entity Name": "NETHERLANDS"
+          },
+          "264": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "264",
+            "Entity Name": "TANGIER",
+            "Deleted": "true"
+          },
+          "265": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "265",
+            "Entity Name": "NORTHERN IRELAND"
+          },
+          "266": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "266",
+            "Entity Name": "NORWAY"
+          },
+          "267": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "267",
+            "Entity Name": "TERRITORY OF NEW GUINEA",
+            "Deleted": "true"
+          },
+          "268": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "268",
+            "Entity Name": "TIBET",
+            "Deleted": "true"
+          },
+          "269": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "269",
+            "Entity Name": "POLAND"
+          },
+          "270": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "270",
+            "Entity Name": "TOKELAU IS."
+          },
+          "271": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "271",
+            "Entity Name": "TRIESTE",
+            "Deleted": "true"
+          },
+          "272": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "272",
+            "Entity Name": "PORTUGAL"
+          },
+          "273": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "273",
+            "Entity Name": "TRINDADE \u0026 MARTIM VAZ IS."
+          },
+          "274": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "274",
+            "Entity Name": "TRISTAN DA CUNHA \u0026 GOUGH I."
+          },
+          "275": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "275",
+            "Entity Name": "ROMANIA"
+          },
+          "276": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "276",
+            "Entity Name": "TROMELIN I."
+          },
+          "277": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "277",
+            "Entity Name": "ST. PIERRE \u0026 MIQUELON"
+          },
+          "278": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "278",
+            "Entity Name": "SAN MARINO"
+          },
+          "279": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "279",
+            "Entity Name": "SCOTLAND"
+          },
+          "280": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "280",
+            "Entity Name": "TURKMENISTAN"
+          },
+          "281": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "281",
+            "Entity Name": "SPAIN"
+          },
+          "282": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "282",
+            "Entity Name": "TUVALU"
+          },
+          "283": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "283",
+            "Entity Name": "UK SOVEREIGN BASE AREAS ON CYPRUS"
+          },
+          "284": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "284",
+            "Entity Name": "SWEDEN"
+          },
+          "285": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "285",
+            "Entity Name": "VIRGIN IS."
+          },
+          "286": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "286",
+            "Entity Name": "UGANDA"
+          },
+          "287": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "287",
+            "Entity Name": "SWITZERLAND"
+          },
+          "288": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "288",
+            "Entity Name": "UKRAINE"
+          },
+          "289": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "289",
+            "Entity Name": "UNITED NATIONS HQ"
+          },
+          "291": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "291",
+            "Entity Name": "UNITED STATES OF AMERICA"
+          },
+          "292": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "292",
+            "Entity Name": "UZBEKISTAN"
+          },
+          "293": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "293",
+            "Entity Name": "VIET NAM"
+          },
+          "294": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "294",
+            "Entity Name": "WALES"
+          },
+          "295": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "295",
+            "Entity Name": "VATICAN"
+          },
+          "296": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "296",
+            "Entity Name": "SERBIA"
+          },
+          "297": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "297",
+            "Entity Name": "WAKE I."
+          },
+          "298": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "298",
+            "Entity Name": "WALLIS \u0026 FUTUNA IS."
+          },
+          "299": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "299",
+            "Entity Name": "WEST MALAYSIA"
+          },
+          "301": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "301",
+            "Entity Name": "W. KIRIBATI (GILBERT IS. )"
+          },
+          "302": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "302",
+            "Entity Name": "WESTERN SAHARA"
+          },
+          "303": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "303",
+            "Entity Name": "WILLIS I."
+          },
+          "304": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "304",
+            "Entity Name": "BAHRAIN"
+          },
+          "305": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "305",
+            "Entity Name": "BANGLADESH"
+          },
+          "306": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "306",
+            "Entity Name": "BHUTAN"
+          },
+          "307": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "307",
+            "Entity Name": "ZANZIBAR",
+            "Deleted": "true"
+          },
+          "308": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "308",
+            "Entity Name": "COSTA RICA"
+          },
+          "309": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "309",
+            "Entity Name": "MYANMAR"
+          },
+          "312": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "312",
+            "Entity Name": "CAMBODIA"
+          },
+          "315": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "315",
+            "Entity Name": "SRI LANKA"
+          },
+          "318": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "318",
+            "Entity Name": "CHINA"
+          },
+          "321": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "321",
+            "Entity Name": "HONG KONG"
+          },
+          "324": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "324",
+            "Entity Name": "INDIA"
+          },
+          "327": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "327",
+            "Entity Name": "INDONESIA"
+          },
+          "330": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "330",
+            "Entity Name": "IRAN"
+          },
+          "333": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "333",
+            "Entity Name": "IRAQ"
+          },
+          "336": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "336",
+            "Entity Name": "ISRAEL"
+          },
+          "339": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "339",
+            "Entity Name": "JAPAN"
+          },
+          "342": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "342",
+            "Entity Name": "JORDAN"
+          },
+          "344": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "344",
+            "Entity Name": "DEMOCRATIC PEOPLE\u0027S REP. OF KOREA"
+          },
+          "345": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "345",
+            "Entity Name": "BRUNEI DARUSSALAM"
+          },
+          "348": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "348",
+            "Entity Name": "KUWAIT"
+          },
+          "354": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "354",
+            "Entity Name": "LEBANON"
+          },
+          "363": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "363",
+            "Entity Name": "MONGOLIA"
+          },
+          "369": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "369",
+            "Entity Name": "NEPAL"
+          },
+          "370": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "370",
+            "Entity Name": "OMAN"
+          },
+          "372": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "372",
+            "Entity Name": "PAKISTAN"
+          },
+          "375": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "375",
+            "Entity Name": "PHILIPPINES"
+          },
+          "376": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "376",
+            "Entity Name": "QATAR"
+          },
+          "378": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "378",
+            "Entity Name": "SAUDI ARABIA"
+          },
+          "379": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "379",
+            "Entity Name": "SEYCHELLES"
+          },
+          "381": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "381",
+            "Entity Name": "SINGAPORE"
+          },
+          "382": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "382",
+            "Entity Name": "DJIBOUTI"
+          },
+          "384": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "384",
+            "Entity Name": "SYRIA"
+          },
+          "386": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "386",
+            "Entity Name": "TAIWAN"
+          },
+          "387": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "387",
+            "Entity Name": "THAILAND"
+          },
+          "390": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "390",
+            "Entity Name": "TURKEY"
+          },
+          "391": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "391",
+            "Entity Name": "UNITED ARAB EMIRATES"
+          },
+          "400": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "400",
+            "Entity Name": "ALGERIA"
+          },
+          "401": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "401",
+            "Entity Name": "ANGOLA"
+          },
+          "402": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "402",
+            "Entity Name": "BOTSWANA"
+          },
+          "404": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "404",
+            "Entity Name": "BURUNDI"
+          },
+          "406": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "406",
+            "Entity Name": "CAMEROON"
+          },
+          "408": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "408",
+            "Entity Name": "CENTRAL AFRICA"
+          },
+          "409": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "409",
+            "Entity Name": "CAPE VERDE"
+          },
+          "410": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "410",
+            "Entity Name": "CHAD"
+          },
+          "411": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "411",
+            "Entity Name": "COMOROS"
+          },
+          "412": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "412",
+            "Entity Name": "REPUBLIC OF THE CONGO"
+          },
+          "414": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "414",
+            "Entity Name": "DEMOCRATIC REPUBLIC OF THE CONGO"
+          },
+          "416": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "416",
+            "Entity Name": "BENIN"
+          },
+          "420": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "420",
+            "Entity Name": "GABON"
+          },
+          "422": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "422",
+            "Entity Name": "THE GAMBIA"
+          },
+          "424": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "424",
+            "Entity Name": "GHANA"
+          },
+          "428": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "428",
+            "Entity Name": "COTE D\u0027IVOIRE"
+          },
+          "430": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "430",
+            "Entity Name": "KENYA"
+          },
+          "432": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "432",
+            "Entity Name": "LESOTHO"
+          },
+          "434": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "434",
+            "Entity Name": "LIBERIA"
+          },
+          "436": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "436",
+            "Entity Name": "LIBYA"
+          },
+          "438": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "438",
+            "Entity Name": "MADAGASCAR"
+          },
+          "440": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "440",
+            "Entity Name": "MALAWI"
+          },
+          "442": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "442",
+            "Entity Name": "MALI"
+          },
+          "444": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "444",
+            "Entity Name": "MAURITANIA"
+          },
+          "446": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "446",
+            "Entity Name": "MOROCCO"
+          },
+          "450": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "450",
+            "Entity Name": "NIGERIA"
+          },
+          "452": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "452",
+            "Entity Name": "ZIMBABWE"
+          },
+          "453": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "453",
+            "Entity Name": "REUNION I."
+          },
+          "454": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "454",
+            "Entity Name": "RWANDA"
+          },
+          "456": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "456",
+            "Entity Name": "SENEGAL"
+          },
+          "458": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "458",
+            "Entity Name": "SIERRA LEONE"
+          },
+          "460": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "460",
+            "Entity Name": "ROTUMA I."
+          },
+          "462": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "462",
+            "Entity Name": "REPUBLIC OF SOUTH AFRICA"
+          },
+          "464": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "464",
+            "Entity Name": "NAMIBIA"
+          },
+          "466": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "466",
+            "Entity Name": "SUDAN"
+          },
+          "468": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "468",
+            "Entity Name": "KINGDOM OF ESWATINI"
+          },
+          "470": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "470",
+            "Entity Name": "TANZANIA"
+          },
+          "474": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "474",
+            "Entity Name": "TUNISIA"
+          },
+          "478": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "478",
+            "Entity Name": "EGYPT"
+          },
+          "480": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "480",
+            "Entity Name": "BURKINA FASO"
+          },
+          "482": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "482",
+            "Entity Name": "ZAMBIA"
+          },
+          "483": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "483",
+            "Entity Name": "TOGO"
+          },
+          "488": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "488",
+            "Entity Name": "WALVIS BAY",
+            "Deleted": "true"
+          },
+          "489": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "489",
+            "Entity Name": "CONWAY REEF"
+          },
+          "490": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "490",
+            "Entity Name": "BANABA I. (OCEAN I.)"
+          },
+          "492": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "492",
+            "Entity Name": "YEMEN"
+          },
+          "493": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "493",
+            "Entity Name": "PENGUIN IS.",
+            "Deleted": "true"
+          },
+          "497": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "497",
+            "Entity Name": "CROATIA"
+          },
+          "499": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "499",
+            "Entity Name": "SLOVENIA"
+          },
+          "501": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "501",
+            "Entity Name": "BOSNIA-HERZEGOVINA"
+          },
+          "502": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "502",
+            "Entity Name": "NORTH MACEDONIA (REPUBLIC OF)"
+          },
+          "503": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "503",
+            "Entity Name": "CZECH REPUBLIC"
+          },
+          "504": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "504",
+            "Entity Name": "SLOVAK REPUBLIC"
+          },
+          "505": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "505",
+            "Entity Name": "PRATAS I."
+          },
+          "506": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "506",
+            "Entity Name": "SCARBOROUGH REEF"
+          },
+          "507": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "507",
+            "Entity Name": "TEMOTU PROVINCE"
+          },
+          "508": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "508",
+            "Entity Name": "AUSTRAL I."
+          },
+          "509": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "509",
+            "Entity Name": "MARQUESAS IS."
+          },
+          "510": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "510",
+            "Entity Name": "PALESTINE"
+          },
+          "511": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "511",
+            "Entity Name": "TIMOR-LESTE"
+          },
+          "512": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "512",
+            "Entity Name": "CHESTERFIELD IS."
+          },
+          "513": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "513",
+            "Entity Name": "DUCIE I."
+          },
+          "514": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "514",
+            "Entity Name": "MONTENEGRO"
+          },
+          "515": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "515",
+            "Entity Name": "SWAINS I."
+          },
+          "516": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "516",
+            "Entity Name": "SAINT BARTHELEMY"
+          },
+          "517": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "517",
+            "Entity Name": "CURACAO"
+          },
+          "518": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "518",
+            "Entity Name": "SINT MAARTEN"
+          },
+          "519": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "519",
+            "Entity Name": "SABA \u0026 ST. EUSTATIUS"
+          },
+          "520": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "520",
+            "Entity Name": "BONAIRE"
+          },
+          "521": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "521",
+            "Entity Name": "SOUTH SUDAN (REPUBLIC OF)"
+          },
+          "522": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "522",
+            "Entity Name": "REPUBLIC OF KOSOVO"
+          }
+        }
+      },
+      "EQSL_AG": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "Y",
+            "Description": "The QSO\u0027s callsign holds eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "N": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "N",
+            "Description": "The QSO\u0027s callsign does not hold eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "U": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "U",
+            "Description": "Unspecified (Default)"
+          }
+        }
+      },
+      "Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Mode",
+          "Submodes",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AM": {
+            "Enumeration Name": "Mode",
+            "Mode": "AM"
+          },
+          "ARDOP": {
+            "Enumeration Name": "Mode",
+            "Mode": "ARDOP",
+            "Description": "Amateur Radio Digital Open Protocol"
+          },
+          "ATV": {
+            "Enumeration Name": "Mode",
+            "Mode": "ATV"
+          },
+          "CHIP": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP",
+            "Submodes": "CHIP64,CHIP128"
+          },
+          "CLO": {
+            "Enumeration Name": "Mode",
+            "Mode": "CLO"
+          },
+          "CONTESTI": {
+            "Enumeration Name": "Mode",
+            "Mode": "CONTESTI"
+          },
+          "CW": {
+            "Enumeration Name": "Mode",
+            "Mode": "CW",
+            "Submodes": "PCW"
+          },
+          "DIGITALVOICE": {
+            "Enumeration Name": "Mode",
+            "Mode": "DIGITALVOICE",
+            "Submodes": "C4FM,DMR,DSTAR,FREEDV,M17"
+          },
+          "DOMINO": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINO",
+            "Submodes": "DOM-M,DOM4,DOM5,DOM8,DOM11,DOM16,DOM22,DOM44,DOM88,DOMINOEX,DOMINOF"
+          },
+          "DYNAMIC": {
+            "Enumeration Name": "Mode",
+            "Mode": "DYNAMIC",
+            "Submodes": "FREEDATA,VARA HF,VARA SATELLITE,VARA FM 1200,VARA FM 9600"
+          },
+          "FAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "FAX"
+          },
+          "FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "FM"
+          },
+          "FSK441": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK441"
+          },
+          "FSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK",
+            "Submodes": "SCAMP_FAST,SCAMP_SLOW,SCAMP_VSLOW",
+            "Description": "Frequency shift keying"
+          },
+          "FT8": {
+            "Enumeration Name": "Mode",
+            "Mode": "FT8",
+            "Description": "Franke-Taylor design, 8-FSK modulation"
+          },
+          "HELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL",
+            "Submodes": "FMHELL,FSKH105,FSKH245,FSKHELL,HELL80,HELLX5,HELLX9,HFSK,PSKHELL,SLOWHELL"
+          },
+          "ISCAT": {
+            "Enumeration Name": "Mode",
+            "Mode": "ISCAT",
+            "Submodes": "ISCAT-A,ISCAT-B"
+          },
+          "JT4": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4",
+            "Submodes": "JT4A,JT4B,JT4C,JT4D,JT4E,JT4F,JT4G"
+          },
+          "JT6M": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT6M"
+          },
+          "JT9": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT9",
+            "Submodes": "JT9-1,JT9-2,JT9-5,JT9-10,JT9-30,JT9A,JT9B,JT9C,JT9D,JT9E,JT9E FAST,JT9F,JT9F FAST,JT9G,JT9G FAST,JT9H,JT9H FAST"
+          },
+          "JT44": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT44"
+          },
+          "JT65": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65",
+            "Submodes": "JT65A,JT65B,JT65B2,JT65C,JT65C2"
+          },
+          "MFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK",
+            "Submodes": "FSQCALL,FST4,FST4W,FT2,FT4,JS8,JTMS,MFSK4,MFSK8,MFSK11,MFSK16,MFSK22,MFSK31,MFSK32,MFSK64,MFSK64L,MFSK128 MFSK128L,Q65"
+          },
+          "MSK144": {
+            "Enumeration Name": "Mode",
+            "Mode": "MSK144"
+          },
+          "MTONE": {
+            "Enumeration Name": "Mode",
+            "Mode": "MTONE",
+            "Submodes": "SCAMP_OO,SCAMP_OO_SLW",
+            "Description": "Single modulated tone"
+          },
+          "MT63": {
+            "Enumeration Name": "Mode",
+            "Mode": "MT63"
+          },
+          "OFDM": {
+            "Enumeration Name": "Mode",
+            "Mode": "OFDM",
+            "Submodes": "RIBBIT_PIX,RIBBIT_SMS",
+            "Description": "Orthogonal Frequency-Division Multiplexing including COFDM"
+          },
+          "OLIVIA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OLIVIA",
+            "Submodes": "OLIVIA 4/125,OLIVIA 4/250,OLIVIA 8/250,OLIVIA 8/500,OLIVIA 16/500,OLIVIA 16/1000,OLIVIA 32/1000"
+          },
+          "OPERA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OPERA",
+            "Submodes": "OPERA-BEACON,OPERA-QSO"
+          },
+          "PAC": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC",
+            "Submodes": "PAC2,PAC3,PAC4"
+          },
+          "PAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX",
+            "Submodes": "PAX2"
+          },
+          "PKT": {
+            "Enumeration Name": "Mode",
+            "Mode": "PKT"
+          },
+          "PSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK",
+            "Submodes": "8PSK125,8PSK125F,8PSK125FL,8PSK250,8PSK250F,8PSK250FL,8PSK500,8PSK500F,8PSK1000,8PSK1000F,8PSK1200F,FSK31,PSK10,PSK31,PSK63,PSK63F,PSK63RC4,PSK63RC5,PSK63RC10,PSK63RC20,PSK63RC32,PSK125,PSK125C12,PSK125R,PSK125RC10,PSK125RC12,PSK125RC16,PSK125RC4,PSK125RC5,PSK250,PSK250C6,PSK250R,PSK250RC2,PSK250RC3,PSK250RC5,PSK250RC6,PSK250RC7,PSK500,PSK500C2,PSK500C4,PSK500R,PSK500RC2,PSK500RC3,PSK500RC4,PSK800C2,PSK800RC2,PSK1000,PSK1000C2,PSK1000R,PSK1000RC2,PSKAM10,PSKAM31,PSKAM50,PSKFEC31,QPSK31,QPSK63,QPSK125,QPSK250,QPSK500,SIM31"
+          },
+          "PSK2K": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK2K"
+          },
+          "Q15": {
+            "Enumeration Name": "Mode",
+            "Mode": "Q15"
+          },
+          "QRA64": {
+            "Enumeration Name": "Mode",
+            "Mode": "QRA64",
+            "Submodes": "QRA64A,QRA64B,QRA64C,QRA64D,QRA64E"
+          },
+          "ROS": {
+            "Enumeration Name": "Mode",
+            "Mode": "ROS",
+            "Submodes": "ROS-EME,ROS-HF,ROS-MF"
+          },
+          "RTTY": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTY",
+            "Submodes": "ASCI"
+          },
+          "RTTYM": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTYM"
+          },
+          "SSB": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSB",
+            "Submodes": "LSB,USB"
+          },
+          "SSTV": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSTV"
+          },
+          "T10": {
+            "Enumeration Name": "Mode",
+            "Mode": "T10",
+            "Description": "Tonal 10 digital mode with focus on sensitivity, band capacity and resistance to the HF Doppler frequency spread"
+          },
+          "THOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "THOR",
+            "Submodes": "THOR-M,THOR4,THOR5,THOR8,THOR11,THOR16,THOR22,THOR25X4,THOR50X1,THOR50X2,THOR100"
+          },
+          "THRB": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRB",
+            "Submodes": "THRBX,THRBX1,THRBX2,THRBX4,THROB1,THROB2,THROB4"
+          },
+          "TOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "TOR",
+            "Submodes": "AMTORFEC,GTOR,NAVTEX,SITORB"
+          },
+          "V4": {
+            "Enumeration Name": "Mode",
+            "Mode": "V4"
+          },
+          "VOI": {
+            "Enumeration Name": "Mode",
+            "Mode": "VOI"
+          },
+          "WINMOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WINMOR"
+          },
+          "WSPR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WSPR"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Mode",
+            "Mode": "AMTORFEC",
+            "Import-only": "true"
+          },
+          "ASCI": {
+            "Enumeration Name": "Mode",
+            "Mode": "ASCI",
+            "Import-only": "true"
+          },
+          "C4FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "C4FM",
+            "Description": "C4FM 4-level FSK Technology Imported QSOs with \u003CMODE:4\u003EC4FM\u003E must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:4\u003EC4FM",
+            "Import-only": "true"
+          },
+          "CHIP64": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP64",
+            "Import-only": "true"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP128",
+            "Import-only": "true"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINOF",
+            "Import-only": "true"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Mode",
+            "Mode": "DSTAR",
+            "Description": "Digital Smart Technologies for Amateur Radio Imported QSOs with \u003CMODE:5\u003EDSTAR must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:5\u003EDSTAR",
+            "Import-only": "true"
+          },
+          "FMHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "FMHELL",
+            "Import-only": "true"
+          },
+          "FSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK31",
+            "Import-only": "true"
+          },
+          "GTOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "GTOR",
+            "Import-only": "true"
+          },
+          "HELL80": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL80",
+            "Import-only": "true"
+          },
+          "HFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "HFSK",
+            "Import-only": "true"
+          },
+          "JT4A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4A",
+            "Import-only": "true"
+          },
+          "JT4B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4B",
+            "Import-only": "true"
+          },
+          "JT4C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4C",
+            "Import-only": "true"
+          },
+          "JT4D": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4D",
+            "Import-only": "true"
+          },
+          "JT4E": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4E",
+            "Import-only": "true"
+          },
+          "JT4F": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4F",
+            "Import-only": "true"
+          },
+          "JT4G": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4G",
+            "Import-only": "true"
+          },
+          "JT65A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65A",
+            "Import-only": "true"
+          },
+          "JT65B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65B",
+            "Import-only": "true"
+          },
+          "JT65C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65C",
+            "Import-only": "true"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK8",
+            "Import-only": "true"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK16",
+            "Import-only": "true"
+          },
+          "PAC2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC2",
+            "Import-only": "true"
+          },
+          "PAC3": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC3",
+            "Import-only": "true"
+          },
+          "PAX2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX2",
+            "Import-only": "true"
+          },
+          "PCW": {
+            "Enumeration Name": "Mode",
+            "Mode": "PCW",
+            "Import-only": "true"
+          },
+          "PSK10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK10",
+            "Import-only": "true"
+          },
+          "PSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK31",
+            "Import-only": "true"
+          },
+          "PSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63",
+            "Import-only": "true"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63F",
+            "Import-only": "true"
+          },
+          "PSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK125",
+            "Import-only": "true"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM10",
+            "Import-only": "true"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM31",
+            "Import-only": "true"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM50",
+            "Import-only": "true"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKFEC31",
+            "Import-only": "true"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKHELL",
+            "Import-only": "true"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK31",
+            "Import-only": "true"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK63",
+            "Import-only": "true"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK125",
+            "Import-only": "true"
+          },
+          "THRBX": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRBX",
+            "Import-only": "true"
+          }
+        }
+      },
+      "Morse_Key_Type": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Characteristics",
+          "Morse Composition",
+          "Examples",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "SK": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SK",
+            "Meaning": "Straight Key",
+            "Characteristics": "a single control which actuates a single switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "Lionel J-38"
+          },
+          "SS": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SS",
+            "Meaning": "Sideswiper",
+            "Characteristics": "a single control which actuates a SPDT (single poll, double throw) switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "W1SFR Green Machine Torsion Bar Cootie"
+          },
+          "BUG": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "BUG",
+            "Meaning": "Mechanical semi-automatic keyer or Bug",
+            "Characteristics": "a control which actuates a switch as well as a control which actuates a spring and pendulum mechanism which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and a human makes the dahs and builds characters.",
+            "Examples": "Vibroplex Blue Racer Deluxe"
+          },
+          "FAB": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "FAB",
+            "Meaning": "Mechanical fully-automatic keyer or Bug",
+            "Characteristics": "a control which actuates one of two separate spring and pendulum mechanisms at a time, each of which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds characters.",
+            "Examples": "GHD GN209FA fully-automatic bug"
+          },
+          "SP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SP",
+            "Meaning": "Single Paddle",
+            "Characteristics": "a single control which actuates two independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "American Morse Mini-B"
+          },
+          "DP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "DP",
+            "Meaning": "Dual Paddle",
+            "Characteristics": "two controls which actuate independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "Begali Sculpture, VK3IL pressure paddles, M0UKD capacitive touch paddles"
+          },
+          "CPU": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "CPU",
+            "Meaning": "Computer Driven",
+            "Characteristics": "an electronic device performs the actuation of the switch.",
+            "Morse Composition": "a machine makes the dits and dahs to build the characters.",
+            "Examples": "N1MM\u002B Logging Software"
+          }
+        }
+      },
+      "Primary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Primary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Contained Within",
+          "Oblast #",
+          "CQ Zone",
+          "ITU Zone",
+          "Prefix",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NS.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "QC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QC",
+            "Primary Administrative Subdivision": "Québec",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "04,09"
+          },
+          "ON.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ON",
+            "Primary Administrative Subdivision": "Ontario",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "MB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Manitoba",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "SK.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Saskatchewan",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03"
+          },
+          "AB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alberta",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "02"
+          },
+          "BC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "British Columbia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "03",
+            "ITU Zone": "02"
+          },
+          "NT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northwest Territories",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01,02,04",
+            "ITU Zone": "03,04,75"
+          },
+          "NB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NL.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Newfoundland and Labrador",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "09"
+          },
+          "YT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YT",
+            "Primary Administrative Subdivision": "Yukon",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01",
+            "ITU Zone": "02"
+          },
+          "PE.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NU.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nunavut",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02",
+            "ITU Zone": "04,09"
+          },
+          "001.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "001",
+            "Primary Administrative Subdivision": "Brändö",
+            "DXCC Entity Code": "5"
+          },
+          "002.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "002",
+            "Primary Administrative Subdivision": "Eckerö",
+            "DXCC Entity Code": "5"
+          },
+          "003.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "003",
+            "Primary Administrative Subdivision": "Finström",
+            "DXCC Entity Code": "5"
+          },
+          "004.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "004",
+            "Primary Administrative Subdivision": "Föglö",
+            "DXCC Entity Code": "5"
+          },
+          "005.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "005",
+            "Primary Administrative Subdivision": "Geta",
+            "DXCC Entity Code": "5"
+          },
+          "006.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "006",
+            "Primary Administrative Subdivision": "Hammarland",
+            "DXCC Entity Code": "5"
+          },
+          "007.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "007",
+            "Primary Administrative Subdivision": "Jomala",
+            "DXCC Entity Code": "5"
+          },
+          "008.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "008",
+            "Primary Administrative Subdivision": "Kumlinge",
+            "DXCC Entity Code": "5"
+          },
+          "009.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "009",
+            "Primary Administrative Subdivision": "Kökar",
+            "DXCC Entity Code": "5"
+          },
+          "010.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "010",
+            "Primary Administrative Subdivision": "Lemland",
+            "DXCC Entity Code": "5"
+          },
+          "011.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "011",
+            "Primary Administrative Subdivision": "Lumparland",
+            "DXCC Entity Code": "5"
+          },
+          "012.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "012",
+            "Primary Administrative Subdivision": "Maarianhamina",
+            "DXCC Entity Code": "5"
+          },
+          "013.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "013",
+            "Primary Administrative Subdivision": "Saltvik",
+            "DXCC Entity Code": "5"
+          },
+          "014.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "014",
+            "Primary Administrative Subdivision": "Sottunga",
+            "DXCC Entity Code": "5"
+          },
+          "015.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Sund",
+            "DXCC Entity Code": "5"
+          },
+          "016.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "016",
+            "Primary Administrative Subdivision": "Vårdö",
+            "DXCC Entity Code": "5"
+          },
+          "051.5.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "051",
+            "Primary Administrative Subdivision": "Märket",
+            "DXCC Entity Code": "5",
+            "Deleted": "true"
+          },
+          "AK.6": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AK",
+            "Primary Administrative Subdivision": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AN.11": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Andaman and Nicobar Islands",
+            "DXCC Entity Code": "11",
+            "Comments": "Union territory"
+          },
+          "UO.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UO",
+            "Primary Administrative Subdivision": "Ust’-Ordynsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "174",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-01-01"
+          },
+          "AB.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Aginsky Buryatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "175",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-03-01"
+          },
+          "CB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Chelyabinsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "165",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Chelyabinskaya oblast"
+          },
+          "SV.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Sverdlovskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "154",
+            "CQ Zone": "17",
+            "ITU Zone": "30"
+          },
+          "PM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Perm\u0060",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "for contacts made on or after 2005-12-01; Permskaya oblast"
+          },
+          "PM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Permskaya Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "KP.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KP",
+            "Primary Administrative Subdivision": "Komi-Permyatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "141",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "TO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tomsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "158",
+            "CQ Zone": "18",
+            "ITU Zone": "30",
+            "Comments": "Tomskaya oblast"
+          },
+          "HM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khanty-Mansyisky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "162",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "YN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yamalo-Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "163",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "TN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tyumen\u0027",
+            "DXCC Entity Code": "15",
+            "Oblast #": "161",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Tyumenskaya oblast"
+          },
+          "OM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OM",
+            "Primary Administrative Subdivision": "Omsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "146",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Omskaya oblast"
+          },
+          "NS.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Novosibirsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "145",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Novosibirskaya oblast"
+          },
+          "KN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KN",
+            "Primary Administrative Subdivision": "Kurgan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "134",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Kurganskaya oblast"
+          },
+          "OB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OB",
+            "Primary Administrative Subdivision": "Orenburg",
+            "DXCC Entity Code": "15",
+            "Oblast #": "167",
+            "CQ Zone": "S=16 T=17",
+            "ITU Zone": "30",
+            "Comments": "Orenburgskaya oblast"
+          },
+          "KE.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kemerovo",
+            "DXCC Entity Code": "15",
+            "Oblast #": "130",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Kemerovskaya oblast"
+          },
+          "BA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Republic of Bashkortostan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "84",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "KO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Republic of Komi",
+            "DXCC Entity Code": "15",
+            "Oblast #": "90",
+            "CQ Zone": "17",
+            "ITU Zone": "20"
+          },
+          "AL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Altaysky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "99",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "GA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Republic Gorny Altay",
+            "DXCC Entity Code": "15",
+            "Oblast #": "100",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "KK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Krasnoyarsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "103",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Krasnoyarsk Kraj"
+          },
+          "TM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Taymyr Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "105",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "HK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HK",
+            "Primary Administrative Subdivision": "Khabarovsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "110",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Khabarovsky Kraj"
+          },
+          "EA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EA",
+            "Primary Administrative Subdivision": "Yevreyskaya Autonomous Oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "111",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "SL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sakhalin",
+            "DXCC Entity Code": "15",
+            "Oblast #": "153",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Sakhalinskaya oblast"
+          },
+          "EV.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evenkiysky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "106",
+            "CQ Zone": "18",
+            "ITU Zone": "22",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "MG.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Magadan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "138",
+            "CQ Zone": "19",
+            "ITU Zone": "24",
+            "Comments": "Magadanskaya oblast"
+          },
+          "AM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amurskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "112",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "CK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CK",
+            "Primary Administrative Subdivision": "Chukotka Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "139",
+            "CQ Zone": "19",
+            "ITU Zone": "26"
+          },
+          "PK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Primorsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "107",
+            "CQ Zone": "19",
+            "ITU Zone": "34"
+          },
+          "BU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Republic of Buryatia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "85",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "YA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Republic of Sakha",
+            "DXCC Entity Code": "15",
+            "Oblast #": "98",
+            "CQ Zone": "19",
+            "ITU Zone": "32"
+          },
+          "IR.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IR",
+            "Primary Administrative Subdivision": "Irkutsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "124",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Irkutskaya oblast"
+          },
+          "CT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Zabaykalsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "166",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Comments": "referred to as Chita (Chitinskaya oblast) before 2008-03-01"
+          },
+          "HA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Republic of Khakassia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "104",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "KY.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Koryaksky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "129",
+            "CQ Zone": "19",
+            "ITU Zone": "25",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "TU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Republic of Tuva",
+            "DXCC Entity Code": "15",
+            "Oblast #": "159",
+            "CQ Zone": "23",
+            "ITU Zone": "32"
+          },
+          "KT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KT",
+            "Primary Administrative Subdivision": "Kamchatka",
+            "DXCC Entity Code": "15",
+            "Oblast #": "128",
+            "CQ Zone": "19",
+            "ITU Zone": "35",
+            "Comments": "Kamchatskaya oblast"
+          },
+          "IB.21": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IB",
+            "Primary Administrative Subdivision": "Balears",
+            "DXCC Entity Code": "21"
+          },
+          "MI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Minsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Minskaya voblasts\u0027"
+          },
+          "BR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brest",
+            "DXCC Entity Code": "27",
+            "Comments": "Brestskaya voblasts\u0027"
+          },
+          "HR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Grodno",
+            "DXCC Entity Code": "27",
+            "Comments": "Hrodzenskaya voblasts\u0027"
+          },
+          "VI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vitebsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Vitsyebskaya voblasts\u0027"
+          },
+          "MA.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mogilev",
+            "DXCC Entity Code": "27",
+            "Comments": "Mahilyowskaya voblasts\u0027"
+          },
+          "HO.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Gomel",
+            "DXCC Entity Code": "27",
+            "Comments": "Homyel\u0027skaya voblasts\u0027"
+          },
+          "HM.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Horad Minsk",
+            "DXCC Entity Code": "27"
+          },
+          "GC.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Las Palmas",
+            "DXCC Entity Code": "29"
+          },
+          "TF.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TF",
+            "Primary Administrative Subdivision": "Santa Cruz de Tenerife",
+            "DXCC Entity Code": "29"
+          },
+          "CE.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceuta",
+            "DXCC Entity Code": "32"
+          },
+          "ML.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Melilla",
+            "DXCC Entity Code": "32"
+          },
+          "COL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COL",
+            "Primary Administrative Subdivision": "Colima",
+            "DXCC Entity Code": "50"
+          },
+          "DF.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "50",
+            "Import-only": "true",
+            "Comments": "replaced by CMX"
+          },
+          "CMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CMX",
+            "Primary Administrative Subdivision": "Ciudad de México",
+            "DXCC Entity Code": "50"
+          },
+          "EMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMX",
+            "Primary Administrative Subdivision": "Estado de México",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "MEX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MEX",
+            "Primary Administrative Subdivision": "México",
+            "DXCC Entity Code": "50"
+          },
+          "GTO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTO",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "GUA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUA",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50"
+          },
+          "HGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HGO",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "HID.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HID",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50"
+          },
+          "JAL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JAL",
+            "Primary Administrative Subdivision": "Jalisco",
+            "DXCC Entity Code": "50"
+          },
+          "MIC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michoacán de Ocampo",
+            "DXCC Entity Code": "50"
+          },
+          "MOR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOR",
+            "Primary Administrative Subdivision": "Morelos",
+            "DXCC Entity Code": "50"
+          },
+          "NAY.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAY",
+            "Primary Administrative Subdivision": "Nayarit",
+            "DXCC Entity Code": "50"
+          },
+          "PUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUE",
+            "Primary Administrative Subdivision": "Puebla",
+            "DXCC Entity Code": "50"
+          },
+          "QRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QRO",
+            "Primary Administrative Subdivision": "Querétaro de Arteaga",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "QUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Querétaro",
+            "DXCC Entity Code": "50"
+          },
+          "TLX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLX",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TLA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLA",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50"
+          },
+          "VER.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VER",
+            "Primary Administrative Subdivision": "Veracruz de Ignacio de la Llave",
+            "DXCC Entity Code": "50"
+          },
+          "AGS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "AGU.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGU",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50"
+          },
+          "BC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "BCN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCN",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50"
+          },
+          "BCS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCS",
+            "Primary Administrative Subdivision": "Baja California Sur",
+            "DXCC Entity Code": "50"
+          },
+          "CHH.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHH",
+            "Primary Administrative Subdivision": "Chihuahua",
+            "DXCC Entity Code": "50"
+          },
+          "COA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COA",
+            "Primary Administrative Subdivision": "Coahuila de Zaragoza",
+            "DXCC Entity Code": "50"
+          },
+          "DGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DGO",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "DUR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DUR",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50"
+          },
+          "NL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nuevo Leon",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "NLE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NLE",
+            "Primary Administrative Subdivision": "Nuevo León",
+            "DXCC Entity Code": "50"
+          },
+          "SLP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLP",
+            "Primary Administrative Subdivision": "San Luis Potosí",
+            "DXCC Entity Code": "50"
+          },
+          "SIN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIN",
+            "Primary Administrative Subdivision": "Sinaloa",
+            "DXCC Entity Code": "50"
+          },
+          "SON.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SON",
+            "Primary Administrative Subdivision": "Sonora",
+            "DXCC Entity Code": "50"
+          },
+          "TMS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TMS",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAM",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50"
+          },
+          "ZAC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAC",
+            "Primary Administrative Subdivision": "Zacatecas",
+            "DXCC Entity Code": "50"
+          },
+          "CAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Campeche",
+            "DXCC Entity Code": "50"
+          },
+          "CHS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHS",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "CHP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHP",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50"
+          },
+          "GRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GRO",
+            "Primary Administrative Subdivision": "Guerrero",
+            "DXCC Entity Code": "50"
+          },
+          "OAX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OAX",
+            "Primary Administrative Subdivision": "Oaxaca",
+            "DXCC Entity Code": "50"
+          },
+          "QTR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QTR",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "ROO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROO",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50"
+          },
+          "TAB.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAB",
+            "Primary Administrative Subdivision": "Tabasco",
+            "DXCC Entity Code": "50"
+          },
+          "YUC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUC",
+            "Primary Administrative Subdivision": "Yucatán",
+            "DXCC Entity Code": "50"
+          },
+          "SP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "City of St. Petersburg",
+            "DXCC Entity Code": "54",
+            "Oblast #": "169",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "LO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "136",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Republic of Karelia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "88",
+            "CQ Zone": "16",
+            "ITU Zone": "19"
+          },
+          "AR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "113",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "NO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "54",
+            "Oblast #": "114",
+            "CQ Zone": "16",
+            "ITU Zone": "20"
+          },
+          "VO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Vologda",
+            "DXCC Entity Code": "54",
+            "Oblast #": "120",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vologodskaya oblast"
+          },
+          "NV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Novgorodskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "144",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "PS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pskov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "149",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Pskovskaya oblast"
+          },
+          "MU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murmansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "143",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Murmanskaya oblast"
+          },
+          "MA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "City of Moscow",
+            "DXCC Entity Code": "54",
+            "Oblast #": "170",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Moscowskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "142",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "OR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oryel",
+            "DXCC Entity Code": "54",
+            "Oblast #": "147",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Orlovskaya oblast"
+          },
+          "LP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LP",
+            "Primary Administrative Subdivision": "Lipetsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "137",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Lipetskaya oblast"
+          },
+          "TV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Tver\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "126",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tverskaya oblast"
+          },
+          "SM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smolensk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "155",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Smolenskaya oblast"
+          },
+          "YR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YR",
+            "Primary Administrative Subdivision": "Yaroslavl",
+            "DXCC Entity Code": "54",
+            "Oblast #": "168",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Yaroslavskaya oblast"
+          },
+          "KS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kostroma",
+            "DXCC Entity Code": "54",
+            "Oblast #": "132",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kostromskaya oblast"
+          },
+          "TL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tula",
+            "DXCC Entity Code": "54",
+            "Oblast #": "160",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tul\u0027skaya oblast"
+          },
+          "VR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Voronezh",
+            "DXCC Entity Code": "54",
+            "Oblast #": "121",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Voronezhskaya oblast"
+          },
+          "TB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TB",
+            "Primary Administrative Subdivision": "Tambov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "157",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tambovskaya oblast"
+          },
+          "RA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ryazan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "151",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ryazanskaya oblast"
+          },
+          "NN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NN",
+            "Primary Administrative Subdivision": "Nizhni Novgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "122",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Nizhegorodskaya oblast"
+          },
+          "IV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Ivanovo",
+            "DXCC Entity Code": "54",
+            "Oblast #": "123",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ivanovskaya oblast"
+          },
+          "VL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vladimir",
+            "DXCC Entity Code": "54",
+            "Oblast #": "119",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vladimirskaya oblast"
+          },
+          "KU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kursk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "135",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kurskaya oblast"
+          },
+          "KG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KG",
+            "Primary Administrative Subdivision": "Kaluga",
+            "DXCC Entity Code": "54",
+            "Oblast #": "127",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kaluzhskaya oblast"
+          },
+          "BR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bryansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "118",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Bryanskaya oblast"
+          },
+          "BO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Belgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "117",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Belgorodskaya oblast"
+          },
+          "VG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VG",
+            "Primary Administrative Subdivision": "Volgograd",
+            "DXCC Entity Code": "54",
+            "Oblast #": "156",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Volgogradskaya oblast"
+          },
+          "SA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Saratov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "152",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Saratovskaya oblast"
+          },
+          "PE.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Penza",
+            "DXCC Entity Code": "54",
+            "Oblast #": "148",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Penzenskaya oblast"
+          },
+          "SR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Samara",
+            "DXCC Entity Code": "54",
+            "Oblast #": "133",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Samarskaya oblast"
+          },
+          "UL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UL",
+            "Primary Administrative Subdivision": "Ulyanovsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "164",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ulyanovskaya oblast"
+          },
+          "KI.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "131",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Kirovskaya oblast"
+          },
+          "TA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Republic of Tataria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "94",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "MR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MR",
+            "Primary Administrative Subdivision": "Republic of Marij-El",
+            "DXCC Entity Code": "54",
+            "Oblast #": "91",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Republic of Mordovia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "92",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "UD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Republic of Udmurtia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "95",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "CU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Republic of Chuvashia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "97",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krasnodar",
+            "DXCC Entity Code": "54",
+            "Oblast #": "101",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Krasnodarsky Kraj"
+          },
+          "KC.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Republic of Karachaevo-Cherkessia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "109",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "ST.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Stavropol\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "108",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Stavropolsky Kraj"
+          },
+          "KM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KM",
+            "Primary Administrative Subdivision": "Republic of Kalmykia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "89",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "SO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Republic of Northern Ossetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "93",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "RO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rostov-on-Don",
+            "DXCC Entity Code": "54",
+            "Oblast #": "150",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Rostovskaya oblast"
+          },
+          "CN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Republic Chechnya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "IN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Republic of Ingushetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Astrakhan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "115",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Astrakhanskaya oblast"
+          },
+          "DA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Republic of Daghestan",
+            "DXCC Entity Code": "54",
+            "Oblast #": "86",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Republic of Kabardino-Balkaria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "87",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AD",
+            "Primary Administrative Subdivision": "Republic of Adygeya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "102",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AR.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "61",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "FJL.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJL",
+            "Primary Administrative Subdivision": "Franz Josef Land",
+            "DXCC Entity Code": "61",
+            "Import-only": "true"
+          },
+          "15.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Artemisa",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "09.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Camagüey",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "08.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ciego de Ávila",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "06.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Cienfuegos",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "12.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Granma",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "14.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Guantánamo",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "11.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Holguín",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "99.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "99",
+            "Primary Administrative Subdivision": "Isla de la Juventud",
+            "DXCC Entity Code": "70",
+            "Comments": "special municipality"
+          },
+          "03.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "La Habana",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "10.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Las Tunas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "04.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Matanzas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "16.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Mayabeque",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "01.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Pinar del Río",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "07.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Sancti Spíritus",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "13.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Santiago de Cuba",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "05.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Villa Clara",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "C.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Capital federal",
+            "DXCC Entity Code": "100",
+            "Comments": "Buenos Aires City"
+          },
+          "B.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Buenos Aires Province",
+            "DXCC Entity Code": "100"
+          },
+          "S.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Santa Fe",
+            "DXCC Entity Code": "100"
+          },
+          "H.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chaco",
+            "DXCC Entity Code": "100"
+          },
+          "P.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Formosa",
+            "DXCC Entity Code": "100"
+          },
+          "X.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "100"
+          },
+          "N.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "100"
+          },
+          "E.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Entre Ríos",
+            "DXCC Entity Code": "100"
+          },
+          "T.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tucumán",
+            "DXCC Entity Code": "100"
+          },
+          "W.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Corrientes",
+            "DXCC Entity Code": "100"
+          },
+          "M.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Mendoza",
+            "DXCC Entity Code": "100"
+          },
+          "G.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Santiago del Estero",
+            "DXCC Entity Code": "100"
+          },
+          "A.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Salta",
+            "DXCC Entity Code": "100"
+          },
+          "J.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "San Juan",
+            "DXCC Entity Code": "100"
+          },
+          "D.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "San Luis",
+            "DXCC Entity Code": "100"
+          },
+          "K.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Catamarca",
+            "DXCC Entity Code": "100"
+          },
+          "F.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "100"
+          },
+          "Y.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Jujuy",
+            "DXCC Entity Code": "100"
+          },
+          "L.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "La Pampa",
+            "DXCC Entity Code": "100"
+          },
+          "R.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "100"
+          },
+          "U.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Chubut",
+            "DXCC Entity Code": "100"
+          },
+          "Z.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Santa Cruz",
+            "DXCC Entity Code": "100"
+          },
+          "V.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Tierra del Fuego",
+            "DXCC Entity Code": "100"
+          },
+          "Q.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Neuquén",
+            "DXCC Entity Code": "100"
+          },
+          "ES.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ES",
+            "Primary Administrative Subdivision": "Espírito Santo",
+            "DXCC Entity Code": "108"
+          },
+          "GO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Goiás",
+            "DXCC Entity Code": "108"
+          },
+          "SC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Santa Catarina",
+            "DXCC Entity Code": "108"
+          },
+          "SE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sergipe",
+            "DXCC Entity Code": "108"
+          },
+          "AL.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alagoas",
+            "DXCC Entity Code": "108"
+          },
+          "AM.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "108"
+          },
+          "TO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tocantins",
+            "DXCC Entity Code": "108"
+          },
+          "AP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Amapá",
+            "DXCC Entity Code": "108"
+          },
+          "PB.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Paraíba",
+            "DXCC Entity Code": "108"
+          },
+          "MA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maranhão",
+            "DXCC Entity Code": "108"
+          },
+          "RN.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rio Grande do Norte",
+            "DXCC Entity Code": "108"
+          },
+          "PI.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Piauí",
+            "DXCC Entity Code": "108"
+          },
+          "DF.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "108"
+          },
+          "CE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceará",
+            "DXCC Entity Code": "108"
+          },
+          "AC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Acre",
+            "DXCC Entity Code": "108"
+          },
+          "MS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mato Grosso do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "RR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RR",
+            "Primary Administrative Subdivision": "Roraima",
+            "DXCC Entity Code": "108"
+          },
+          "RO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rondônia",
+            "DXCC Entity Code": "108"
+          },
+          "RJ.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rio de Janeiro",
+            "DXCC Entity Code": "108"
+          },
+          "SP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "São Paulo",
+            "DXCC Entity Code": "108"
+          },
+          "RS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Rio Grande do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "MG.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Minas Gerais",
+            "DXCC Entity Code": "108"
+          },
+          "PR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Paraná",
+            "DXCC Entity Code": "108"
+          },
+          "BA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bahia",
+            "DXCC Entity Code": "108"
+          },
+          "PE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pernambuco",
+            "DXCC Entity Code": "108"
+          },
+          "PA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pará",
+            "DXCC Entity Code": "108"
+          },
+          "MT.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Mato Grosso",
+            "DXCC Entity Code": "108"
+          },
+          "HI.110": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hawaii",
+            "DXCC Entity Code": "110"
+          },
+          "II.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "II",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AN.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112"
+          },
+          "III.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "III",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AT.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112"
+          },
+          "I.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "TA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112"
+          },
+          "XV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XV",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AP.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112"
+          },
+          "IV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "CO.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112"
+          },
+          "V.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "VS.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112"
+          },
+          "RM.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Region Metropolitana de Santiago",
+            "DXCC Entity Code": "112"
+          },
+          "VI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112"
+          },
+          "VII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VII",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "ML.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112"
+          },
+          "VIII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIII",
+            "Primary Administrative Subdivision": "Bío-Bío",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "BI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biobío",
+            "DXCC Entity Code": "112"
+          },
+          "IX.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IX",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112"
+          },
+          "XIV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XIV",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112"
+          },
+          "X.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LL.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112"
+          },
+          "XI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibáñez del Campo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibañez del Campo",
+            "DXCC Entity Code": "112"
+          },
+          "XII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XII",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "MA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112"
+          },
+          "NB.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Ñuble",
+            "DXCC Entity Code": "112"
+          },
+          "22.118": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Jan Mayen",
+            "DXCC Entity Code": "118"
+          },
+          "KA.126": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kalingrad",
+            "DXCC Entity Code": "126",
+            "Oblast #": "125",
+            "CQ Zone": "15",
+            "ITU Zone": "29",
+            "Comments": "Kaliningradskaya oblast"
+          },
+          "16.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Alto Paraguay",
+            "DXCC Entity Code": "132"
+          },
+          "19.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Boquerón",
+            "DXCC Entity Code": "132"
+          },
+          "15.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Presidente Hayes",
+            "DXCC Entity Code": "132"
+          },
+          "13.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Amambay",
+            "DXCC Entity Code": "132"
+          },
+          "01.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "1.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "1",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132"
+          },
+          "14.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Canindeyú",
+            "DXCC Entity Code": "132"
+          },
+          "02.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "2.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132"
+          },
+          "ASU.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ASU",
+            "Primary Administrative Subdivision": "Asunción",
+            "DXCC Entity Code": "132"
+          },
+          "11.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "132"
+          },
+          "03.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "3.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "3",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132"
+          },
+          "09.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "9.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "9",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132"
+          },
+          "06.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Caazapl",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "6.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "6",
+            "Primary Administrative Subdivision": "Caazapá",
+            "DXCC Entity Code": "132"
+          },
+          "05.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "5.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "5",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132"
+          },
+          "04.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "4.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "4",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132"
+          },
+          "08.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Miaiones",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "8.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "8",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "132"
+          },
+          "12.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Ñeembucú",
+            "DXCC Entity Code": "132"
+          },
+          "10.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Alto Paraná",
+            "DXCC Entity Code": "132"
+          },
+          "07.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Itapua",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "7.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "7",
+            "Primary Administrative Subdivision": "Itapúa",
+            "DXCC Entity Code": "132"
+          },
+          "A.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Seoul",
+            "DXCC Entity Code": "137",
+            "Comments": "Seoul Teugbyeolsi"
+          },
+          "N.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Inchon",
+            "DXCC Entity Code": "137",
+            "Comments": "Incheon Gwang\u0027yeogsi"
+          },
+          "D.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Kangwon-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gang \u0027weondo"
+          },
+          "C.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Kyunggi-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeonggido"
+          },
+          "E.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Choongchungbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongbugdo"
+          },
+          "F.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Choongchungnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongnamdo"
+          },
+          "R.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Taejon",
+            "DXCC Entity Code": "137",
+            "Comments": "Daejeon Gwang\u0027yeogsi"
+          },
+          "M.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Cheju-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jejudo"
+          },
+          "G.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Chollabuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonrabugdo"
+          },
+          "H.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chollanam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonranamdo"
+          },
+          "Q.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Kwangju",
+            "DXCC Entity Code": "137",
+            "Comments": "Gwangju Gwang\u0027yeogsi"
+          },
+          "K.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Kyungsangbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangbugdo"
+          },
+          "L.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Kyungsangnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangnamdo"
+          },
+          "B.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Pusan",
+            "DXCC Entity Code": "137",
+            "Comments": "Busan Gwang\u0027yeogsi"
+          },
+          "P.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Taegu",
+            "DXCC Entity Code": "137",
+            "Comments": "Daegu Gwang\u0027yeogsi"
+          },
+          "S.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Ulsan",
+            "DXCC Entity Code": "137",
+            "Comments": "Ulsan Gwanq\u0027yeogsi"
+          },
+          "T.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Sejong",
+            "DXCC Entity Code": "137"
+          },
+          "IS.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Special Island",
+            "DXCC Entity Code": "137"
+          },
+          "KI.138": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kure Island",
+            "DXCC Entity Code": "138"
+          },
+          "LD.142": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Lakshadweep",
+            "DXCC Entity Code": "142",
+            "Comments": "Union territory"
+          },
+          "MO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Montevideo",
+            "DXCC Entity Code": "144"
+          },
+          "CA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Canelones",
+            "DXCC Entity Code": "144"
+          },
+          "SJ.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "San José",
+            "DXCC Entity Code": "144"
+          },
+          "CO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colonia",
+            "DXCC Entity Code": "144"
+          },
+          "SO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soriano",
+            "DXCC Entity Code": "144"
+          },
+          "RN.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "144"
+          },
+          "PA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Paysandú",
+            "DXCC Entity Code": "144"
+          },
+          "SA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salto",
+            "DXCC Entity Code": "144"
+          },
+          "AR.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Artigas",
+            "DXCC Entity Code": "144"
+          },
+          "FD.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FD",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "144"
+          },
+          "FS.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FS",
+            "Primary Administrative Subdivision": "Flores",
+            "DXCC Entity Code": "144"
+          },
+          "DU.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DU",
+            "Primary Administrative Subdivision": "Durazno",
+            "DXCC Entity Code": "144"
+          },
+          "TA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tacuarembó",
+            "DXCC Entity Code": "144"
+          },
+          "RV.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RV",
+            "Primary Administrative Subdivision": "Rivera",
+            "DXCC Entity Code": "144"
+          },
+          "MA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maldonado",
+            "DXCC Entity Code": "144"
+          },
+          "LA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lavalleja",
+            "DXCC Entity Code": "144"
+          },
+          "RO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rocha",
+            "DXCC Entity Code": "144"
+          },
+          "TT.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TT",
+            "Primary Administrative Subdivision": "Treinta y Tres",
+            "DXCC Entity Code": "144"
+          },
+          "CL.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Cerro Largo",
+            "DXCC Entity Code": "144"
+          },
+          "LH.147": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Lord Howe Is",
+            "DXCC Entity Code": "147"
+          },
+          "AM.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "148"
+          },
+          "AN.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Anzoátegui",
+            "DXCC Entity Code": "148"
+          },
+          "AP.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Apure",
+            "DXCC Entity Code": "148"
+          },
+          "AR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Aragua",
+            "DXCC Entity Code": "148"
+          },
+          "BA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Barinas",
+            "DXCC Entity Code": "148"
+          },
+          "BO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bolívar",
+            "DXCC Entity Code": "148"
+          },
+          "CA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Carabobo",
+            "DXCC Entity Code": "148"
+          },
+          "CO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cojedes",
+            "DXCC Entity Code": "148"
+          },
+          "DA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Delta Amacuro",
+            "DXCC Entity Code": "148"
+          },
+          "DC.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "Distrito Capital",
+            "DXCC Entity Code": "148"
+          },
+          "FA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FA",
+            "Primary Administrative Subdivision": "Falcón",
+            "DXCC Entity Code": "148"
+          },
+          "GU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guárico",
+            "DXCC Entity Code": "148"
+          },
+          "LA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lara",
+            "DXCC Entity Code": "148"
+          },
+          "ME.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Mérida",
+            "DXCC Entity Code": "148"
+          },
+          "MI.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Miranda",
+            "DXCC Entity Code": "148"
+          },
+          "MO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Monagas",
+            "DXCC Entity Code": "148"
+          },
+          "NE.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nueva Esparta",
+            "DXCC Entity Code": "148"
+          },
+          "PO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Portuguesa",
+            "DXCC Entity Code": "148"
+          },
+          "SU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sucre",
+            "DXCC Entity Code": "148"
+          },
+          "TA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Táchira",
+            "DXCC Entity Code": "148"
+          },
+          "TR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Trujillo",
+            "DXCC Entity Code": "148"
+          },
+          "VA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vargas",
+            "DXCC Entity Code": "148"
+          },
+          "YA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yaracuy",
+            "DXCC Entity Code": "148"
+          },
+          "ZU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZU",
+            "Primary Administrative Subdivision": "Zulia",
+            "DXCC Entity Code": "148"
+          },
+          "AC.149": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Açores",
+            "DXCC Entity Code": "149"
+          },
+          "ACT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ACT",
+            "Primary Administrative Subdivision": "Australian Capital Territory",
+            "DXCC Entity Code": "150"
+          },
+          "NSW.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSW",
+            "Primary Administrative Subdivision": "New South Wales",
+            "DXCC Entity Code": "150"
+          },
+          "VIC.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIC",
+            "Primary Administrative Subdivision": "Victoria",
+            "DXCC Entity Code": "150"
+          },
+          "QLD.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QLD",
+            "Primary Administrative Subdivision": "Queensland",
+            "DXCC Entity Code": "150"
+          },
+          "SA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "South Australia",
+            "DXCC Entity Code": "150"
+          },
+          "WA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Western Australia",
+            "DXCC Entity Code": "150"
+          },
+          "TAS.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasmania",
+            "DXCC Entity Code": "150"
+          },
+          "NT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northern Territory",
+            "DXCC Entity Code": "150"
+          },
+          "LO.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya Oblast",
+            "DXCC Entity Code": "151"
+          },
+          "MV.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Malyj Vysotskij",
+            "DXCC Entity Code": "151",
+            "Import-only": "true"
+          },
+          "MA.153": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Macquarie Is",
+            "DXCC Entity Code": "153"
+          },
+          "NCD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCD",
+            "Primary Administrative Subdivision": "National Capital District",
+            "DXCC Entity Code": "163",
+            "Comments": "Port Moresby"
+          },
+          "CPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPM",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "163"
+          },
+          "CPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPK",
+            "Primary Administrative Subdivision": "Chimbu",
+            "DXCC Entity Code": "163"
+          },
+          "EHG.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EHG",
+            "Primary Administrative Subdivision": "Eastern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "EBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EBR",
+            "Primary Administrative Subdivision": "East New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "ESW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ESW",
+            "Primary Administrative Subdivision": "East Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "EPW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EPW",
+            "Primary Administrative Subdivision": "Enga",
+            "DXCC Entity Code": "163"
+          },
+          "GPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPK",
+            "Primary Administrative Subdivision": "Gulf",
+            "DXCC Entity Code": "163"
+          },
+          "MPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPM",
+            "Primary Administrative Subdivision": "Madang",
+            "DXCC Entity Code": "163"
+          },
+          "MRL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MRL",
+            "Primary Administrative Subdivision": "Manus",
+            "DXCC Entity Code": "163"
+          },
+          "MBA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBA",
+            "Primary Administrative Subdivision": "Milne Bay",
+            "DXCC Entity Code": "163"
+          },
+          "MPL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPL",
+            "Primary Administrative Subdivision": "Morobe",
+            "DXCC Entity Code": "163"
+          },
+          "NIK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIK",
+            "Primary Administrative Subdivision": "New Ireland",
+            "DXCC Entity Code": "163"
+          },
+          "NPP.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NPP",
+            "Primary Administrative Subdivision": "Northern",
+            "DXCC Entity Code": "163"
+          },
+          "NSA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "North Solomons",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "NSB.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSB",
+            "Primary Administrative Subdivision": "Bougainville",
+            "DXCC Entity Code": "163"
+          },
+          "SAN.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAN",
+            "Primary Administrative Subdivision": "West Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "SHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SHM",
+            "Primary Administrative Subdivision": "Southern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WPD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WPD",
+            "Primary Administrative Subdivision": "Western",
+            "DXCC Entity Code": "163"
+          },
+          "WHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WHM",
+            "Primary Administrative Subdivision": "Western Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBR",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "WBK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBK",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "HLA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLA",
+            "Primary Administrative Subdivision": "Hela",
+            "DXCC Entity Code": "163"
+          },
+          "JWK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JWK",
+            "Primary Administrative Subdivision": "Jiwaka",
+            "DXCC Entity Code": "163"
+          },
+          "AUK.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUK",
+            "Primary Administrative Subdivision": "Auckland",
+            "DXCC Entity Code": "170"
+          },
+          "BOP.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOP",
+            "Primary Administrative Subdivision": "Bay of Plenty",
+            "DXCC Entity Code": "170"
+          },
+          "NTL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NTL",
+            "Primary Administrative Subdivision": "Northland",
+            "DXCC Entity Code": "170"
+          },
+          "WKO.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WKO",
+            "Primary Administrative Subdivision": "Waikato",
+            "DXCC Entity Code": "170"
+          },
+          "GIS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GIS",
+            "Primary Administrative Subdivision": "Gisborne",
+            "DXCC Entity Code": "170"
+          },
+          "HKB.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKB",
+            "Primary Administrative Subdivision": "Hawke\u0027s Bay",
+            "DXCC Entity Code": "170"
+          },
+          "MWT.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MWT",
+            "Primary Administrative Subdivision": "Manawatū-Whanganui",
+            "DXCC Entity Code": "170"
+          },
+          "TKI.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TKI",
+            "Primary Administrative Subdivision": "Taranaki",
+            "DXCC Entity Code": "170"
+          },
+          "WGN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WGN",
+            "Primary Administrative Subdivision": "Greater Wellington",
+            "DXCC Entity Code": "170"
+          },
+          "CAN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Canterbury",
+            "DXCC Entity Code": "170"
+          },
+          "MBH.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBH",
+            "Primary Administrative Subdivision": "Marlborough",
+            "DXCC Entity Code": "170"
+          },
+          "NSN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSN",
+            "Primary Administrative Subdivision": "Nelson",
+            "DXCC Entity Code": "170"
+          },
+          "TAS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasman",
+            "DXCC Entity Code": "170"
+          },
+          "WTC.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WTC",
+            "Primary Administrative Subdivision": "West Coast",
+            "DXCC Entity Code": "170"
+          },
+          "OTA.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OTA",
+            "Primary Administrative Subdivision": "Otago",
+            "DXCC Entity Code": "170"
+          },
+          "STL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STL",
+            "Primary Administrative Subdivision": "Southland",
+            "DXCC Entity Code": "170"
+          },
+          "MT.177": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Minami Torishima",
+            "DXCC Entity Code": "177"
+          },
+          "O.192": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Ogasawara",
+            "DXCC Entity Code": "192"
+          },
+          "WC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WC",
+            "Primary Administrative Subdivision": "Wien",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vienna (Wien)"
+          },
+          "HA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Hallein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "JO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JO",
+            "Primary Administrative Subdivision": "St. Johann",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Salzburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Salzburg-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "TA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tamsweg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "ZE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zell Am See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "AM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amstetten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Bruck/Leitha",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Baden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gmünd",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GF",
+            "Primary Administrative Subdivision": "Gänserndorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Hollabrunn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Horn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Korneuburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krems-Region",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Krems",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "LF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LF",
+            "Primary Administrative Subdivision": "Lilienfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Mödling",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ME.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Melk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Mistelbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "NK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NK",
+            "Primary Administrative Subdivision": "Neunkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "St. Pölten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "St. Pölten-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Scheibbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SW",
+            "Primary Administrative Subdivision": "Schwechat",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "TU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Tulln",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "Wr.Neustadt-Bezirk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WN",
+            "Primary Administrative Subdivision": "Wr.Neustadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WT",
+            "Primary Administrative Subdivision": "Waidhofen/Thaya",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WU",
+            "Primary Administrative Subdivision": "Wien-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WY.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Waidhofen/Ybbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ZT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZT",
+            "Primary Administrative Subdivision": "Zwettl",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "EC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EC",
+            "Primary Administrative Subdivision": "Eisenstadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "EU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EU",
+            "Primary Administrative Subdivision": "Eisenstadt-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "GS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Güssing",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "JE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JE",
+            "Primary Administrative Subdivision": "Jennersdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "MA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mattersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "ND.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "Neusiedl/See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OP",
+            "Primary Administrative Subdivision": "Oberpullendorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Oberwart",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "BR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braunau/Inn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "EF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EF",
+            "Primary Administrative Subdivision": "Eferding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "FR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freistadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GM",
+            "Primary Administrative Subdivision": "Gmunden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grieskirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "KI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirchdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Linz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Linz-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "PE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Perg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Ried/Innkreis",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rohrbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Schärding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Steyr-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Steyr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "UU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UU",
+            "Primary Administrative Subdivision": "Urfahr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "VB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vöcklabruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WE",
+            "Primary Administrative Subdivision": "Wels",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WL",
+            "Primary Administrative Subdivision": "Wels-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "BA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bad Aussee",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "BM.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck/Mur",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "BM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck-Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "DL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Deutschlandsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "FB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FB",
+            "Primary Administrative Subdivision": "Feldbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "FF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FF",
+            "Primary Administrative Subdivision": "Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "GB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GB",
+            "Primary Administrative Subdivision": "Gröbming",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Graz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Graz-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "HB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hartberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "HF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HF",
+            "Primary Administrative Subdivision": "Hartberg-Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "JU.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Judenburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "KF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KF",
+            "Primary Administrative Subdivision": "Knittelfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "LB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Leibnitz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Leoben",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Liezen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Leoben-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Murtal",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2012/01/01"
+          },
+          "MU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MZ.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "RA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Radkersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "SO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Südoststeiermark",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "VO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Voitsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "WZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WZ",
+            "Primary Administrative Subdivision": "Weiz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "IC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IC",
+            "Primary Administrative Subdivision": "Innsbruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Innsbruck-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imst",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Kitzbühel",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kufstein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Landeck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LZ",
+            "Primary Administrative Subdivision": "Lienz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "RE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reutte",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "SZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwaz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "FE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Feldkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "HE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hermagor",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Klagenfurt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Klagenfurt-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "Spittal/Drau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SV.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "St.Veit/Glan",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Villach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VK",
+            "Primary Administrative Subdivision": "Völkermarkt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Villach-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "WO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WO",
+            "Primary Administrative Subdivision": "Wolfsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "BC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bregenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "BZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bludenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "DO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dornbirn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "FK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FK",
+            "Primary Administrative Subdivision": "Feldkirch",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "AN.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antwerpen",
+            "DXCC Entity Code": "209"
+          },
+          "BR.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brussels",
+            "DXCC Entity Code": "209"
+          },
+          "BW.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Brabant Wallon",
+            "DXCC Entity Code": "209"
+          },
+          "HT.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HT",
+            "Primary Administrative Subdivision": "Hainaut",
+            "DXCC Entity Code": "209"
+          },
+          "LB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "209"
+          },
+          "LG.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LG",
+            "Primary Administrative Subdivision": "Liêge",
+            "DXCC Entity Code": "209"
+          },
+          "NM.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Namur",
+            "DXCC Entity Code": "209"
+          },
+          "LU.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luxembourg",
+            "DXCC Entity Code": "209"
+          },
+          "OV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Oost-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "VB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vlaams Brabant",
+            "DXCC Entity Code": "209"
+          },
+          "WV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "BU.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgas",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "SL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sliven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "YA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yambol",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas",
+            "Comments": "Jambol"
+          },
+          "SO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sofija Grad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "City of Sofia"
+          },
+          "HA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Haskovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "KA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kărdžali",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "SZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Stara Zagora",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "PA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pazardžik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "PD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Plovdiv",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "SM.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smoljan",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "BL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Blagoevgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "KD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KD",
+            "Primary Administrative Subdivision": "Kjustendil",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "PK.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Pernik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "SF.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SF",
+            "Primary Administrative Subdivision": "Sofija",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia",
+            "Comments": "Sofia"
+          },
+          "GA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Gabrovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "LV.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "Loveč",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč",
+            "Comments": "Lovech"
+          },
+          "PL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "Pleven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "VT.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Veliko Tărnovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "MN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Vidin",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VR.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vraca",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "RZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RZ",
+            "Primary Administrative Subdivision": "Razgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "RS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Ruse",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "SS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Silistra",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "TA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tărgovište",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "DO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dobrič",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "SN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Šumen",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "VN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Varna",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "2A.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2A",
+            "Primary Administrative Subdivision": "Corse-du-Sud",
+            "DXCC Entity Code": "214"
+          },
+          "2B.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2B",
+            "Primary Administrative Subdivision": "Haute-Corse",
+            "DXCC Entity Code": "214"
+          },
+          "015.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Koebenhavns amt",
+            "DXCC Entity Code": "221"
+          },
+          "020.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "020",
+            "Primary Administrative Subdivision": "Frederiksborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "025.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "025",
+            "Primary Administrative Subdivision": "Roskilde amt",
+            "DXCC Entity Code": "221"
+          },
+          "030.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "030",
+            "Primary Administrative Subdivision": "Vestsjaellands amt",
+            "DXCC Entity Code": "221"
+          },
+          "035.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "035",
+            "Primary Administrative Subdivision": "Storstrøm amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Storstroems"
+          },
+          "040.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "040",
+            "Primary Administrative Subdivision": "Bornholms amt",
+            "DXCC Entity Code": "221"
+          },
+          "042.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "042",
+            "Primary Administrative Subdivision": "Fyns amt",
+            "DXCC Entity Code": "221"
+          },
+          "050.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "050",
+            "Primary Administrative Subdivision": "Sínderjylland amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Sydjyllands"
+          },
+          "055.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "055",
+            "Primary Administrative Subdivision": "Ribe amt",
+            "DXCC Entity Code": "221"
+          },
+          "060.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "060",
+            "Primary Administrative Subdivision": "Vejle amt",
+            "DXCC Entity Code": "221"
+          },
+          "065.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "065",
+            "Primary Administrative Subdivision": "Ringkøbing amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Ringkoebing"
+          },
+          "070.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "070",
+            "Primary Administrative Subdivision": "Århus amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Aarhus"
+          },
+          "076.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "076",
+            "Primary Administrative Subdivision": "Viborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "080.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "080",
+            "Primary Administrative Subdivision": "Nordjyllands amt",
+            "DXCC Entity Code": "221"
+          },
+          "101.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "101",
+            "Primary Administrative Subdivision": "Copenhagen City",
+            "DXCC Entity Code": "221"
+          },
+          "147.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Frederiksberg",
+            "DXCC Entity Code": "221"
+          },
+          "100.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "100",
+            "Primary Administrative Subdivision": "Somero",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "102.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "102",
+            "Primary Administrative Subdivision": "Alastaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "103.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "103",
+            "Primary Administrative Subdivision": "Askainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "104.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "104",
+            "Primary Administrative Subdivision": "Aura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "105.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "105",
+            "Primary Administrative Subdivision": "Dragsfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "106.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "106",
+            "Primary Administrative Subdivision": "Eura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "107.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "107",
+            "Primary Administrative Subdivision": "Eurajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "108.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "108",
+            "Primary Administrative Subdivision": "Halikko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "109.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "109",
+            "Primary Administrative Subdivision": "Harjavalta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "110.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "110",
+            "Primary Administrative Subdivision": "Honkajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "111.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "111",
+            "Primary Administrative Subdivision": "Houtskari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "112.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "112",
+            "Primary Administrative Subdivision": "Huittinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "115.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "115",
+            "Primary Administrative Subdivision": "Iniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "116.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "116",
+            "Primary Administrative Subdivision": "Jämijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "117.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "117",
+            "Primary Administrative Subdivision": "Kaarina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "119.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "119",
+            "Primary Administrative Subdivision": "Kankaanpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "120.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "120",
+            "Primary Administrative Subdivision": "Karinainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "122.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "122",
+            "Primary Administrative Subdivision": "Karvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "123.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "123",
+            "Primary Administrative Subdivision": "Äetsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "124.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "124",
+            "Primary Administrative Subdivision": "Kemiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "126.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "126",
+            "Primary Administrative Subdivision": "Kiikala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "128.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "128",
+            "Primary Administrative Subdivision": "Kiikoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "129.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "129",
+            "Primary Administrative Subdivision": "Kisko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "130.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "130",
+            "Primary Administrative Subdivision": "Kiukainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "131.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "131",
+            "Primary Administrative Subdivision": "Kodisjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "132.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "132",
+            "Primary Administrative Subdivision": "Kokemäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "133.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "133",
+            "Primary Administrative Subdivision": "Korppoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "134.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "134",
+            "Primary Administrative Subdivision": "Koski tl",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "135.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "135",
+            "Primary Administrative Subdivision": "Kullaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "136.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "136",
+            "Primary Administrative Subdivision": "Kustavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "137.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "137",
+            "Primary Administrative Subdivision": "Kuusjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "138.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "138",
+            "Primary Administrative Subdivision": "Köyliö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "139.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "139",
+            "Primary Administrative Subdivision": "Laitila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "140.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "140",
+            "Primary Administrative Subdivision": "Lappi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "141.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "141",
+            "Primary Administrative Subdivision": "Lavia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "142.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "142",
+            "Primary Administrative Subdivision": "Lemu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "143.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "143",
+            "Primary Administrative Subdivision": "Lieto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "144.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "144",
+            "Primary Administrative Subdivision": "Loimaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "145.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "145",
+            "Primary Administrative Subdivision": "Loimaan kunta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "147.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Luvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "148.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "148",
+            "Primary Administrative Subdivision": "Marttila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "149.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "149",
+            "Primary Administrative Subdivision": "Masku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "150.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "150",
+            "Primary Administrative Subdivision": "Mellilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "151.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "151",
+            "Primary Administrative Subdivision": "Merikarvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "152.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "152",
+            "Primary Administrative Subdivision": "Merimasku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "154.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "154",
+            "Primary Administrative Subdivision": "Mietoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "156.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "156",
+            "Primary Administrative Subdivision": "Muurla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "157.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "157",
+            "Primary Administrative Subdivision": "Mynämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "158.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "158",
+            "Primary Administrative Subdivision": "Naantali",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "159.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "159",
+            "Primary Administrative Subdivision": "Nakkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "160.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "160",
+            "Primary Administrative Subdivision": "Nauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "161.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "161",
+            "Primary Administrative Subdivision": "Noormarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "162.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "162",
+            "Primary Administrative Subdivision": "Nousiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "163.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "163",
+            "Primary Administrative Subdivision": "Oripää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "164.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "164",
+            "Primary Administrative Subdivision": "Paimio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "165.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "165",
+            "Primary Administrative Subdivision": "Parainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "167.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "167",
+            "Primary Administrative Subdivision": "Perniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "168.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "168",
+            "Primary Administrative Subdivision": "Pertteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "169.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "169",
+            "Primary Administrative Subdivision": "Piikkiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "170.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "170",
+            "Primary Administrative Subdivision": "Pomarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "171.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "171",
+            "Primary Administrative Subdivision": "Pori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "172.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "172",
+            "Primary Administrative Subdivision": "Punkalaidun",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "173.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "173",
+            "Primary Administrative Subdivision": "Pyhäranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "174.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "174",
+            "Primary Administrative Subdivision": "Pöytyä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "175.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "175",
+            "Primary Administrative Subdivision": "Raisio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "176.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "176",
+            "Primary Administrative Subdivision": "Rauma",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "178.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "178",
+            "Primary Administrative Subdivision": "Rusko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "179.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "179",
+            "Primary Administrative Subdivision": "Rymättylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "180.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "180",
+            "Primary Administrative Subdivision": "Salo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "181.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "181",
+            "Primary Administrative Subdivision": "Sauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "182.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "182",
+            "Primary Administrative Subdivision": "Siikainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "183.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "183",
+            "Primary Administrative Subdivision": "Suodenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "184.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "184",
+            "Primary Administrative Subdivision": "Suomusjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "185.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "185",
+            "Primary Administrative Subdivision": "Säkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "186.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "186",
+            "Primary Administrative Subdivision": "Särkisalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "187.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "187",
+            "Primary Administrative Subdivision": "Taivassalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "188.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "188",
+            "Primary Administrative Subdivision": "Tarvasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "189.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "189",
+            "Primary Administrative Subdivision": "Turku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "190.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "190",
+            "Primary Administrative Subdivision": "Ulvila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "191.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "191",
+            "Primary Administrative Subdivision": "Uusikaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "192.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "192",
+            "Primary Administrative Subdivision": "Vahto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "193.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "193",
+            "Primary Administrative Subdivision": "Vammala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "194.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "194",
+            "Primary Administrative Subdivision": "Vampula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "195.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "195",
+            "Primary Administrative Subdivision": "Vehmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "196.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "196",
+            "Primary Administrative Subdivision": "Velkua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "198.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "198",
+            "Primary Administrative Subdivision": "Västanfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "199.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "199",
+            "Primary Administrative Subdivision": "Yläne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "201.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "201",
+            "Primary Administrative Subdivision": "Artjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "202.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "202",
+            "Primary Administrative Subdivision": "Askola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "204.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "204",
+            "Primary Administrative Subdivision": "Espoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "205.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "205",
+            "Primary Administrative Subdivision": "Hanko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "206.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "206",
+            "Primary Administrative Subdivision": "Helsinki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "207.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "207",
+            "Primary Administrative Subdivision": "Hyvinkää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "208.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "208",
+            "Primary Administrative Subdivision": "Inkoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "209.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "209",
+            "Primary Administrative Subdivision": "Järvenpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "210.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "210",
+            "Primary Administrative Subdivision": "Karjaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "211.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "211",
+            "Primary Administrative Subdivision": "Karjalohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "212.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "212",
+            "Primary Administrative Subdivision": "Karkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "213.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "213",
+            "Primary Administrative Subdivision": "Kauniainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "214.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "214",
+            "Primary Administrative Subdivision": "Kerava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "215.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "215",
+            "Primary Administrative Subdivision": "Kirkkonummi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "216.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "216",
+            "Primary Administrative Subdivision": "Lapinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "217.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "217",
+            "Primary Administrative Subdivision": "Liljendal",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "218.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "218",
+            "Primary Administrative Subdivision": "Lohjan kaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "220.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "220",
+            "Primary Administrative Subdivision": "Loviisa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "221.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "221",
+            "Primary Administrative Subdivision": "Myrskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "222.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "222",
+            "Primary Administrative Subdivision": "Mäntsälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "223.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "223",
+            "Primary Administrative Subdivision": "Nummi-Pusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "224.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "224",
+            "Primary Administrative Subdivision": "Nurmijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "225.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "225",
+            "Primary Administrative Subdivision": "Orimattila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "226.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "226",
+            "Primary Administrative Subdivision": "Pernaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "227.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "227",
+            "Primary Administrative Subdivision": "Pohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "228.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "228",
+            "Primary Administrative Subdivision": "Pornainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "229.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "229",
+            "Primary Administrative Subdivision": "Porvoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "231.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "231",
+            "Primary Administrative Subdivision": "Pukkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "233.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "233",
+            "Primary Administrative Subdivision": "Ruotsinpyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "234.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "234",
+            "Primary Administrative Subdivision": "Sammatti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "235.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "235",
+            "Primary Administrative Subdivision": "Sipoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "236.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "236",
+            "Primary Administrative Subdivision": "Siuntio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "238.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "238",
+            "Primary Administrative Subdivision": "Tammisaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "241.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "241",
+            "Primary Administrative Subdivision": "Tuusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "242.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "242",
+            "Primary Administrative Subdivision": "Vantaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "243.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "243",
+            "Primary Administrative Subdivision": "Vihti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "301.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "301",
+            "Primary Administrative Subdivision": "Asikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "303.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "303",
+            "Primary Administrative Subdivision": "Forssa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "304.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "304",
+            "Primary Administrative Subdivision": "Hattula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "305.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "305",
+            "Primary Administrative Subdivision": "Hauho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "306.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "306",
+            "Primary Administrative Subdivision": "Hausjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "307.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "307",
+            "Primary Administrative Subdivision": "Hollola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "308.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "308",
+            "Primary Administrative Subdivision": "Humppila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "309.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "309",
+            "Primary Administrative Subdivision": "Hämeenlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "310.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "310",
+            "Primary Administrative Subdivision": "Janakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "311.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "311",
+            "Primary Administrative Subdivision": "Jokioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "312.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "312",
+            "Primary Administrative Subdivision": "Juupajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "313.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "313",
+            "Primary Administrative Subdivision": "Kalvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "314.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "314",
+            "Primary Administrative Subdivision": "Kangasala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "315.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "315",
+            "Primary Administrative Subdivision": "Hämeenkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "316.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "316",
+            "Primary Administrative Subdivision": "Kuhmalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "318.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "318",
+            "Primary Administrative Subdivision": "Kuru",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "319.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "319",
+            "Primary Administrative Subdivision": "Kylmäkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "320.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "320",
+            "Primary Administrative Subdivision": "Kärkölä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "321.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "321",
+            "Primary Administrative Subdivision": "Lahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "322.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "322",
+            "Primary Administrative Subdivision": "Lammi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "323.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "323",
+            "Primary Administrative Subdivision": "Lempäälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "324.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "324",
+            "Primary Administrative Subdivision": "Loppi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "325.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "325",
+            "Primary Administrative Subdivision": "Luopioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "326.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "326",
+            "Primary Administrative Subdivision": "Längelmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "327.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "327",
+            "Primary Administrative Subdivision": "Mänttä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "328.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "328",
+            "Primary Administrative Subdivision": "Nastola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "329.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "329",
+            "Primary Administrative Subdivision": "Nokia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "330.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "330",
+            "Primary Administrative Subdivision": "Orivesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "331.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "331",
+            "Primary Administrative Subdivision": "Padasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "332.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "332",
+            "Primary Administrative Subdivision": "Pirkkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "333.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "333",
+            "Primary Administrative Subdivision": "Pälkäne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "334.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "334",
+            "Primary Administrative Subdivision": "Renko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "335.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "335",
+            "Primary Administrative Subdivision": "Riihimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "336.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "336",
+            "Primary Administrative Subdivision": "Ruovesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "337.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "337",
+            "Primary Administrative Subdivision": "Sahalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "340.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "340",
+            "Primary Administrative Subdivision": "Tammela",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "341.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "341",
+            "Primary Administrative Subdivision": "Tampere",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "342.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "342",
+            "Primary Administrative Subdivision": "Toijala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "344.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "344",
+            "Primary Administrative Subdivision": "Tuulos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "345.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "345",
+            "Primary Administrative Subdivision": "Urjala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "346.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "346",
+            "Primary Administrative Subdivision": "Valkeakoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "347.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "347",
+            "Primary Administrative Subdivision": "Vesilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "348.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "348",
+            "Primary Administrative Subdivision": "Viiala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "349.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "349",
+            "Primary Administrative Subdivision": "Vilppula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "350.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "350",
+            "Primary Administrative Subdivision": "Virrat",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "351.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "351",
+            "Primary Administrative Subdivision": "Ylöjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "352.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "352",
+            "Primary Administrative Subdivision": "Ypäjä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "353.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "353",
+            "Primary Administrative Subdivision": "Hämeenkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "354.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "354",
+            "Primary Administrative Subdivision": "Ikaalinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "355.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "355",
+            "Primary Administrative Subdivision": "Kihniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "356.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "356",
+            "Primary Administrative Subdivision": "Mouhijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "357.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "357",
+            "Primary Administrative Subdivision": "Parkano",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "358.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "358",
+            "Primary Administrative Subdivision": "Viljakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "402.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "402",
+            "Primary Administrative Subdivision": "Enonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "403.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "403",
+            "Primary Administrative Subdivision": "Hartola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "404.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "404",
+            "Primary Administrative Subdivision": "Haukivuori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "405.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "405",
+            "Primary Administrative Subdivision": "Heinola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "407.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "407",
+            "Primary Administrative Subdivision": "Heinävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "408.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "408",
+            "Primary Administrative Subdivision": "Hirvensalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "409.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "409",
+            "Primary Administrative Subdivision": "Joroinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "410.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "410",
+            "Primary Administrative Subdivision": "Juva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "411.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "411",
+            "Primary Administrative Subdivision": "Jäppilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "412.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "412",
+            "Primary Administrative Subdivision": "Kangaslampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "413.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "413",
+            "Primary Administrative Subdivision": "Kangasniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "414.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "414",
+            "Primary Administrative Subdivision": "Kerimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "415.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "415",
+            "Primary Administrative Subdivision": "Mikkeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "417.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "417",
+            "Primary Administrative Subdivision": "Mäntyharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "418.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "418",
+            "Primary Administrative Subdivision": "Pertunmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "419.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "419",
+            "Primary Administrative Subdivision": "Pieksämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "420.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "420",
+            "Primary Administrative Subdivision": "Pieksänmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "421.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "421",
+            "Primary Administrative Subdivision": "Punkaharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "422.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "422",
+            "Primary Administrative Subdivision": "Puumala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "423.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "423",
+            "Primary Administrative Subdivision": "Rantasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "424.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "424",
+            "Primary Administrative Subdivision": "Ristiina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "425.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "425",
+            "Primary Administrative Subdivision": "Savonlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "426.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "426",
+            "Primary Administrative Subdivision": "Savonranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "427.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "427",
+            "Primary Administrative Subdivision": "Sulkava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "428.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "428",
+            "Primary Administrative Subdivision": "Sysmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "502.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "502",
+            "Primary Administrative Subdivision": "Elimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "503.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "503",
+            "Primary Administrative Subdivision": "Hamina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "504.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "504",
+            "Primary Administrative Subdivision": "Iitti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "505.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "505",
+            "Primary Administrative Subdivision": "Imatra",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "506.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "506",
+            "Primary Administrative Subdivision": "Jaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "507.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "507",
+            "Primary Administrative Subdivision": "Joutseno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "509.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "509",
+            "Primary Administrative Subdivision": "Kotka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "510.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "510",
+            "Primary Administrative Subdivision": "Kouvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "511.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "511",
+            "Primary Administrative Subdivision": "Kuusankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "513.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "513",
+            "Primary Administrative Subdivision": "Lappeenranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "514.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "514",
+            "Primary Administrative Subdivision": "Lemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "515.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "515",
+            "Primary Administrative Subdivision": "Luumäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "516.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "516",
+            "Primary Administrative Subdivision": "Miehikkälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "518.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "518",
+            "Primary Administrative Subdivision": "Parikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "519.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "519",
+            "Primary Administrative Subdivision": "Pyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "520.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "520",
+            "Primary Administrative Subdivision": "Rautjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "521.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "521",
+            "Primary Administrative Subdivision": "Ruokolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "522.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "522",
+            "Primary Administrative Subdivision": "Saari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "523.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "523",
+            "Primary Administrative Subdivision": "Savitaipale",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "525.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "525",
+            "Primary Administrative Subdivision": "Suomenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "526.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "526",
+            "Primary Administrative Subdivision": "Taipalsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "527.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "527",
+            "Primary Administrative Subdivision": "Uukuniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "528.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "528",
+            "Primary Administrative Subdivision": "Valkeala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "530.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "530",
+            "Primary Administrative Subdivision": "Virolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "531.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "531",
+            "Primary Administrative Subdivision": "Ylämaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "532.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "532",
+            "Primary Administrative Subdivision": "Anjalankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "601.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "601",
+            "Primary Administrative Subdivision": "Alahärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "602.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "602",
+            "Primary Administrative Subdivision": "Alajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "603.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "603",
+            "Primary Administrative Subdivision": "Alavus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "604.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "604",
+            "Primary Administrative Subdivision": "Evijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "605.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "605",
+            "Primary Administrative Subdivision": "Halsua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "606.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "606",
+            "Primary Administrative Subdivision": "Hankasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "607.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "607",
+            "Primary Administrative Subdivision": "Himanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "608.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "608",
+            "Primary Administrative Subdivision": "Ilmajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "609.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "609",
+            "Primary Administrative Subdivision": "Isojoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "610.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "610",
+            "Primary Administrative Subdivision": "Isokyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "611.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "611",
+            "Primary Administrative Subdivision": "Jalasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "612.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "612",
+            "Primary Administrative Subdivision": "Joutsa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "613.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "613",
+            "Primary Administrative Subdivision": "Jurva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "614.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "614",
+            "Primary Administrative Subdivision": "Jyväskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "615.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "615",
+            "Primary Administrative Subdivision": "Jyväskylän mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "616.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "616",
+            "Primary Administrative Subdivision": "Jämsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "617.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "617",
+            "Primary Administrative Subdivision": "Jämsänkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "619.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "619",
+            "Primary Administrative Subdivision": "Kannonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "620.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "620",
+            "Primary Administrative Subdivision": "Kannus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "621.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "621",
+            "Primary Administrative Subdivision": "Karijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "622.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "622",
+            "Primary Administrative Subdivision": "Karstula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "623.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "623",
+            "Primary Administrative Subdivision": "Kaskinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "624.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "624",
+            "Primary Administrative Subdivision": "Kauhajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "625.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "625",
+            "Primary Administrative Subdivision": "Kauhava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "626.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "626",
+            "Primary Administrative Subdivision": "Kaustinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "627.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "627",
+            "Primary Administrative Subdivision": "Keuruu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "628.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "628",
+            "Primary Administrative Subdivision": "Kinnula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "629.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "629",
+            "Primary Administrative Subdivision": "Kivijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "630.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "630",
+            "Primary Administrative Subdivision": "Kokkola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "632.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "632",
+            "Primary Administrative Subdivision": "Konnevesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "633.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "633",
+            "Primary Administrative Subdivision": "Korpilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "634.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "634",
+            "Primary Administrative Subdivision": "Korsnäs",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "635.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "635",
+            "Primary Administrative Subdivision": "Kortesjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "636.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "636",
+            "Primary Administrative Subdivision": "Kristiinankaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "637.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "637",
+            "Primary Administrative Subdivision": "Kruunupyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "638.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "638",
+            "Primary Administrative Subdivision": "Kuhmoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "639.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "639",
+            "Primary Administrative Subdivision": "Kuortane",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "640.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "640",
+            "Primary Administrative Subdivision": "Kurikka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "641.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "641",
+            "Primary Administrative Subdivision": "Kyyjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "642.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "642",
+            "Primary Administrative Subdivision": "Kälviä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "643.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "643",
+            "Primary Administrative Subdivision": "Laihia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "644.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "644",
+            "Primary Administrative Subdivision": "Lappajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "645.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "645",
+            "Primary Administrative Subdivision": "Lapua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "646.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "646",
+            "Primary Administrative Subdivision": "Laukaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "647.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "647",
+            "Primary Administrative Subdivision": "Lehtimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "648.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "648",
+            "Primary Administrative Subdivision": "Leivonmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "649.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "649",
+            "Primary Administrative Subdivision": "Lestijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "650.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "650",
+            "Primary Administrative Subdivision": "Lohtaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "651.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "651",
+            "Primary Administrative Subdivision": "Luhanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "652.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "652",
+            "Primary Administrative Subdivision": "Luoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "653.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "653",
+            "Primary Administrative Subdivision": "Maalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "654.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "654",
+            "Primary Administrative Subdivision": "Maksamaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "655.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "655",
+            "Primary Administrative Subdivision": "Multia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "656.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "656",
+            "Primary Administrative Subdivision": "Mustasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "657.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "657",
+            "Primary Administrative Subdivision": "Muurame",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "658.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "658",
+            "Primary Administrative Subdivision": "Nurmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "659.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "659",
+            "Primary Administrative Subdivision": "Närpiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "660.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "660",
+            "Primary Administrative Subdivision": "Oravainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "661.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "661",
+            "Primary Administrative Subdivision": "Perho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "662.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "662",
+            "Primary Administrative Subdivision": "Peräseinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "663.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "663",
+            "Primary Administrative Subdivision": "Petäjävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "664.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "664",
+            "Primary Administrative Subdivision": "Pietarsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "665.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "665",
+            "Primary Administrative Subdivision": "Pedersöre",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "666.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "666",
+            "Primary Administrative Subdivision": "Pihtipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "668.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "668",
+            "Primary Administrative Subdivision": "Pylkönmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "669.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "669",
+            "Primary Administrative Subdivision": "Saarijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "670.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "670",
+            "Primary Administrative Subdivision": "Seinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "671.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "671",
+            "Primary Administrative Subdivision": "Soini",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "672.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "672",
+            "Primary Administrative Subdivision": "Sumiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "673.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "673",
+            "Primary Administrative Subdivision": "Suolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "675.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "675",
+            "Primary Administrative Subdivision": "Teuva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "676.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "676",
+            "Primary Administrative Subdivision": "Toholampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "677.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "677",
+            "Primary Administrative Subdivision": "Toivakka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "678.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "678",
+            "Primary Administrative Subdivision": "Töysä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "679.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "679",
+            "Primary Administrative Subdivision": "Ullava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "680.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "680",
+            "Primary Administrative Subdivision": "Uurainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "681.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "681",
+            "Primary Administrative Subdivision": "Uusikaarlepyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "682.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "682",
+            "Primary Administrative Subdivision": "Vaasa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "683.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "683",
+            "Primary Administrative Subdivision": "Veteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "684.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "684",
+            "Primary Administrative Subdivision": "Viitasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "685.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "685",
+            "Primary Administrative Subdivision": "Vimpeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "686.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "686",
+            "Primary Administrative Subdivision": "Vähäkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "687.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "687",
+            "Primary Administrative Subdivision": "Vöyri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "688.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "688",
+            "Primary Administrative Subdivision": "Ylihärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "689.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "689",
+            "Primary Administrative Subdivision": "Ylistaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "690.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "690",
+            "Primary Administrative Subdivision": "Ähtäri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "692.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "692",
+            "Primary Administrative Subdivision": "Äänekoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "701.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "701",
+            "Primary Administrative Subdivision": "Eno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "702.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "702",
+            "Primary Administrative Subdivision": "Iisalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "703.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "703",
+            "Primary Administrative Subdivision": "Ilomantsi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "704.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "704",
+            "Primary Administrative Subdivision": "Joensuu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "705.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "705",
+            "Primary Administrative Subdivision": "Juankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "706.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "706",
+            "Primary Administrative Subdivision": "Juuka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "707.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "707",
+            "Primary Administrative Subdivision": "Kaavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "708.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "708",
+            "Primary Administrative Subdivision": "Karttula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "709.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "709",
+            "Primary Administrative Subdivision": "Keitele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "710.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "710",
+            "Primary Administrative Subdivision": "Kesälahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "711.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "711",
+            "Primary Administrative Subdivision": "Kiihtelysvaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "712.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "712",
+            "Primary Administrative Subdivision": "Kitee",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "713.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "713",
+            "Primary Administrative Subdivision": "Kiuruvesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "714.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "714",
+            "Primary Administrative Subdivision": "Kontiolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "715.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "715",
+            "Primary Administrative Subdivision": "Kuopio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "716.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "716",
+            "Primary Administrative Subdivision": "Lapinlahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "717.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "717",
+            "Primary Administrative Subdivision": "Leppävirta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "718.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "718",
+            "Primary Administrative Subdivision": "Lieksa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "719.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "719",
+            "Primary Administrative Subdivision": "Liperi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "720.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "720",
+            "Primary Administrative Subdivision": "Maaninka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "721.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "721",
+            "Primary Administrative Subdivision": "Nilsiä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "722.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "722",
+            "Primary Administrative Subdivision": "Nurmes",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "723.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "723",
+            "Primary Administrative Subdivision": "Outokumpu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "724.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "724",
+            "Primary Administrative Subdivision": "Pielavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "725.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "725",
+            "Primary Administrative Subdivision": "Polvijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "726.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "726",
+            "Primary Administrative Subdivision": "Pyhäselkä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "727.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "727",
+            "Primary Administrative Subdivision": "Rautalampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "728.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "728",
+            "Primary Administrative Subdivision": "Rautavaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "729.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "729",
+            "Primary Administrative Subdivision": "Rääkkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "730.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "730",
+            "Primary Administrative Subdivision": "Siilinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "731.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "731",
+            "Primary Administrative Subdivision": "Sonkajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "732.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "732",
+            "Primary Administrative Subdivision": "Suonenjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "733.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "733",
+            "Primary Administrative Subdivision": "Tervo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "734.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "734",
+            "Primary Administrative Subdivision": "Tohmajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "735.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "735",
+            "Primary Administrative Subdivision": "Tuupovaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "736.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "736",
+            "Primary Administrative Subdivision": "Tuusniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "737.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "737",
+            "Primary Administrative Subdivision": "Valtimo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "738.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "738",
+            "Primary Administrative Subdivision": "Varkaus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "739.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "739",
+            "Primary Administrative Subdivision": "Varpaisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "740.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "740",
+            "Primary Administrative Subdivision": "Vehmersalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "741.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "741",
+            "Primary Administrative Subdivision": "Vesanto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "742.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "742",
+            "Primary Administrative Subdivision": "Vieremä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "743.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "743",
+            "Primary Administrative Subdivision": "Värtsilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "801.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "801",
+            "Primary Administrative Subdivision": "Alavieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "802.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "802",
+            "Primary Administrative Subdivision": "Haapajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "803.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "803",
+            "Primary Administrative Subdivision": "Haapavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "804.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "804",
+            "Primary Administrative Subdivision": "Hailuoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "805.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "805",
+            "Primary Administrative Subdivision": "Haukipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "806.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "806",
+            "Primary Administrative Subdivision": "Hyrynsalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "807.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "807",
+            "Primary Administrative Subdivision": "Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "808.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "808",
+            "Primary Administrative Subdivision": "Kajaani",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "810.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "810",
+            "Primary Administrative Subdivision": "Kalajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "811.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "811",
+            "Primary Administrative Subdivision": "Kempele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "812.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "812",
+            "Primary Administrative Subdivision": "Kestilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "813.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "813",
+            "Primary Administrative Subdivision": "Kiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "814.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "814",
+            "Primary Administrative Subdivision": "Kuhmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "815.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "815",
+            "Primary Administrative Subdivision": "Kuivaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "816.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "816",
+            "Primary Administrative Subdivision": "Kuusamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "817.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "817",
+            "Primary Administrative Subdivision": "Kärsämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "818.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "818",
+            "Primary Administrative Subdivision": "Liminka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "819.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "819",
+            "Primary Administrative Subdivision": "Lumijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "820.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "820",
+            "Primary Administrative Subdivision": "Merijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "821.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "821",
+            "Primary Administrative Subdivision": "Muhos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "822.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "822",
+            "Primary Administrative Subdivision": "Nivala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "823.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "823",
+            "Primary Administrative Subdivision": "Oulainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "824.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "824",
+            "Primary Administrative Subdivision": "Oulu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "825.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "825",
+            "Primary Administrative Subdivision": "Oulunsalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "826.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "826",
+            "Primary Administrative Subdivision": "Paltamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "827.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "827",
+            "Primary Administrative Subdivision": "Pattijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "828.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "828",
+            "Primary Administrative Subdivision": "Piippola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "829.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "829",
+            "Primary Administrative Subdivision": "Pudasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "830.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "830",
+            "Primary Administrative Subdivision": "Pulkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "831.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "831",
+            "Primary Administrative Subdivision": "Puolanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "832.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "832",
+            "Primary Administrative Subdivision": "Pyhäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "833.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "833",
+            "Primary Administrative Subdivision": "Pyhäjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "834.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "834",
+            "Primary Administrative Subdivision": "Pyhäntä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "835.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "835",
+            "Primary Administrative Subdivision": "Raahe",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "836.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "836",
+            "Primary Administrative Subdivision": "Rantsila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "837.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "837",
+            "Primary Administrative Subdivision": "Reisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "838.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "838",
+            "Primary Administrative Subdivision": "Ristijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "839.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "839",
+            "Primary Administrative Subdivision": "Ruukki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "840.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "840",
+            "Primary Administrative Subdivision": "Sievi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "841.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "841",
+            "Primary Administrative Subdivision": "Siikajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "842.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "842",
+            "Primary Administrative Subdivision": "Sotkamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "843.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "843",
+            "Primary Administrative Subdivision": "Suomussalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "844.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "844",
+            "Primary Administrative Subdivision": "Taivalkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "846.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "846",
+            "Primary Administrative Subdivision": "Tyrnävä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "847.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "847",
+            "Primary Administrative Subdivision": "Utajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "848.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "848",
+            "Primary Administrative Subdivision": "Vaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "849.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "849",
+            "Primary Administrative Subdivision": "Vihanti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "850.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "850",
+            "Primary Administrative Subdivision": "Vuolijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "851.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "851",
+            "Primary Administrative Subdivision": "Yli-Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "852.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "852",
+            "Primary Administrative Subdivision": "Ylikiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "853.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "853",
+            "Primary Administrative Subdivision": "Ylivieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "901.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "901",
+            "Primary Administrative Subdivision": "Enontekiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "902.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "902",
+            "Primary Administrative Subdivision": "Inari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "903.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "903",
+            "Primary Administrative Subdivision": "Kemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "904.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "904",
+            "Primary Administrative Subdivision": "Keminmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "905.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "905",
+            "Primary Administrative Subdivision": "Kemijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "907.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "907",
+            "Primary Administrative Subdivision": "Kittilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "908.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "908",
+            "Primary Administrative Subdivision": "Kolari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "909.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "909",
+            "Primary Administrative Subdivision": "Muonio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "910.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "910",
+            "Primary Administrative Subdivision": "Pelkosenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "911.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "911",
+            "Primary Administrative Subdivision": "Pello",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "912.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "912",
+            "Primary Administrative Subdivision": "Posio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "913.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "913",
+            "Primary Administrative Subdivision": "Ranua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "914.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "914",
+            "Primary Administrative Subdivision": "Rovaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "915.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "915",
+            "Primary Administrative Subdivision": "Rovaniemen mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "916.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "916",
+            "Primary Administrative Subdivision": "Salla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "917.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "917",
+            "Primary Administrative Subdivision": "Savukoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "918.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "918",
+            "Primary Administrative Subdivision": "Simo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "919.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "919",
+            "Primary Administrative Subdivision": "Sodankylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "920.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "920",
+            "Primary Administrative Subdivision": "Tervola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "921.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "921",
+            "Primary Administrative Subdivision": "Tornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "922.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "922",
+            "Primary Administrative Subdivision": "Utsjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "923.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "923",
+            "Primary Administrative Subdivision": "Ylitornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "CA.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cagliari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "CI.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CI",
+            "Primary Administrative Subdivision": "Carbonia-Iglesias",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true",
+            "Comments": "replaced by SU"
+          },
+          "SU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sud Sardegna",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "MD.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Medio Campidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true"
+          },
+          "NU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nuoro",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OG.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OG",
+            "Primary Administrative Subdivision": "Ogliastra",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OR.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oristano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OT.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olbia-Tempio",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "SS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Sassari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "VS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "MedioCampidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "01.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Ain",
+            "DXCC Entity Code": "227"
+          },
+          "02.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aisne",
+            "DXCC Entity Code": "227"
+          },
+          "03.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Allier",
+            "DXCC Entity Code": "227"
+          },
+          "04.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Alpes-de-Haute-Provence",
+            "DXCC Entity Code": "227"
+          },
+          "05.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Hautes-Alpes",
+            "DXCC Entity Code": "227"
+          },
+          "06.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Alpes-Maritimes",
+            "DXCC Entity Code": "227"
+          },
+          "07.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Ardèche",
+            "DXCC Entity Code": "227"
+          },
+          "08.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ardennes",
+            "DXCC Entity Code": "227"
+          },
+          "09.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ariège",
+            "DXCC Entity Code": "227"
+          },
+          "10.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Aube",
+            "DXCC Entity Code": "227"
+          },
+          "11.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Aude",
+            "DXCC Entity Code": "227"
+          },
+          "12.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Aveyron",
+            "DXCC Entity Code": "227"
+          },
+          "13.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Bouches-du-Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "14.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Calvados",
+            "DXCC Entity Code": "227"
+          },
+          "15.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Cantal",
+            "DXCC Entity Code": "227"
+          },
+          "16.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Charente",
+            "DXCC Entity Code": "227"
+          },
+          "17.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Charente-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "18.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Cher",
+            "DXCC Entity Code": "227"
+          },
+          "19.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Corrèze",
+            "DXCC Entity Code": "227"
+          },
+          "21.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Côte-d\u0027Or",
+            "DXCC Entity Code": "227"
+          },
+          "22.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Côtes-d\u0027Armor",
+            "DXCC Entity Code": "227"
+          },
+          "23.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Creuse",
+            "DXCC Entity Code": "227"
+          },
+          "24.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Dordogne",
+            "DXCC Entity Code": "227"
+          },
+          "25.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Doubs",
+            "DXCC Entity Code": "227"
+          },
+          "26.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Drôme",
+            "DXCC Entity Code": "227"
+          },
+          "27.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Eure",
+            "DXCC Entity Code": "227"
+          },
+          "28.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Eure-et-Loir",
+            "DXCC Entity Code": "227"
+          },
+          "29.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Finistère",
+            "DXCC Entity Code": "227"
+          },
+          "30.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Gard",
+            "DXCC Entity Code": "227"
+          },
+          "31.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Haute-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "32.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Gers",
+            "DXCC Entity Code": "227"
+          },
+          "33.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Gironde",
+            "DXCC Entity Code": "227"
+          },
+          "34.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Hérault",
+            "DXCC Entity Code": "227"
+          },
+          "35.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Ille-et-Vilaine",
+            "DXCC Entity Code": "227"
+          },
+          "36.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Indre",
+            "DXCC Entity Code": "227"
+          },
+          "37.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Indre-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "38.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Isère",
+            "DXCC Entity Code": "227"
+          },
+          "39.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "227"
+          },
+          "40.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Landes",
+            "DXCC Entity Code": "227"
+          },
+          "41.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Loir-et-Cher",
+            "DXCC Entity Code": "227"
+          },
+          "42.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Loire",
+            "DXCC Entity Code": "227"
+          },
+          "43.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Haute-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "44.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Loire-Atlantique",
+            "DXCC Entity Code": "227"
+          },
+          "45.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Loiret",
+            "DXCC Entity Code": "227"
+          },
+          "46.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Lot",
+            "DXCC Entity Code": "227"
+          },
+          "47.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Lot-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "48.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "48",
+            "Primary Administrative Subdivision": "Lozère",
+            "DXCC Entity Code": "227"
+          },
+          "49.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "49",
+            "Primary Administrative Subdivision": "Maine-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "50.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Manche",
+            "DXCC Entity Code": "227"
+          },
+          "51.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "51",
+            "Primary Administrative Subdivision": "Marne",
+            "DXCC Entity Code": "227"
+          },
+          "52.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "52",
+            "Primary Administrative Subdivision": "Haute-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "53.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "53",
+            "Primary Administrative Subdivision": "Mayenne",
+            "DXCC Entity Code": "227"
+          },
+          "54.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Meurthe-et-Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "55.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "55",
+            "Primary Administrative Subdivision": "Meuse",
+            "DXCC Entity Code": "227"
+          },
+          "56.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "56",
+            "Primary Administrative Subdivision": "Morbihan",
+            "DXCC Entity Code": "227"
+          },
+          "57.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "57",
+            "Primary Administrative Subdivision": "Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "58.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "58",
+            "Primary Administrative Subdivision": "Nièvre",
+            "DXCC Entity Code": "227"
+          },
+          "59.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "59",
+            "Primary Administrative Subdivision": "Nord",
+            "DXCC Entity Code": "227"
+          },
+          "60.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "60",
+            "Primary Administrative Subdivision": "Oise",
+            "DXCC Entity Code": "227"
+          },
+          "61.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "61",
+            "Primary Administrative Subdivision": "Orne",
+            "DXCC Entity Code": "227"
+          },
+          "62.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "62",
+            "Primary Administrative Subdivision": "Pas-de-Calais",
+            "DXCC Entity Code": "227"
+          },
+          "63.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "63",
+            "Primary Administrative Subdivision": "Puy-de-Dôme",
+            "DXCC Entity Code": "227"
+          },
+          "64.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "64",
+            "Primary Administrative Subdivision": "Pyrénées-Atlantiques",
+            "DXCC Entity Code": "227"
+          },
+          "65.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "65",
+            "Primary Administrative Subdivision": "Hautes-Pyrénées",
+            "DXCC Entity Code": "227"
+          },
+          "66.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "66",
+            "Primary Administrative Subdivision": "Pyrénées-Orientales",
+            "DXCC Entity Code": "227"
+          },
+          "67.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "67",
+            "Primary Administrative Subdivision": "Bas-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "68.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "68",
+            "Primary Administrative Subdivision": "Haut-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "69.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "69",
+            "Primary Administrative Subdivision": "Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "70.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "70",
+            "Primary Administrative Subdivision": "Haute-Saône",
+            "DXCC Entity Code": "227"
+          },
+          "71.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "71",
+            "Primary Administrative Subdivision": "Saône-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "72.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "72",
+            "Primary Administrative Subdivision": "Sarthe",
+            "DXCC Entity Code": "227"
+          },
+          "73.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "73",
+            "Primary Administrative Subdivision": "Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "74.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "74",
+            "Primary Administrative Subdivision": "Haute-Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "75.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "75",
+            "Primary Administrative Subdivision": "Paris",
+            "DXCC Entity Code": "227"
+          },
+          "76.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "76",
+            "Primary Administrative Subdivision": "Seine-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "77.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "77",
+            "Primary Administrative Subdivision": "Seine-et-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "78.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "78",
+            "Primary Administrative Subdivision": "Yvelines",
+            "DXCC Entity Code": "227"
+          },
+          "79.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "79",
+            "Primary Administrative Subdivision": "Deux-Sèvres",
+            "DXCC Entity Code": "227"
+          },
+          "80.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "80",
+            "Primary Administrative Subdivision": "Somme",
+            "DXCC Entity Code": "227"
+          },
+          "81.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "81",
+            "Primary Administrative Subdivision": "Tarn",
+            "DXCC Entity Code": "227"
+          },
+          "82.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "82",
+            "Primary Administrative Subdivision": "Tarn-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "83.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "83",
+            "Primary Administrative Subdivision": "Var",
+            "DXCC Entity Code": "227"
+          },
+          "84.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "84",
+            "Primary Administrative Subdivision": "Vaucluse",
+            "DXCC Entity Code": "227"
+          },
+          "85.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "85",
+            "Primary Administrative Subdivision": "Vendée",
+            "DXCC Entity Code": "227"
+          },
+          "86.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "86",
+            "Primary Administrative Subdivision": "Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "87.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "87",
+            "Primary Administrative Subdivision": "Haute-Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "88.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "88",
+            "Primary Administrative Subdivision": "Vosges",
+            "DXCC Entity Code": "227"
+          },
+          "89.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "89",
+            "Primary Administrative Subdivision": "Yonne",
+            "DXCC Entity Code": "227"
+          },
+          "90.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "90",
+            "Primary Administrative Subdivision": "Territoire de Belfort",
+            "DXCC Entity Code": "227"
+          },
+          "91.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "91",
+            "Primary Administrative Subdivision": "Essonne",
+            "DXCC Entity Code": "227"
+          },
+          "92.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "92",
+            "Primary Administrative Subdivision": "Hauts-de-Seine",
+            "DXCC Entity Code": "227"
+          },
+          "93.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "93",
+            "Primary Administrative Subdivision": "Seine-Saint-Denis",
+            "DXCC Entity Code": "227"
+          },
+          "94.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "94",
+            "Primary Administrative Subdivision": "Val-de-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "95.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "95",
+            "Primary Administrative Subdivision": "Val-d\u0027Oise",
+            "DXCC Entity Code": "227"
+          },
+          "BB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BB",
+            "Primary Administrative Subdivision": "Brandenburg",
+            "DXCC Entity Code": "230"
+          },
+          "BE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Berlin",
+            "DXCC Entity Code": "230"
+          },
+          "BW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Baden-Württemberg",
+            "DXCC Entity Code": "230"
+          },
+          "BY.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BY",
+            "Primary Administrative Subdivision": "Bayern",
+            "DXCC Entity Code": "230"
+          },
+          "HB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Bremen",
+            "DXCC Entity Code": "230"
+          },
+          "HE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hessen",
+            "DXCC Entity Code": "230"
+          },
+          "HH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HH",
+            "Primary Administrative Subdivision": "Hamburg",
+            "DXCC Entity Code": "230"
+          },
+          "MV.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Mecklenburg-Vorpommern",
+            "DXCC Entity Code": "230"
+          },
+          "NI.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Niedersachsen",
+            "DXCC Entity Code": "230"
+          },
+          "NW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nordrhein-Westfalen",
+            "DXCC Entity Code": "230"
+          },
+          "RP.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RP",
+            "Primary Administrative Subdivision": "Rheinland-Pfalz",
+            "DXCC Entity Code": "230"
+          },
+          "SL.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Saarland",
+            "DXCC Entity Code": "230"
+          },
+          "SH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schleswig-Holstein",
+            "DXCC Entity Code": "230"
+          },
+          "SN.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Sachsen",
+            "DXCC Entity Code": "230"
+          },
+          "ST.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Sachsen-Anhalt",
+            "DXCC Entity Code": "230"
+          },
+          "TH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TH",
+            "Primary Administrative Subdivision": "Thüringen",
+            "DXCC Entity Code": "230"
+          },
+          "GY.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GY",
+            "Primary Administrative Subdivision": "Gyõr",
+            "DXCC Entity Code": "239",
+            "Comments": "Gyõr-Moson-Sopron"
+          },
+          "VA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vas",
+            "DXCC Entity Code": "239"
+          },
+          "ZA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zala",
+            "DXCC Entity Code": "239"
+          },
+          "KO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Komárom",
+            "DXCC Entity Code": "239",
+            "Comments": "Komárom-Esztergom"
+          },
+          "VE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Veszprém",
+            "DXCC Entity Code": "239"
+          },
+          "BA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Baranya",
+            "DXCC Entity Code": "239"
+          },
+          "SO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Somogy",
+            "DXCC Entity Code": "239"
+          },
+          "TO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tolna",
+            "DXCC Entity Code": "239"
+          },
+          "FE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Fejér",
+            "DXCC Entity Code": "239"
+          },
+          "BP.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BP",
+            "Primary Administrative Subdivision": "Budapest",
+            "DXCC Entity Code": "239"
+          },
+          "HE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Heves",
+            "DXCC Entity Code": "239"
+          },
+          "NG.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NG",
+            "Primary Administrative Subdivision": "Nógrád",
+            "DXCC Entity Code": "239"
+          },
+          "PE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pest",
+            "DXCC Entity Code": "239"
+          },
+          "SZ.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Szolnok",
+            "DXCC Entity Code": "239",
+            "Comments": "Jász-Nagykun-Szolnok"
+          },
+          "BE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Békés",
+            "DXCC Entity Code": "239"
+          },
+          "BN.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bács-Kiskun",
+            "DXCC Entity Code": "239"
+          },
+          "CS.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Csongrád",
+            "DXCC Entity Code": "239"
+          },
+          "BO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Borsod",
+            "DXCC Entity Code": "239",
+            "Comments": "Borsod-Abaúj-Zemplén"
+          },
+          "HB.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hajdú-Bihar",
+            "DXCC Entity Code": "239"
+          },
+          "SA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Szabolcs",
+            "DXCC Entity Code": "239",
+            "Comments": "Szabolcs-Szatmár-Bereg"
+          },
+          "CW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CW",
+            "Primary Administrative Subdivision": "Carlow",
+            "DXCC Entity Code": "245",
+            "Comments": "Ceatharlach"
+          },
+          "CN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cavan",
+            "DXCC Entity Code": "245",
+            "Comments": "An Cabhán"
+          },
+          "CE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Clare",
+            "DXCC Entity Code": "245",
+            "Comments": "An Clár"
+          },
+          "C.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Import-only": "true",
+            "Comments": "Corcaigh"
+          },
+          "CO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Comments": "Corcaigh"
+          },
+          "DL.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Donegal",
+            "DXCC Entity Code": "245",
+            "Comments": "Dún na nGall"
+          },
+          "D.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dublin",
+            "DXCC Entity Code": "245",
+            "Comments": "Baile Áth Cliath"
+          },
+          "G.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Galway",
+            "DXCC Entity Code": "245",
+            "Comments": "Gaillimh"
+          },
+          "KY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kerry",
+            "DXCC Entity Code": "245",
+            "Comments": "Ciarraí"
+          },
+          "KE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kildare",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Dara"
+          },
+          "KK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Kilkenny",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Chainnigh"
+          },
+          "LS.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LS",
+            "Primary Administrative Subdivision": "Laois",
+            "DXCC Entity Code": "245",
+            "Comments": "Laois"
+          },
+          "LM.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LM",
+            "Primary Administrative Subdivision": "Leitrim",
+            "DXCC Entity Code": "245",
+            "Comments": "Liatroim"
+          },
+          "LK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LK",
+            "Primary Administrative Subdivision": "Limerick",
+            "DXCC Entity Code": "245",
+            "Comments": "Luimneach"
+          },
+          "LD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Longford",
+            "DXCC Entity Code": "245",
+            "Comments": "An Longfort"
+          },
+          "LH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Louth",
+            "DXCC Entity Code": "245",
+            "Comments": "Lú"
+          },
+          "MO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Mayo",
+            "DXCC Entity Code": "245",
+            "Comments": "Maigh Eo"
+          },
+          "MH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Meath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Mhí"
+          },
+          "MN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Monaghan",
+            "DXCC Entity Code": "245",
+            "Comments": "Muineachán"
+          },
+          "OY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OY",
+            "Primary Administrative Subdivision": "Offaly",
+            "DXCC Entity Code": "245",
+            "Comments": "Uíbh Fhailí"
+          },
+          "RN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Roscommon",
+            "DXCC Entity Code": "245",
+            "Comments": "Ros Comáin"
+          },
+          "SO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sligo",
+            "DXCC Entity Code": "245",
+            "Comments": "Sligeach"
+          },
+          "TA.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tipperary",
+            "DXCC Entity Code": "245",
+            "Comments": "Tiobraid Árann"
+          },
+          "WD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WD",
+            "Primary Administrative Subdivision": "Waterford",
+            "DXCC Entity Code": "245",
+            "Comments": "Port Láirge"
+          },
+          "WH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WH",
+            "Primary Administrative Subdivision": "Westmeath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Iarmhí"
+          },
+          "WX.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WX",
+            "Primary Administrative Subdivision": "Wexford",
+            "DXCC Entity Code": "245",
+            "Comments": "Loch Garman"
+          },
+          "WW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WW",
+            "Primary Administrative Subdivision": "Wicklow",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Mhantáin"
+          },
+          "GE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "IM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imperia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "La Spezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Savona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "AL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alessandria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Asti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "BI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biella",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "CN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cuneo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "NO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Novara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "TO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Torino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Verbano Cusio Ossola",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Vercelli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Aosta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Aosta Valley (Valle D\u0027Aosta)"
+          },
+          "BG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bergamo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Brescia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Como",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Cremona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Lecco",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Lodi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Monza e Brianza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Mantova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Milano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "PV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PV",
+            "Primary Administrative Subdivision": "Pavia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "SO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sondrio",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "VA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Varese",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Belluno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "PD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Padova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "RO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rovigo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "TV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Treviso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Venezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Verona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vicenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "BZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bolzano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "TN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Trento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "GO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Gorizia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "PN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PN",
+            "Primary Administrative Subdivision": "Pordenone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "TS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TS",
+            "Primary Administrative Subdivision": "Trieste",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "UD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Udine",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "BO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bologna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Ferrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FO",
+            "Primary Administrative Subdivision": "Forlì",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna",
+            "Import-only": "true"
+          },
+          "FC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FC",
+            "Primary Administrative Subdivision": "Forlì-Cesena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "MO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Modena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Parma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "Piacenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ravenna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reggio Emilia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rimini",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "AR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arezzo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "FI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FI",
+            "Primary Administrative Subdivision": "Firenze",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "GR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grosseto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Livorno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lucca",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "MS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Massa Carrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Pistoia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Pisa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Prato",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "SI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SI",
+            "Primary Administrative Subdivision": "Siena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "CH.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AQ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AQ",
+            "Primary Administrative Subdivision": "L\u0027Aquila",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "PE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pescara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "TE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teramo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Ancona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "AP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Ascoli Piceno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "FM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FM",
+            "Primary Administrative Subdivision": "Fermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MC",
+            "Primary Administrative Subdivision": "Macerata",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "PS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche",
+            "Import-only": "true"
+          },
+          "PU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PU",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Matera",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "PZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PZ",
+            "Primary Administrative Subdivision": "Potenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "BA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bari",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Barletta-Andria-Trani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brindisi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "FG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FG",
+            "Primary Administrative Subdivision": "Foggia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "LE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Lecce",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "TA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Taranto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "CZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CZ",
+            "Primary Administrative Subdivision": "Catanzaro",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "CS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Cosenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "KR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Crotone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "RC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RC",
+            "Primary Administrative Subdivision": "Reggio Calabria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "VV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VV",
+            "Primary Administrative Subdivision": "Vibo Valentia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "AV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Avellino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "BN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Benevento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "CE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Caserta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "NA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Napoli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "SA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salerno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "IS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Isernia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "CB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Campobasso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "FR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Frosinone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "LT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LT",
+            "Primary Administrative Subdivision": "Latina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Roma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "VT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Viterbo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "PG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Perugia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "TR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Terni",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "AG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Agrigento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Caltanissetta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Catania",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "EN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EN",
+            "Primary Administrative Subdivision": "Enna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "ME.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Messina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "PA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Palermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "RG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RG",
+            "Primary Administrative Subdivision": "Ragusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "SR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Siracusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "TP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TP",
+            "Primary Administrative Subdivision": "Trapani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "21.259": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Svalbard",
+            "DXCC Entity Code": "259"
+          },
+          "42.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Agder",
+            "DXCC Entity Code": "266"
+          },
+          "34.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Innlandet",
+            "DXCC Entity Code": "266"
+          },
+          "15.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Møre og Romsdal",
+            "DXCC Entity Code": "266"
+          },
+          "18.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Nordland",
+            "DXCC Entity Code": "266"
+          },
+          "03.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Oslo",
+            "DXCC Entity Code": "266"
+          },
+          "11.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Rogaland",
+            "DXCC Entity Code": "266"
+          },
+          "54.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Troms og Finnmark",
+            "DXCC Entity Code": "266"
+          },
+          "50.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Trøndelag",
+            "DXCC Entity Code": "266"
+          },
+          "38.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Vestfold og Telemark",
+            "DXCC Entity Code": "266"
+          },
+          "46.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Vestland",
+            "DXCC Entity Code": "266"
+          },
+          "30.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Viken",
+            "DXCC Entity Code": "266"
+          },
+          "MD.256": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Madeira",
+            "DXCC Entity Code": "256"
+          },
+          "DR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DR",
+            "Primary Administrative Subdivision": "Drenthe",
+            "DXCC Entity Code": "263"
+          },
+          "FR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Fryslân",
+            "DXCC Entity Code": "263"
+          },
+          "GR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Groningen",
+            "DXCC Entity Code": "263"
+          },
+          "NB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Noord-Brabant",
+            "DXCC Entity Code": "263"
+          },
+          "OV.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Overijssel",
+            "DXCC Entity Code": "263"
+          },
+          "ZH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuid-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "FL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Flevoland",
+            "DXCC Entity Code": "263"
+          },
+          "GD.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "GE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263"
+          },
+          "LB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "LI.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263"
+          },
+          "NH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "Noord-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "UT.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utrecht",
+            "DXCC Entity Code": "263"
+          },
+          "ZL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZL",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "ZE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263"
+          },
+          "Z.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zachodnio-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "F.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "P.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Kujawsko-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "B.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Lubuskie",
+            "DXCC Entity Code": "269"
+          },
+          "W.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Wielkopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "J.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Warminsko-Mazurskie",
+            "DXCC Entity Code": "269"
+          },
+          "O.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Podlaskie",
+            "DXCC Entity Code": "269"
+          },
+          "R.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Mazowieckie",
+            "DXCC Entity Code": "269"
+          },
+          "D.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dolnoslaskie",
+            "DXCC Entity Code": "269"
+          },
+          "U.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Opolskie",
+            "DXCC Entity Code": "269"
+          },
+          "C.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Lodzkie",
+            "DXCC Entity Code": "269"
+          },
+          "S.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Swietokrzyskie",
+            "DXCC Entity Code": "269"
+          },
+          "K.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Podkarpackie",
+            "DXCC Entity Code": "269"
+          },
+          "L.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lubelskie",
+            "DXCC Entity Code": "269"
+          },
+          "G.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Slaskie",
+            "DXCC Entity Code": "269"
+          },
+          "M.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Malopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "AV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Aveiro",
+            "DXCC Entity Code": "272"
+          },
+          "BJ.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beja",
+            "DXCC Entity Code": "272"
+          },
+          "BR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braga",
+            "DXCC Entity Code": "272"
+          },
+          "BG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bragança",
+            "DXCC Entity Code": "272"
+          },
+          "CB.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Castelo Branco",
+            "DXCC Entity Code": "272"
+          },
+          "CO.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coimbra",
+            "DXCC Entity Code": "272"
+          },
+          "EV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evora",
+            "DXCC Entity Code": "272"
+          },
+          "FR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Faro",
+            "DXCC Entity Code": "272"
+          },
+          "GD.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guarda",
+            "DXCC Entity Code": "272"
+          },
+          "LR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Leiria",
+            "DXCC Entity Code": "272"
+          },
+          "LX.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LX",
+            "Primary Administrative Subdivision": "Lisboa",
+            "DXCC Entity Code": "272"
+          },
+          "PG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Portalegre",
+            "DXCC Entity Code": "272"
+          },
+          "PT.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Porto",
+            "DXCC Entity Code": "272"
+          },
+          "SR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Santarem",
+            "DXCC Entity Code": "272"
+          },
+          "ST.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Setubal",
+            "DXCC Entity Code": "272"
+          },
+          "VC.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Viana do Castelo",
+            "DXCC Entity Code": "272"
+          },
+          "VR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vila Real",
+            "DXCC Entity Code": "272"
+          },
+          "VS.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Viseu",
+            "DXCC Entity Code": "272"
+          },
+          "AR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arad",
+            "DXCC Entity Code": "275"
+          },
+          "CS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Caraș-Severin",
+            "DXCC Entity Code": "275"
+          },
+          "HD.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HD",
+            "Primary Administrative Subdivision": "Hunedoara",
+            "DXCC Entity Code": "275"
+          },
+          "TM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Timiș",
+            "DXCC Entity Code": "275"
+          },
+          "BU.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Bucureşti",
+            "DXCC Entity Code": "275",
+            "Import-only": "true",
+            "Comments": "Bucure\u0027ti"
+          },
+          "B.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "București",
+            "DXCC Entity Code": "275"
+          },
+          "IF.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ilfov",
+            "DXCC Entity Code": "275"
+          },
+          "BR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brăila",
+            "DXCC Entity Code": "275"
+          },
+          "CT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Constanța",
+            "DXCC Entity Code": "275"
+          },
+          "GL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Galați",
+            "DXCC Entity Code": "275"
+          },
+          "TL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tulcea",
+            "DXCC Entity Code": "275"
+          },
+          "VN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Vrancea",
+            "DXCC Entity Code": "275"
+          },
+          "AB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alba",
+            "DXCC Entity Code": "275"
+          },
+          "BH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BH",
+            "Primary Administrative Subdivision": "Bihor",
+            "DXCC Entity Code": "275"
+          },
+          "BN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bistrița-Năsăud",
+            "DXCC Entity Code": "275"
+          },
+          "CJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJ",
+            "Primary Administrative Subdivision": "Cluj",
+            "DXCC Entity Code": "275"
+          },
+          "MM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MM",
+            "Primary Administrative Subdivision": "Maramureș",
+            "DXCC Entity Code": "275"
+          },
+          "SJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "Sălaj",
+            "DXCC Entity Code": "275"
+          },
+          "SM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Satu Mare",
+            "DXCC Entity Code": "275"
+          },
+          "BV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BV",
+            "Primary Administrative Subdivision": "Brașov",
+            "DXCC Entity Code": "275"
+          },
+          "CV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CV",
+            "Primary Administrative Subdivision": "Covasna",
+            "DXCC Entity Code": "275"
+          },
+          "HR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Harghita",
+            "DXCC Entity Code": "275"
+          },
+          "MS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mureș",
+            "DXCC Entity Code": "275"
+          },
+          "SB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Sibiu",
+            "DXCC Entity Code": "275"
+          },
+          "AG.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Argeș",
+            "DXCC Entity Code": "275"
+          },
+          "DJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DJ",
+            "Primary Administrative Subdivision": "Dolj",
+            "DXCC Entity Code": "275"
+          },
+          "GJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gorj",
+            "DXCC Entity Code": "275"
+          },
+          "MH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mehedinți",
+            "DXCC Entity Code": "275"
+          },
+          "OT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olt",
+            "DXCC Entity Code": "275"
+          },
+          "VL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vâlcea",
+            "DXCC Entity Code": "275"
+          },
+          "BC.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bacău",
+            "DXCC Entity Code": "275"
+          },
+          "BT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Botoșani",
+            "DXCC Entity Code": "275"
+          },
+          "IS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Iași",
+            "DXCC Entity Code": "275"
+          },
+          "NT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Neamț",
+            "DXCC Entity Code": "275"
+          },
+          "SV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Suceava",
+            "DXCC Entity Code": "275"
+          },
+          "VS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Vaslui",
+            "DXCC Entity Code": "275"
+          },
+          "BZ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Buzău",
+            "DXCC Entity Code": "275"
+          },
+          "CL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Călărași",
+            "DXCC Entity Code": "275"
+          },
+          "DB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DB",
+            "Primary Administrative Subdivision": "Dâmbovița",
+            "DXCC Entity Code": "275"
+          },
+          "GR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Giurgiu",
+            "DXCC Entity Code": "275"
+          },
+          "IL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Ialomița",
+            "DXCC Entity Code": "275"
+          },
+          "PH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PH",
+            "Primary Administrative Subdivision": "Prahova",
+            "DXCC Entity Code": "275"
+          },
+          "TR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Teleorman",
+            "DXCC Entity Code": "275"
+          },
+          "AV.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Ávila",
+            "DXCC Entity Code": "281"
+          },
+          "BU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgos",
+            "DXCC Entity Code": "281"
+          },
+          "C.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "A Coruña",
+            "DXCC Entity Code": "281"
+          },
+          "LE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "León",
+            "DXCC Entity Code": "281"
+          },
+          "LO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "281"
+          },
+          "LU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lugo",
+            "DXCC Entity Code": "281"
+          },
+          "O.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Asturias",
+            "DXCC Entity Code": "281"
+          },
+          "OU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OU",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281",
+            "Import-only": "true"
+          },
+          "OR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281"
+          },
+          "P.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Palencia",
+            "DXCC Entity Code": "281"
+          },
+          "PO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Pontevedra",
+            "DXCC Entity Code": "281"
+          },
+          "S.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Cantabria",
+            "DXCC Entity Code": "281"
+          },
+          "SA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salamanca",
+            "DXCC Entity Code": "281"
+          },
+          "SG.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "Segovia",
+            "DXCC Entity Code": "281"
+          },
+          "SO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soria",
+            "DXCC Entity Code": "281"
+          },
+          "VA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Valladolid",
+            "DXCC Entity Code": "281"
+          },
+          "ZA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zamora",
+            "DXCC Entity Code": "281"
+          },
+          "BI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Bizkaia",
+            "DXCC Entity Code": "281"
+          },
+          "HU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HU",
+            "Primary Administrative Subdivision": "Huesca",
+            "DXCC Entity Code": "281"
+          },
+          "NA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Navarra",
+            "DXCC Entity Code": "281"
+          },
+          "SS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Gipuzkoa",
+            "DXCC Entity Code": "281"
+          },
+          "TE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teruel",
+            "DXCC Entity Code": "281"
+          },
+          "VI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Álava",
+            "DXCC Entity Code": "281"
+          },
+          "Z.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zaragoza",
+            "DXCC Entity Code": "281"
+          },
+          "B.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Barcelona",
+            "DXCC Entity Code": "281"
+          },
+          "GI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GI",
+            "Primary Administrative Subdivision": "Girona",
+            "DXCC Entity Code": "281"
+          },
+          "L.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lleida",
+            "DXCC Entity Code": "281"
+          },
+          "T.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tarragona",
+            "DXCC Entity Code": "281"
+          },
+          "BA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Badajoz",
+            "DXCC Entity Code": "281"
+          },
+          "CC.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CC",
+            "Primary Administrative Subdivision": "Cáceres",
+            "DXCC Entity Code": "281"
+          },
+          "CR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Ciudad Real",
+            "DXCC Entity Code": "281"
+          },
+          "CU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Cuenca",
+            "DXCC Entity Code": "281"
+          },
+          "GU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guadalajara",
+            "DXCC Entity Code": "281"
+          },
+          "M.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Madrid",
+            "DXCC Entity Code": "281"
+          },
+          "TO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Toledo",
+            "DXCC Entity Code": "281"
+          },
+          "A.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Alicante",
+            "DXCC Entity Code": "281"
+          },
+          "AB.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Albacete",
+            "DXCC Entity Code": "281"
+          },
+          "CS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Castellón",
+            "DXCC Entity Code": "281"
+          },
+          "MU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murcia",
+            "DXCC Entity Code": "281"
+          },
+          "V.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "València",
+            "DXCC Entity Code": "281"
+          },
+          "AL.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Almeria",
+            "DXCC Entity Code": "281"
+          },
+          "CA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cádiz",
+            "DXCC Entity Code": "281"
+          },
+          "CO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "281"
+          },
+          "GR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Granada",
+            "DXCC Entity Code": "281"
+          },
+          "H.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Huelva",
+            "DXCC Entity Code": "281"
+          },
+          "J.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Jaén",
+            "DXCC Entity Code": "281"
+          },
+          "MA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Málaga",
+            "DXCC Entity Code": "281"
+          },
+          "SE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sevilla",
+            "DXCC Entity Code": "281"
+          },
+          "AB.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Stockholms län",
+            "DXCC Entity Code": "284"
+          },
+          "I.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Gotlands län",
+            "DXCC Entity Code": "284"
+          },
+          "BD.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BD",
+            "Primary Administrative Subdivision": "Norrbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "AC.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Västerbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "X.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Gävleborgs län",
+            "DXCC Entity Code": "284"
+          },
+          "Z.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Jämtlands län",
+            "DXCC Entity Code": "284"
+          },
+          "Y.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Västernorrlands län",
+            "DXCC Entity Code": "284"
+          },
+          "W.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Dalarnas län",
+            "DXCC Entity Code": "284"
+          },
+          "S.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Värmlands län",
+            "DXCC Entity Code": "284"
+          },
+          "O.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Västra Götalands län",
+            "DXCC Entity Code": "284"
+          },
+          "T.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Örebro län",
+            "DXCC Entity Code": "284"
+          },
+          "E.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Östergötlands län",
+            "DXCC Entity Code": "284"
+          },
+          "D.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Södermanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "C.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Uppsala län",
+            "DXCC Entity Code": "284"
+          },
+          "U.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Västmanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "N.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Hallands län",
+            "DXCC Entity Code": "284"
+          },
+          "K.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Blekinge län",
+            "DXCC Entity Code": "284"
+          },
+          "F.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Jönköpings län",
+            "DXCC Entity Code": "284"
+          },
+          "H.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Kalmar län",
+            "DXCC Entity Code": "284"
+          },
+          "G.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Kronobergs län",
+            "DXCC Entity Code": "284"
+          },
+          "M.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Skåne län",
+            "DXCC Entity Code": "284"
+          },
+          "AG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Aargau",
+            "DXCC Entity Code": "287"
+          },
+          "AR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Appenzell Ausserrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "AI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Appenzell Innerrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "BL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Basel Landschaft",
+            "DXCC Entity Code": "287"
+          },
+          "BS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Basel Stadt",
+            "DXCC Entity Code": "287"
+          },
+          "BE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Bern",
+            "DXCC Entity Code": "287"
+          },
+          "FR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freiburg / Fribourg",
+            "DXCC Entity Code": "287"
+          },
+          "GE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genf / Genève",
+            "DXCC Entity Code": "287"
+          },
+          "GL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Glarus",
+            "DXCC Entity Code": "287"
+          },
+          "GR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Graubuenden / Grisons",
+            "DXCC Entity Code": "287"
+          },
+          "JU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "287"
+          },
+          "LU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luzern",
+            "DXCC Entity Code": "287"
+          },
+          "NE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Neuenburg / Neuchâtel",
+            "DXCC Entity Code": "287"
+          },
+          "NW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nidwalden",
+            "DXCC Entity Code": "287"
+          },
+          "OW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Obwalden",
+            "DXCC Entity Code": "287"
+          },
+          "SH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schaffhausen",
+            "DXCC Entity Code": "287"
+          },
+          "SZ.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwyz",
+            "DXCC Entity Code": "287"
+          },
+          "SO.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Solothurn",
+            "DXCC Entity Code": "287"
+          },
+          "SG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "St. Gallen",
+            "DXCC Entity Code": "287"
+          },
+          "TI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TI",
+            "Primary Administrative Subdivision": "Tessin / Ticino",
+            "DXCC Entity Code": "287"
+          },
+          "TG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Thurgau",
+            "DXCC Entity Code": "287"
+          },
+          "UR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UR",
+            "Primary Administrative Subdivision": "Uri",
+            "DXCC Entity Code": "287"
+          },
+          "VD.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Waadt / Vaud",
+            "DXCC Entity Code": "287"
+          },
+          "VS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Wallis / Valais",
+            "DXCC Entity Code": "287"
+          },
+          "ZH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuerich",
+            "DXCC Entity Code": "287"
+          },
+          "ZG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZG",
+            "Primary Administrative Subdivision": "Zug",
+            "DXCC Entity Code": "287"
+          },
+          "SU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sums\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "TE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Ternopil\u0027s\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Cherkas\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zakarpats\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dnipropetrovs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "OD.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odes\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Khersons\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "PO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Poltavs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Donets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "RI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rivnens\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Kharkivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luhans\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vinnyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Volyos\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZP.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZP",
+            "Primary Administrative Subdivision": "Zaporiz\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Chernihivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "IF.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ivano-Frankivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HM.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khmel\u0027nyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KV",
+            "Primary Administrative Subdivision": "Kyïv",
+            "DXCC Entity Code": "288"
+          },
+          "KO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Kyivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirovohrads\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "L\u0027vivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zhytomyrs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Chernivets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "NI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Mykolaivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Respublika Krym",
+            "DXCC Entity Code": "288"
+          },
+          "SL.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sevastopol\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Connecticut",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "ME.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Maine",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Massachusetts",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "New Hampshire",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "RI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rhode Island",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "VT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Vermont",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NJ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NJ",
+            "Primary Administrative Subdivision": "New Jersey",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NY",
+            "Primary Administrative Subdivision": "New York",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DE",
+            "Primary Administrative Subdivision": "Delaware",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "District of Columbia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Maryland",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "PA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pennsylvania",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alabama",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "FL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "GA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Georgia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "KY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kentucky",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "NC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NC",
+            "Primary Administrative Subdivision": "North Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "SC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "South Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "TN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tennessee",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "VA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "LA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Louisiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mississippi",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NM.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "New Mexico",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "OK.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OK",
+            "Primary Administrative Subdivision": "Oklahoma",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "TX.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TX",
+            "Primary Administrative Subdivision": "Texas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "CA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "California",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "AZ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AZ",
+            "Primary Administrative Subdivision": "Arizona",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "ID.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ID",
+            "Primary Administrative Subdivision": "Idaho",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "MT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "06/07"
+          },
+          "NV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Nevada",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "OR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oregon",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "UT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utah",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "WA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Washington",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "WY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Wyoming",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Michigan",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "OH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OH",
+            "Primary Administrative Subdivision": "Ohio",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "IL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Illinois",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "IN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Indiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WI",
+            "Primary Administrative Subdivision": "Wisconsin",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "CO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colorado",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "IA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IA",
+            "Primary Administrative Subdivision": "Iowa",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "KS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Minnesota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Missouri",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nebraska",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "ND.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "North Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "SD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "South Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "AH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AH",
+            "Primary Administrative Subdivision": "Anhui",
+            "DXCC Entity Code": "318"
+          },
+          "BJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beijing",
+            "DXCC Entity Code": "318"
+          },
+          "CQ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CQ",
+            "Primary Administrative Subdivision": "Chongqing",
+            "DXCC Entity Code": "318"
+          },
+          "FJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJ",
+            "Primary Administrative Subdivision": "Fujian",
+            "DXCC Entity Code": "318"
+          },
+          "GD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guangdong",
+            "DXCC Entity Code": "318"
+          },
+          "GS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Gansu",
+            "DXCC Entity Code": "318"
+          },
+          "GX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GX",
+            "Primary Administrative Subdivision": "Guangxi Zhuangzu",
+            "DXCC Entity Code": "318"
+          },
+          "GZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZ",
+            "Primary Administrative Subdivision": "Guizhou",
+            "DXCC Entity Code": "318"
+          },
+          "HA.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Henan",
+            "DXCC Entity Code": "318"
+          },
+          "HB.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hubei",
+            "DXCC Entity Code": "318"
+          },
+          "HE.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hebei",
+            "DXCC Entity Code": "318"
+          },
+          "HI.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hainan",
+            "DXCC Entity Code": "318"
+          },
+          "HL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Heilongjiang",
+            "DXCC Entity Code": "318"
+          },
+          "HN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HN",
+            "Primary Administrative Subdivision": "Hunan",
+            "DXCC Entity Code": "318"
+          },
+          "JL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JL",
+            "Primary Administrative Subdivision": "Jilin",
+            "DXCC Entity Code": "318"
+          },
+          "JS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JS",
+            "Primary Administrative Subdivision": "Jiangsu",
+            "DXCC Entity Code": "318"
+          },
+          "JX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JX",
+            "Primary Administrative Subdivision": "Jiangxi",
+            "DXCC Entity Code": "318"
+          },
+          "LN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Liaoning",
+            "DXCC Entity Code": "318"
+          },
+          "NM.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Nei Mongol",
+            "DXCC Entity Code": "318"
+          },
+          "NX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NX",
+            "Primary Administrative Subdivision": "Ningxia Huizu",
+            "DXCC Entity Code": "318"
+          },
+          "QH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QH",
+            "Primary Administrative Subdivision": "Qinghai",
+            "DXCC Entity Code": "318"
+          },
+          "SC.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Sichuan",
+            "DXCC Entity Code": "318"
+          },
+          "SD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Shandong",
+            "DXCC Entity Code": "318"
+          },
+          "SH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Shanghai",
+            "DXCC Entity Code": "318"
+          },
+          "SN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Shaanxi",
+            "DXCC Entity Code": "318"
+          },
+          "SX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SX",
+            "Primary Administrative Subdivision": "Shanxi",
+            "DXCC Entity Code": "318"
+          },
+          "TJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TJ",
+            "Primary Administrative Subdivision": "Tianjin",
+            "DXCC Entity Code": "318"
+          },
+          "XJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XJ",
+            "Primary Administrative Subdivision": "Xinjiang Uygur",
+            "DXCC Entity Code": "318"
+          },
+          "XZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XZ",
+            "Primary Administrative Subdivision": "Xizang",
+            "DXCC Entity Code": "318"
+          },
+          "YN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yunnan",
+            "DXCC Entity Code": "318"
+          },
+          "ZJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZJ",
+            "Primary Administrative Subdivision": "Zhejiang",
+            "DXCC Entity Code": "318"
+          },
+          "AP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Andhra Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arunāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AS.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AS",
+            "Primary Administrative Subdivision": "Assam",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "BR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bihār",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "CH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chandīgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "CG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CG",
+            "Primary Administrative Subdivision": "Chhattīsgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "DD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DD",
+            "Primary Administrative Subdivision": "Damān and Diu",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Delhi",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dādra and Nagar Haveli",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "GA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Goa",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "GJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gujarāt",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Haryāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HP",
+            "Primary Administrative Subdivision": "Himāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "JK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JK",
+            "Primary Administrative Subdivision": "Jammu and Kashmīr",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "JH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JH",
+            "Primary Administrative Subdivision": "Jhārkhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Karnātaka",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Kerala",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "LA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Ladākh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "MP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MP",
+            "Primary Administrative Subdivision": "Madhya Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mahārāshtra",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Manipur",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "ML.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Meghālaya",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MZ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mizoram",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "NL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nāgāland",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "OD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odisha",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "PY.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PY",
+            "Primary Administrative Subdivision": "Puducherry",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "PB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Punjab",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "RJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rājasthān",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "SK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Sikkim",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tamil Nādu",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Telangāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Tripura",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UP",
+            "Primary Administrative Subdivision": "Uttar Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UK",
+            "Primary Administrative Subdivision": "Uttarākhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "WB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "West Bengal",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "12.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Chiba",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "16.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Gunma",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "14.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Ibaraki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "11.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Kanagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "13.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Saitama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "15.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Tochigi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "10.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Tokyo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "17.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Yamanashi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "20.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Aichi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "19.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Gifu",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "21.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Mie",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "18.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Shizuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "27.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Hyogo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "22.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Kyoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "24.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Nara",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "25.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Osaka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "23.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Shiga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "26.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Wakayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "35.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Hiroshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "31.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Okayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "32.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Shimane",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "34.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Tottori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "33.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Yamaguchi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "38.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Ehime",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "36.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Kagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "39.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Kochi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "37.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Tokushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "40.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Fukuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "46.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Kagoshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "43.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Kumamoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "45.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Miyazaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "42.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Nagasaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "44.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Oita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "47.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Okinawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "41.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Saga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "04.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Akita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "02.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aomori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "07.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Fukushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "03.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Iwate",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "06.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Miyagi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "05.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Yamagata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "01.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Hokkaido",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokkaido"
+          },
+          "29.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Fukui",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "30.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Ishikawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "28.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Toyama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "09.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Nagano",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "08.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Niigata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "AUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUR",
+            "Primary Administrative Subdivision": "Aurora",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "BTG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTG",
+            "Primary Administrative Subdivision": "Batangas",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "CAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAV",
+            "Primary Administrative Subdivision": "Cavite",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "LAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAG",
+            "Primary Administrative Subdivision": "Laguna",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MAD.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAD",
+            "Primary Administrative Subdivision": "Marinduque",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDC",
+            "Primary Administrative Subdivision": "Mindoro Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDR",
+            "Primary Administrative Subdivision": "Mindoro Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "PLW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PLW",
+            "Primary Administrative Subdivision": "Palawan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "QUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Quezon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "RIZ.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RIZ",
+            "Primary Administrative Subdivision": "Rizal",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ROM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROM",
+            "Primary Administrative Subdivision": "Romblon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ILN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILN",
+            "Primary Administrative Subdivision": "Ilocos Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "ILS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILS",
+            "Primary Administrative Subdivision": "Ilocos Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "LUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUN",
+            "Primary Administrative Subdivision": "La Union",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "PAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAN",
+            "Primary Administrative Subdivision": "Pangasinan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "BTN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTN",
+            "Primary Administrative Subdivision": "Batanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "CAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAG",
+            "Primary Administrative Subdivision": "Cagayan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ISA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ISA",
+            "Primary Administrative Subdivision": "Isabela",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "NUV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUV",
+            "Primary Administrative Subdivision": "Nueva Vizcaya",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "QUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUI",
+            "Primary Administrative Subdivision": "Quirino",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ABR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ABR",
+            "Primary Administrative Subdivision": "Abra",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "APA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Apayao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BEN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BEN",
+            "Primary Administrative Subdivision": "Benguet",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "IFU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IFU",
+            "Primary Administrative Subdivision": "Ifugao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "KAL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KAL",
+            "Primary Administrative Subdivision": "Kalinga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "MOU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOU",
+            "Primary Administrative Subdivision": "Mountain Province",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Bataan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "BUL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUL",
+            "Primary Administrative Subdivision": "Bulacan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "NUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUE",
+            "Primary Administrative Subdivision": "Nueva Ecija",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "PAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAM",
+            "Primary Administrative Subdivision": "Pampanga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "TAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAR",
+            "Primary Administrative Subdivision": "Tarlac",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ZMB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMB",
+            "Primary Administrative Subdivision": "Zambales",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ALB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ALB",
+            "Primary Administrative Subdivision": "Albay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Camarines Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAS",
+            "Primary Administrative Subdivision": "Camarines Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAT",
+            "Primary Administrative Subdivision": "Catanduanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "MAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAS",
+            "Primary Administrative Subdivision": "Masbate",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "SOR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOR",
+            "Primary Administrative Subdivision": "Sorsogon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "BIL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BIL",
+            "Primary Administrative Subdivision": "Biliran",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "EAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EAS",
+            "Primary Administrative Subdivision": "Eastern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "LEY.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEY",
+            "Primary Administrative Subdivision": "Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "NSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "Northern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "SLE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLE",
+            "Primary Administrative Subdivision": "Southern Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "WSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WSA",
+            "Primary Administrative Subdivision": "Western Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "AKL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AKL",
+            "Primary Administrative Subdivision": "Aklan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ANT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ANT",
+            "Primary Administrative Subdivision": "Antique",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "CAP.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAP",
+            "Primary Administrative Subdivision": "Capiz",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "GUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUI",
+            "Primary Administrative Subdivision": "Guimaras",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ILI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILI",
+            "Primary Administrative Subdivision": "Iloilo",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "NEC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NEC",
+            "Primary Administrative Subdivision": "Negros Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "BOH.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOH",
+            "Primary Administrative Subdivision": "Bohol",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "CEB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CEB",
+            "Primary Administrative Subdivision": "Cebu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "NER.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NER",
+            "Primary Administrative Subdivision": "Negros Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "SIG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIG",
+            "Primary Administrative Subdivision": "Siquijor",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "ZAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAN",
+            "Primary Administrative Subdivision": "Zamboanga del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAS",
+            "Primary Administrative Subdivision": "Zamboanga del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZSI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZSI",
+            "Primary Administrative Subdivision": "Zamboanga Sibugay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "NCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCO",
+            "Primary Administrative Subdivision": "Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUK",
+            "Primary Administrative Subdivision": "Sultan Kudarat",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAR",
+            "Primary Administrative Subdivision": "Sarangani",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SCO",
+            "Primary Administrative Subdivision": "South Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "BAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAS",
+            "Primary Administrative Subdivision": "Basilan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAS",
+            "Primary Administrative Subdivision": "Lanao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "MAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAG",
+            "Primary Administrative Subdivision": "Maguindanao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "SLU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Sulu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "TAW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAW",
+            "Primary Administrative Subdivision": "Tawi-Tawi",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAN",
+            "Primary Administrative Subdivision": "Lanao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "BUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUK",
+            "Primary Administrative Subdivision": "Bukidnon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "CAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Camiguin",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSC",
+            "Primary Administrative Subdivision": "Misamis Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSR",
+            "Primary Administrative Subdivision": "Misamis Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "COM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COM",
+            "Primary Administrative Subdivision": "Davao de Oro",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAV",
+            "Primary Administrative Subdivision": "Davao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAS",
+            "Primary Administrative Subdivision": "Davao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAO",
+            "Primary Administrative Subdivision": "Davao Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "AGN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGN",
+            "Primary Administrative Subdivision": "Agusan del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "AGS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Agusan del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUN",
+            "Primary Administrative Subdivision": "Surigao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUR",
+            "Primary Administrative Subdivision": "Surigao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "CHA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHA",
+            "Primary Administrative Subdivision": "Changhua",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "CYI.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYI",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "CYQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYQ",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HSZ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSZ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "HSQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSQ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HUA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUA",
+            "Primary Administrative Subdivision": "Hualien",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "KHH.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KHH",
+            "Primary Administrative Subdivision": "Kaohsiung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "KEE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEE",
+            "Primary Administrative Subdivision": "Keelung",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "KIN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KIN",
+            "Primary Administrative Subdivision": "Kinmen",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "LIE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LIE",
+            "Primary Administrative Subdivision": "Lienchiang",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "MIA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIA",
+            "Primary Administrative Subdivision": "Miaoli",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NAN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAN",
+            "Primary Administrative Subdivision": "Nantou",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NWT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NWT",
+            "Primary Administrative Subdivision": "New Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "PEN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEN",
+            "Primary Administrative Subdivision": "Penghu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "PIF.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIF",
+            "Primary Administrative Subdivision": "Pingtung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TXG.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TXG",
+            "Primary Administrative Subdivision": "Taichung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TNN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNN",
+            "Primary Administrative Subdivision": "Tainan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TPE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TPE",
+            "Primary Administrative Subdivision": "Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TTT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTT",
+            "Primary Administrative Subdivision": "Taitung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TAO.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAO",
+            "Primary Administrative Subdivision": "Taoyuan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "ILA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Yilan",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "YUN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUN",
+            "Primary Administrative Subdivision": "Yunlin",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "01.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Zagrebačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "02.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Krapinsko-Zagorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "03.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Sisačko-Moslavačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "04.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Karlovačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "05.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Varaždinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "06.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Koprivničko-Križevačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "07.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Bjelovarsko-Bilogorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "08.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Primorsko-Goranska županija",
+            "DXCC Entity Code": "497"
+          },
+          "09.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ličko-Senjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "10.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Virovitičko-Podravska županija",
+            "DXCC Entity Code": "497"
+          },
+          "11.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Požeško-Slavonska županija",
+            "DXCC Entity Code": "497"
+          },
+          "12.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Brodsko-Posavska županija",
+            "DXCC Entity Code": "497"
+          },
+          "13.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Zadarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "14.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Osječko-Baranjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "15.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Šibensko-Kninska županija",
+            "DXCC Entity Code": "497"
+          },
+          "16.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Vukovarsko-Srijemska županija",
+            "DXCC Entity Code": "497"
+          },
+          "17.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Splitsko-Dalmatinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "18.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Istarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "19.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Dubrovačko-Neretvanska županija",
+            "DXCC Entity Code": "497"
+          },
+          "20.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Međimurska županija",
+            "DXCC Entity Code": "497"
+          },
+          "21.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Grad Zagreb",
+            "DXCC Entity Code": "497"
+          },
+          "APA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Praha 1",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APB",
+            "Primary Administrative Subdivision": "Praha 2",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APC.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APC",
+            "Primary Administrative Subdivision": "Praha 3",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APD",
+            "Primary Administrative Subdivision": "Praha 4",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APE",
+            "Primary Administrative Subdivision": "Praha 5",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APF.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APF",
+            "Primary Administrative Subdivision": "Praha 6",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APG.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APG",
+            "Primary Administrative Subdivision": "Praha 7",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APH",
+            "Primary Administrative Subdivision": "Praha 8",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "API.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "API",
+            "Primary Administrative Subdivision": "Praha 9",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APJ",
+            "Primary Administrative Subdivision": "Praha 10",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "BBN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBN",
+            "Primary Administrative Subdivision": "Benesov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BBE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBE",
+            "Primary Administrative Subdivision": "Beroun",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKD",
+            "Primary Administrative Subdivision": "Kladno",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKO",
+            "Primary Administrative Subdivision": "Kolin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKH",
+            "Primary Administrative Subdivision": "Kutna Hora",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BME.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BME",
+            "Primary Administrative Subdivision": "Melnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BMB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BMB",
+            "Primary Administrative Subdivision": "Mlada Boleslav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BNY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BNY",
+            "Primary Administrative Subdivision": "Nymburk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPZ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPZ",
+            "Primary Administrative Subdivision": "Praha zapad",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPV",
+            "Primary Administrative Subdivision": "Praha vychod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPB",
+            "Primary Administrative Subdivision": "Pribram",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BRA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRA",
+            "Primary Administrative Subdivision": "Rakovnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "CBU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CBU",
+            "Primary Administrative Subdivision": "Ceske Budejovice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CCK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CCK",
+            "Primary Administrative Subdivision": "Cesky Krumlov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CJH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJH",
+            "Primary Administrative Subdivision": "Jindrichuv Hradec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPE",
+            "Primary Administrative Subdivision": "Pelhrimov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPI",
+            "Primary Administrative Subdivision": "Pisek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPR",
+            "Primary Administrative Subdivision": "Prachatice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CST.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CST",
+            "Primary Administrative Subdivision": "Strakonice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CTA",
+            "Primary Administrative Subdivision": "Tabor",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "DDO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DDO",
+            "Primary Administrative Subdivision": "Domazlice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DCH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DCH",
+            "Primary Administrative Subdivision": "Cheb",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKV",
+            "Primary Administrative Subdivision": "Karlovy Vary",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKL",
+            "Primary Administrative Subdivision": "Klatovy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPM",
+            "Primary Administrative Subdivision": "Plzen mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPJ",
+            "Primary Administrative Subdivision": "Plzen jih",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPS",
+            "Primary Administrative Subdivision": "Plzen sever",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DRO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DRO",
+            "Primary Administrative Subdivision": "Rokycany",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DSO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DSO",
+            "Primary Administrative Subdivision": "Sokolov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DTA",
+            "Primary Administrative Subdivision": "Tachov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "ECL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECL",
+            "Primary Administrative Subdivision": "Ceska Lipa",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EDE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EDE",
+            "Primary Administrative Subdivision": "Decin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ECH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECH",
+            "Primary Administrative Subdivision": "Chomutov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EJA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EJA",
+            "Primary Administrative Subdivision": "Jablonec n. Nisou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELI",
+            "Primary Administrative Subdivision": "Liberec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELT.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELT",
+            "Primary Administrative Subdivision": "Litomerice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELO",
+            "Primary Administrative Subdivision": "Louny",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EMO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMO",
+            "Primary Administrative Subdivision": "Most",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ETE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ETE",
+            "Primary Administrative Subdivision": "Teplice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EUL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EUL",
+            "Primary Administrative Subdivision": "Usti nad Labem",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "FHB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHB",
+            "Primary Administrative Subdivision": "Havlickuv Brod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FHK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHK",
+            "Primary Administrative Subdivision": "Hradec Kralove",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FCR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FCR",
+            "Primary Administrative Subdivision": "Chrudim",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJI",
+            "Primary Administrative Subdivision": "Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FNA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FNA",
+            "Primary Administrative Subdivision": "Nachod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FPA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FPA",
+            "Primary Administrative Subdivision": "Pardubice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FRK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FRK",
+            "Primary Administrative Subdivision": "Rychn n. Kneznou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSE",
+            "Primary Administrative Subdivision": "Semily",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSV",
+            "Primary Administrative Subdivision": "Svitavy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FTR",
+            "Primary Administrative Subdivision": "Trutnov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FUO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FUO",
+            "Primary Administrative Subdivision": "Usti nad Orlici",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "GBL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBL",
+            "Primary Administrative Subdivision": "Blansko",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBM",
+            "Primary Administrative Subdivision": "Brno mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBV",
+            "Primary Administrative Subdivision": "Brno venkov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBR",
+            "Primary Administrative Subdivision": "Breclav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GHO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GHO",
+            "Primary Administrative Subdivision": "Hodonin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJI",
+            "Primary Administrative Subdivision": "Jihlava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GKR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GKR",
+            "Primary Administrative Subdivision": "Kromeriz",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPR",
+            "Primary Administrative Subdivision": "Prostejov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTR",
+            "Primary Administrative Subdivision": "Trebic",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GUH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUH",
+            "Primary Administrative Subdivision": "Uherske Hradiste",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GVY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GVY",
+            "Primary Administrative Subdivision": "Vyskov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZL",
+            "Primary Administrative Subdivision": "Zlin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZN",
+            "Primary Administrative Subdivision": "Znojmo",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZS",
+            "Primary Administrative Subdivision": "Zdar nad Sazavou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "HBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HBR",
+            "Primary Administrative Subdivision": "Bruntal",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HFM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HFM",
+            "Primary Administrative Subdivision": "Frydek-Mistek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HJE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HJE",
+            "Primary Administrative Subdivision": "Jesenik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HKA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKA",
+            "Primary Administrative Subdivision": "Karvina",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HNJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HNJ",
+            "Primary Administrative Subdivision": "Novy Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOL",
+            "Primary Administrative Subdivision": "Olomouc",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOP.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOP",
+            "Primary Administrative Subdivision": "Opava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOS",
+            "Primary Administrative Subdivision": "Ostrava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HPR",
+            "Primary Administrative Subdivision": "Prerov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HSU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSU",
+            "Primary Administrative Subdivision": "Sumperk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HVS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HVS",
+            "Primary Administrative Subdivision": "Vsetin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "BAA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAA",
+            "Primary Administrative Subdivision": "Bratislava 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAB",
+            "Primary Administrative Subdivision": "Bratislava 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAC",
+            "Primary Administrative Subdivision": "Bratislava 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAD",
+            "Primary Administrative Subdivision": "Bratislava 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAE",
+            "Primary Administrative Subdivision": "Bratislava 5",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "MAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAL",
+            "Primary Administrative Subdivision": "Malacky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "PEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEZ",
+            "Primary Administrative Subdivision": "Pezinok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "SEN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEN",
+            "Primary Administrative Subdivision": "Senec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "DST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DST",
+            "Primary Administrative Subdivision": "Dunajska Streda",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "GAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GAL",
+            "Primary Administrative Subdivision": "Galanta",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "HLO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLO",
+            "Primary Administrative Subdivision": "Hlohovec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "PIE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIE",
+            "Primary Administrative Subdivision": "Piestany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEA",
+            "Primary Administrative Subdivision": "Senica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SKA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SKA",
+            "Primary Administrative Subdivision": "Skalica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "TRN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRN",
+            "Primary Administrative Subdivision": "Trnava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "BAN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Banovce n. Bebr.",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "ILA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Ilava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "MYJ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MYJ",
+            "Primary Administrative Subdivision": "Myjava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "NMV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NMV",
+            "Primary Administrative Subdivision": "Nove Mesto n. Vah",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAR",
+            "Primary Administrative Subdivision": "Partizanske",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PBY",
+            "Primary Administrative Subdivision": "Povazska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PRI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRI",
+            "Primary Administrative Subdivision": "Prievidza",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUC",
+            "Primary Administrative Subdivision": "Puchov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "TNC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNC",
+            "Primary Administrative Subdivision": "Trencin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "KOM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KOM",
+            "Primary Administrative Subdivision": "Komarno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "LVC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LVC",
+            "Primary Administrative Subdivision": "Levice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NIT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIT",
+            "Primary Administrative Subdivision": "Nitra",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NZA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NZA",
+            "Primary Administrative Subdivision": "Nove Zamky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "SAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAL",
+            "Primary Administrative Subdivision": "Sala",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "TOP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TOP",
+            "Primary Administrative Subdivision": "Topolcany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "ZMO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMO",
+            "Primary Administrative Subdivision": "Zlate Moravce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "BYT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BYT",
+            "Primary Administrative Subdivision": "Bytca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "CAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAD",
+            "Primary Administrative Subdivision": "Cadca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "DKU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKU",
+            "Primary Administrative Subdivision": "Dolny Kubin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "KNM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KNM",
+            "Primary Administrative Subdivision": "Kysucke N. Mesto",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "LMI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LMI",
+            "Primary Administrative Subdivision": "Liptovsky Mikulas",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "MAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAR",
+            "Primary Administrative Subdivision": "Martin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "NAM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAM",
+            "Primary Administrative Subdivision": "Namestovo",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "RUZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RUZ",
+            "Primary Administrative Subdivision": "Ruzomberok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TTE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTE",
+            "Primary Administrative Subdivision": "Turcianske Teplice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TVR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TVR",
+            "Primary Administrative Subdivision": "Tvrdosin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "ZIL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIL",
+            "Primary Administrative Subdivision": "Zilina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "BBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBY",
+            "Primary Administrative Subdivision": "Banska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BST",
+            "Primary Administrative Subdivision": "Banska Stiavnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRE",
+            "Primary Administrative Subdivision": "Brezno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "DET.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DET",
+            "Primary Administrative Subdivision": "Detva",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "KRU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KRU",
+            "Primary Administrative Subdivision": "Krupina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "LUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUC",
+            "Primary Administrative Subdivision": "Lucenec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "POL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POL",
+            "Primary Administrative Subdivision": "Poltar",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "REV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "REV",
+            "Primary Administrative Subdivision": "Revuca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "RSO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RSO",
+            "Primary Administrative Subdivision": "Rimavska Sobota",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "VKR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VKR",
+            "Primary Administrative Subdivision": "Velky Krtis",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAR",
+            "Primary Administrative Subdivision": "Zarnovica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZIH.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIH",
+            "Primary Administrative Subdivision": "Ziar nad Hronom",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZVO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZVO",
+            "Primary Administrative Subdivision": "Zvolen",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "GEL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GEL",
+            "Primary Administrative Subdivision": "Gelnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEA",
+            "Primary Administrative Subdivision": "Kosice 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEB",
+            "Primary Administrative Subdivision": "Kosice 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEC",
+            "Primary Administrative Subdivision": "Kosice 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KED",
+            "Primary Administrative Subdivision": "Kosice 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEO",
+            "Primary Administrative Subdivision": "Kosice-okolie",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "MIC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michalovce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "ROZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROZ",
+            "Primary Administrative Subdivision": "Roznava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SOB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOB",
+            "Primary Administrative Subdivision": "Sobrance",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SNV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNV",
+            "Primary Administrative Subdivision": "Spisska Nova Ves",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "TRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRE",
+            "Primary Administrative Subdivision": "Trebisov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "BAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAR",
+            "Primary Administrative Subdivision": "Bardejov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "HUM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUM",
+            "Primary Administrative Subdivision": "Humenne",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "KEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEZ",
+            "Primary Administrative Subdivision": "Kezmarok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "LEV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEV",
+            "Primary Administrative Subdivision": "Levoca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "MED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MED",
+            "Primary Administrative Subdivision": "Medzilaborce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "POP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POP",
+            "Primary Administrative Subdivision": "Poprad",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "PRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRE",
+            "Primary Administrative Subdivision": "Presov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAB",
+            "Primary Administrative Subdivision": "Sabinov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SNI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNI",
+            "Primary Administrative Subdivision": "Snina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SLU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Stara Lubovna",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "STR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STR",
+            "Primary Administrative Subdivision": "Stropkov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SVI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SVI",
+            "Primary Administrative Subdivision": "Svidnik",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "VRT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VRT",
+            "Primary Administrative Subdivision": "Vranov nad Toplou",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          }
+        }
+      },
+      "Propagation_Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Enumeration",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AS",
+            "Description": "Aircraft Scatter"
+          },
+          "AUE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUE",
+            "Description": "Aurora-E"
+          },
+          "AUR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUR",
+            "Description": "Aurora"
+          },
+          "BS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "BS",
+            "Description": "Back scatter"
+          },
+          "ECH": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ECH",
+            "Description": "EchoLink"
+          },
+          "EME": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "EME",
+            "Description": "Earth-Moon-Earth"
+          },
+          "ES": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ES",
+            "Description": "Sporadic E"
+          },
+          "F2": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "F2",
+            "Description": "F2 Reflection"
+          },
+          "FAI": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "FAI",
+            "Description": "Field Aligned Irregularities"
+          },
+          "GWAVE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "GWAVE",
+            "Description": "Ground Wave"
+          },
+          "INTERNET": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "INTERNET",
+            "Description": "Internet-assisted"
+          },
+          "ION": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ION",
+            "Description": "Ionoscatter"
+          },
+          "IRL": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "IRL",
+            "Description": "IRLP"
+          },
+          "LOS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "LOS",
+            "Description": "Line of Sight (includes transmission through obstacles such as walls)"
+          },
+          "MS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "MS",
+            "Description": "Meteor scatter"
+          },
+          "RPT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RPT",
+            "Description": "Terrestrial or atmospheric repeater or transponder"
+          },
+          "RS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RS",
+            "Description": "Rain scatter"
+          },
+          "SAT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "SAT",
+            "Description": "Satellite"
+          },
+          "TEP": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TEP",
+            "Description": "Trans-equatorial"
+          },
+          "TR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TR",
+            "Description": "Tropospheric ducting"
+          }
+        }
+      },
+      "QSL_Medium": {
+        "Header": [
+          "Enumeration Name",
+          "Medium",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CARD": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "CARD",
+            "Description": "QSO confirmation via paper QSL card"
+          },
+          "EQSL": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "EQSL",
+            "Description": "QSO confirmation via eQSL.cc"
+          },
+          "LOTW": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "LOTW",
+            "Description": "QSO confirmation via ARRL Logbook of the World"
+          }
+        }
+      },
+      "QSL_Rcvd": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "Y",
+            "Meaning": "yes (confirmed)",
+            "Description": "an incoming QSL card has been received the QSO has been confirmed by the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "an incoming QSL card has not been received the QSO has not been confirmed by the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the logging station has requested a QSL card the logging station has requested the QSO be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          },
+          "V": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "V",
+            "Meaning": "verified",
+            "Description": "DXCC award credit granted for the QSL card - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:card,DXCC_BAND:card,DXCC_MODE:card DXCC credit granted for the LoTW confirmation - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:lotw,DXCC_BAND:lotw,DXCC_MODE:lotw",
+            "Import-only": "true"
+          }
+        }
+      },
+      "QSL_Sent": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Y",
+            "Meaning": "yes",
+            "Description": "an outgoing QSL card has been sent the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "do not send an outgoing QSL card do not upload the QSO to the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the contacted station has requested a QSL card the contacted station has requested the QSO be uploaded to the online service"
+          },
+          "Q": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Q",
+            "Meaning": "queued",
+            "Description": "an outgoing QSL card has been selected to be sent a QSO has been selected to be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          }
+        }
+      },
+      "QSL_Via": {
+        "Header": [
+          "Enumeration Name",
+          "Via",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "B": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "B",
+            "Description": "bureau"
+          },
+          "D": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "D",
+            "Description": "direct"
+          },
+          "E": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "E",
+            "Description": "electronic"
+          },
+          "M": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "M",
+            "Description": "manager",
+            "Import-only": "true"
+          }
+        }
+      },
+      "QSO_Complete": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "Y",
+            "Meaning": "yes"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "N",
+            "Meaning": "no"
+          },
+          "NIL": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "NIL",
+            "Meaning": "not heard"
+          },
+          "?": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "?",
+            "Meaning": "uncertain"
+          }
+        }
+      },
+      "QSO_Download_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "Y",
+            "Description": "the QSO has been downloaded from the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "N",
+            "Description": "the QSO has not been downloaded from the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "I",
+            "Description": "ignore or invalid"
+          }
+        }
+      },
+      "QSO_Upload_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "Y",
+            "Description": "the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "N",
+            "Description": "do not upload the QSO to the online service"
+          },
+          "M": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "M",
+            "Description": "the QSO has been modified since being uploaded to the online service"
+          }
+        }
+      },
+      "Region": {
+        "Header": [
+          "Enumeration Name",
+          "Region Entity Code",
+          "DXCC Entity Code",
+          "Region",
+          "Prefix",
+          "Applicability",
+          "Start Date",
+          "End Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NONE": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "NONE",
+            "Region": "Not within a WAE or CQ region that is within a DXCC entity"
+          },
+          "IV.206": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "IV",
+            "DXCC Entity Code": "206",
+            "Region": "ITU Vienna",
+            "Prefix": "4U1V",
+            "Applicability": "CQ, WAE"
+          },
+          "AI.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "AI",
+            "DXCC Entity Code": "248",
+            "Region": "African Italy",
+            "Prefix": "IG9",
+            "Applicability": "CQ"
+          },
+          "SY.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SY",
+            "DXCC Entity Code": "248",
+            "Region": "Sicily",
+            "Prefix": "IT9",
+            "Applicability": "CQ, WAE"
+          },
+          "BI.259": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "BI",
+            "DXCC Entity Code": "259",
+            "Region": "Bear Island",
+            "Prefix": "JW/B",
+            "Applicability": "CQ, WAE"
+          },
+          "SI.279": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SI",
+            "DXCC Entity Code": "279",
+            "Region": "Shetland Islands",
+            "Prefix": "GM/S",
+            "Applicability": "CQ, WAE"
+          },
+          "KO.296": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "296",
+            "Region": "Kosovo",
+            "Prefix": "YU8",
+            "Applicability": "CQ, WAE",
+            "End Date": "2012-09-11T00:00:00Z"
+          },
+          "KO.0": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "0",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2012-09-12T00:00:00Z",
+            "End Date": "2018-01-20T00:00:00Z"
+          },
+          "KO.522": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "522",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2018-01-21T00:00:00Z"
+          },
+          "ET.390": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "ET",
+            "DXCC Entity Code": "390",
+            "Region": "European Turkey",
+            "Prefix": "TA1",
+            "Applicability": "CQ"
+          }
+        }
+      },
+      "Secondary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Secondary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Alaska Judicial District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AK,Aleutians East": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians East",
+            "Secondary Administrative Subdivision": "Aleutians East",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Aleutians Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians Islands",
+            "Secondary Administrative Subdivision": "Aleutians Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Aleutians West": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians West",
+            "Secondary Administrative Subdivision": "Aleutians West",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Anchorage": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Anchorage",
+            "Secondary Administrative Subdivision": "Anchorage",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Angoon",
+            "Secondary Administrative Subdivision": "Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Barrow": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Barrow",
+            "Secondary Administrative Subdivision": "Barrow",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Bethel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bethel",
+            "Secondary Administrative Subdivision": "Bethel",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Bristol Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bristol Bay",
+            "Secondary Administrative Subdivision": "Bristol Bay",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Cordova-McCarthy": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Cordova-McCarthy",
+            "Secondary Administrative Subdivision": "Cordova-McCarthy",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Denali": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Denali",
+            "Secondary Administrative Subdivision": "Denali",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Dillingham": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Dillingham",
+            "Secondary Administrative Subdivision": "Dillingham",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks",
+            "Secondary Administrative Subdivision": "Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Fairbanks North Star": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks North Star",
+            "Secondary Administrative Subdivision": "Fairbanks North Star",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,First Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,First Judicial District",
+            "Secondary Administrative Subdivision": "First Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Fourth Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fourth Judicial District",
+            "Secondary Administrative Subdivision": "Fourth Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Haines": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Haines",
+            "Secondary Administrative Subdivision": "Haines",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Juneau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Juneau",
+            "Secondary Administrative Subdivision": "Juneau",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kenai Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai Peninsula",
+            "Secondary Administrative Subdivision": "Kenai Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kenai-Cook Inlet": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai-Cook Inlet",
+            "Secondary Administrative Subdivision": "Kenai-Cook Inlet",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan",
+            "Secondary Administrative Subdivision": "Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan Gateway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan Gateway",
+            "Secondary Administrative Subdivision": "Ketchikan Gateway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kobuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kobuk",
+            "Secondary Administrative Subdivision": "Kobuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kodiak Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kodiak Island",
+            "Secondary Administrative Subdivision": "Kodiak Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kuskokwim": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kuskokwim",
+            "Secondary Administrative Subdivision": "Kuskokwim",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kusilvak": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kusilvak",
+            "Secondary Administrative Subdivision": "Kusilvak",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Lake and Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lake and Peninsula",
+            "Secondary Administrative Subdivision": "Lake and Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Lynn Canal-Icy Straits": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lynn Canal-Icy Straits",
+            "Secondary Administrative Subdivision": "Lynn Canal-Icy Straits",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Matanuska-Susitna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Matanuska-Susitna",
+            "Secondary Administrative Subdivision": "Matanuska-Susitna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Nome": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Nome",
+            "Secondary Administrative Subdivision": "Nome",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,North Slope": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,North Slope",
+            "Secondary Administrative Subdivision": "North Slope",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Northwest Arctic": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Northwest Arctic",
+            "Secondary Administrative Subdivision": "Northwest Arctic",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Palmer-Wasilla-Talkeetna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Palmer-Wasilla-Talkeetna",
+            "Secondary Administrative Subdivision": "Palmer-Wasilla-Talkeetna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Petersburg",
+            "Secondary Administrative Subdivision": "Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Pribilof Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Pribilof Islands",
+            "Secondary Administrative Subdivision": "Pribilof Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Prince of Wales": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales",
+            "Secondary Administrative Subdivision": "Prince of Wales",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Prince of Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Hyder",
+            "Secondary Administrative Subdivision": "Prince of Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Prince of Wales-Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Prince of Wales-Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Saint Matthew Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Saint Matthew Island",
+            "Secondary Administrative Subdivision": "Saint Matthew Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Second Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Second Judicial District",
+            "Secondary Administrative Subdivision": "Second Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Seward": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Seward",
+            "Secondary Administrative Subdivision": "Seward",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Sitka": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Sitka",
+            "Secondary Administrative Subdivision": "Sitka",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway",
+            "Secondary Administrative Subdivision": "Skagway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Yakuta": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakuta",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway-Yakutat-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakutat-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Southeast Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Southeast Fairbanks",
+            "Secondary Administrative Subdivision": "Southeast Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Third Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Third Judicial District",
+            "Secondary Administrative Subdivision": "Third Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Upper Yukon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Upper Yukon",
+            "Secondary Administrative Subdivision": "Upper Yukon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Chitina-Whittier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Chitina-Whittier",
+            "Secondary Administrative Subdivision": "Valdez-Chitina-Whittier",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Cordova": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Cordova",
+            "Secondary Administrative Subdivision": "Valdez-Cordova",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Wade Hampton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wade Hampton",
+            "Secondary Administrative Subdivision": "Wade Hampton",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wales-Hyder",
+            "Secondary Administrative Subdivision": "Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell",
+            "Secondary Administrative Subdivision": "Wrangell",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell-Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell-Petersburg",
+            "Secondary Administrative Subdivision": "Wrangell-Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Yakutat": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yakutat",
+            "Secondary Administrative Subdivision": "Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Yukon-Koyukuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yukon-Koyukuk",
+            "Secondary Administrative Subdivision": "Yukon-Koyukuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          }
+        }
+      },
+      "Secondary_Administrative_Subdivision_Alt": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "DXCC Entity Code",
+          "Region",
+          "District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NZ_Regions:Northland/Far North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Far North",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Far North"
+          },
+          "NZ_Regions:Northland/Whangarei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Whangarei",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Whangarei"
+          },
+          "NZ_Regions:Northland/Kaipara": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Kaipara",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Kaipara"
+          },
+          "NZ_Regions:Auckland/Rodney": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Rodney",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Rodney"
+          },
+          "NZ_Regions:Auckland/North Shore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/North Shore",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "North Shore"
+          },
+          "NZ_Regions:Auckland/Waitakere": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Waitakere",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Waitakere"
+          },
+          "NZ_Regions:Auckland/Auckland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Auckland",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Auckland"
+          },
+          "NZ_Regions:Auckland/Manukau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Manukau",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Manukau"
+          },
+          "NZ_Regions:Auckland/Papakura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Papakura",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Papakura"
+          },
+          "NZ_Regions:Auckland/Franklin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Franklin",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Franklin"
+          },
+          "NZ_Regions:Waikato/Thames-Coromandel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Thames-Coromandel",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Thames-Coromandel"
+          },
+          "NZ_Regions:Waikato/Hauraki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hauraki",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hauraki"
+          },
+          "NZ_Regions:Waikato/Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waikato"
+          },
+          "NZ_Regions:Waikato/Matamata Piako": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Matamata Piako",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Matamata Piako"
+          },
+          "NZ_Regions:Waikato/Hamilton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hamilton",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hamilton"
+          },
+          "NZ_Regions:Waikato/Waipa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waipa",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waipa"
+          },
+          "NZ_Regions:Waikato/Otorohanga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Otorohanga",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Otorohanga"
+          },
+          "NZ_Regions:Waikato/South Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/South Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "South Waikato"
+          },
+          "NZ_Regions:Waikato/Waitomo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waitomo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waitomo"
+          },
+          "NZ_Regions:Waikato/Taupo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Taupo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Taupo"
+          },
+          "NZ_Regions:Bay of Plenty/Western Bay of Plenty": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Western Bay of Plenty",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Western Bay of Plenty"
+          },
+          "NZ_Regions:Bay of Plenty/Tauranga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Tauranga",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Tauranga"
+          },
+          "NZ_Regions:Bay of Plenty/Rotorua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Rotorua",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Rotorua"
+          },
+          "NZ_Regions:Bay of Plenty/Kawerau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Kawerau",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Kawerau"
+          },
+          "NZ_Regions:Bay of Plenty/Whakatane": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Whakatane",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Whakatane"
+          },
+          "NZ_Regions:Bay of Plenty/Opotiki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Opotiki",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Opotiki"
+          },
+          "NZ_Regions:Gisborne/Gisborne": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Gisborne/Gisborne",
+            "DXCC Entity Code": "170",
+            "Region": "Gisborne",
+            "District": "Gisborne"
+          },
+          "NZ_Regions:Hawkes Bay/Wairoa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Wairoa",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Wairoa"
+          },
+          "NZ_Regions:Hawkes Bay/Hastings": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Hastings",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Hastings"
+          },
+          "NZ_Regions:Hawkes Bay/Napier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Napier",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Napier"
+          },
+          "NZ_Regions:Hawkes Bay/Central Hawkes Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Central Hawkes Bay",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Central Hawkes Bay"
+          },
+          "NZ_Regions:Taranaki/New Plymouth": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/New Plymouth",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "New Plymouth"
+          },
+          "NZ_Regions:Taranaki/Stratford": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/Stratford",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "Stratford"
+          },
+          "NZ_Regions:Taranaki/South Taranaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/South Taranaki",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "South Taranaki"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Ruapehu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Ruapehu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Ruapehu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Wanganui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Wanganui",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Wanganui"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Rangitikei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Rangitikei",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Rangitikei"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Manawatu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Manawatu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Manawatu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Palmerston North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Palmerston North",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Palmerston North"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Horowhenua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Horowhenua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Horowhenua"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Tararua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Tararua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Tararua"
+          },
+          "NZ_Regions:Wellington/Masterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Masterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Masterton"
+          },
+          "NZ_Regions:Wellington/Carterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Carterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Carterton"
+          },
+          "NZ_Regions:Wellington/South Wairarapa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/South Wairarapa",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "South Wairarapa"
+          },
+          "NZ_Regions:Wellington/Kapiti Coast": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Kapiti Coast",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Kapiti Coast"
+          },
+          "NZ_Regions:Wellington/Porirua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Porirua",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Porirua"
+          },
+          "NZ_Regions:Wellington/Upper Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Upper Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Upper Hutt"
+          },
+          "NZ_Regions:Wellington/Lower Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Lower Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Lower Hutt"
+          },
+          "NZ_Regions:Wellington/Wellington": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Wellington",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Wellington"
+          },
+          "NZ_Regions:Nelson/Nelson": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Nelson/Nelson",
+            "DXCC Entity Code": "170",
+            "Region": "Nelson",
+            "District": "Nelson"
+          },
+          "NZ_Regions:Marlborough/Marlborough": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Marlborough/Marlborough",
+            "DXCC Entity Code": "170",
+            "Region": "Marlborough",
+            "District": "Marlborough"
+          },
+          "NZ_Regions:Tasman/Tasman": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Tasman/Tasman",
+            "DXCC Entity Code": "170",
+            "Region": "Tasman",
+            "District": "Tasman"
+          },
+          "NZ_Regions:West Coast/Buller": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Buller",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Buller"
+          },
+          "NZ_Regions:West Coast/Grey": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Grey",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Grey"
+          },
+          "NZ_Regions:West Coast/Westland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Westland",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Westland"
+          },
+          "NZ_Regions:Canterbury/Kaikoura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Kaikoura",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Kaikoura"
+          },
+          "NZ_Regions:Canterbury/Hurunui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Hurunui",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Hurunui"
+          },
+          "NZ_Regions:Canterbury/Selwyn": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Selwyn",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Selwyn"
+          },
+          "NZ_Regions:Canterbury/Waimakariri": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimakariri",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimakariri"
+          },
+          "NZ_Regions:Canterbury/Christchurch": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Christchurch",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Christchurch"
+          },
+          "NZ_Regions:Canterbury/Banks Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Banks Peninsula",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Banks Peninsula"
+          },
+          "NZ_Regions:Canterbury/Ashburton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Ashburton",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Ashburton"
+          },
+          "NZ_Regions:Canterbury/Mackenzie": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Mackenzie",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Mackenzie"
+          },
+          "NZ_Regions:Canterbury/Timaru": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Timaru",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Timaru"
+          },
+          "NZ_Regions:Canterbury/Waimate": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimate",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimate"
+          },
+          "NZ_Regions:Otago/Waitaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Waitaki",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Waitaki"
+          },
+          "NZ_Regions:Otago/Queenstown-Lakes": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Queenstown-Lakes",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Queenstown-Lakes"
+          },
+          "NZ_Regions:Otago/Central Otago": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Central Otago",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Central Otago"
+          },
+          "NZ_Regions:Otago/Dunedin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Dunedin",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Dunedin"
+          },
+          "NZ_Regions:Otago/Clutha": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Clutha",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Clutha"
+          },
+          "NZ_Regions:Southland/Gore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Gore",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Gore"
+          },
+          "NZ_Regions:Southland/Southland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Southland",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Southland"
+          },
+          "NZ_Regions:Southland/Invercargill": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Invercargill",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Invercargill"
+          }
+        }
+      },
+      "Submode": {
+        "Header": [
+          "Enumeration Name",
+          "Submode",
+          "Mode",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "8PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125",
+            "Mode": "PSK"
+          },
+          "8PSK125F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125F",
+            "Mode": "PSK"
+          },
+          "8PSK125FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125FL",
+            "Mode": "PSK"
+          },
+          "8PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250",
+            "Mode": "PSK"
+          },
+          "8PSK250F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250F",
+            "Mode": "PSK"
+          },
+          "8PSK250FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250FL",
+            "Mode": "PSK"
+          },
+          "8PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500",
+            "Mode": "PSK"
+          },
+          "8PSK500F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500F",
+            "Mode": "PSK"
+          },
+          "8PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000",
+            "Mode": "PSK"
+          },
+          "8PSK1000F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000F",
+            "Mode": "PSK"
+          },
+          "8PSK1200F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1200F",
+            "Mode": "PSK"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Submode",
+            "Submode": "AMTORFEC",
+            "Mode": "TOR"
+          },
+          "ASCI": {
+            "Enumeration Name": "Submode",
+            "Submode": "ASCI",
+            "Mode": "RTTY"
+          },
+          "C4FM": {
+            "Enumeration Name": "Submode",
+            "Submode": "C4FM",
+            "Mode": "DIGITALVOICE",
+            "Description": "C4FM 4-level FSK See the Propagation_Mode enumeration section for examples of representing C4FM voice transmissions."
+          },
+          "CHIP64": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP64",
+            "Mode": "CHIP"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP128",
+            "Mode": "CHIP"
+          },
+          "DMR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DMR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Mobile Radio See the Propagation_Mode enumeration section for examples of representing DMR voice transmissions."
+          },
+          "DOM-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM-M",
+            "Mode": "DOMINO"
+          },
+          "DOM4": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM4",
+            "Mode": "DOMINO"
+          },
+          "DOM5": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM5",
+            "Mode": "DOMINO"
+          },
+          "DOM8": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM8",
+            "Mode": "DOMINO"
+          },
+          "DOM11": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM11",
+            "Mode": "DOMINO"
+          },
+          "DOM16": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM16",
+            "Mode": "DOMINO"
+          },
+          "DOM22": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM22",
+            "Mode": "DOMINO"
+          },
+          "DOM44": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM44",
+            "Mode": "DOMINO"
+          },
+          "DOM88": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM88",
+            "Mode": "DOMINO"
+          },
+          "DOMINOEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOEX",
+            "Mode": "DOMINO"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOF",
+            "Mode": "DOMINO"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DSTAR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Smart Technologies for Amateur Radio See the Propagation_Mode enumeration section for examples of representing DSTAR voice transmissions."
+          },
+          "FMHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FMHELL",
+            "Mode": "HELL"
+          },
+          "FREEDATA": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDATA",
+            "Mode": "DYNAMIC",
+            "Description": "Data communications leveraging Codec2 HF modems"
+          },
+          "FREEDV": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDV",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital voice mode for HF radio implemented with open source"
+          },
+          "FSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSK31",
+            "Mode": "PSK"
+          },
+          "FSKH105": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH105",
+            "Mode": "HELL"
+          },
+          "FSKH245": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH245",
+            "Mode": "HELL"
+          },
+          "FSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKHELL",
+            "Mode": "HELL"
+          },
+          "FSQCALL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSQCALL",
+            "Mode": "MFSK",
+            "Description": "FSQCall protocol used with FSQ (Fast Simple QSO) transmission mode"
+          },
+          "FST4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software"
+          },
+          "FST4W": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4W",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software that is for quasi-beacon transmissions of WSPR-style messages"
+          },
+          "FT2": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT2",
+            "Mode": "MFSK"
+          },
+          "FT4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT4",
+            "Mode": "MFSK",
+            "Description": "FT4 is a digital mode designed specifically for radio contesting"
+          },
+          "GTOR": {
+            "Enumeration Name": "Submode",
+            "Submode": "GTOR",
+            "Mode": "TOR"
+          },
+          "HELL80": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELL80",
+            "Mode": "HELL"
+          },
+          "HELLX5": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX5",
+            "Mode": "HELL"
+          },
+          "HELLX9": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX9",
+            "Mode": "HELL"
+          },
+          "HFSK": {
+            "Enumeration Name": "Submode",
+            "Submode": "HFSK",
+            "Mode": "HELL"
+          },
+          "ISCAT-A": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-A",
+            "Mode": "ISCAT"
+          },
+          "ISCAT-B": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-B",
+            "Mode": "ISCAT"
+          },
+          "JS8": {
+            "Enumeration Name": "Submode",
+            "Submode": "JS8",
+            "Mode": "MFSK",
+            "Description": "Jordan Sherer designed 8-FSK modulation"
+          },
+          "JT4A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4A",
+            "Mode": "JT4"
+          },
+          "JT4B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4B",
+            "Mode": "JT4"
+          },
+          "JT4C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4C",
+            "Mode": "JT4"
+          },
+          "JT4D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4D",
+            "Mode": "JT4"
+          },
+          "JT4E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4E",
+            "Mode": "JT4"
+          },
+          "JT4F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4F",
+            "Mode": "JT4"
+          },
+          "JT4G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4G",
+            "Mode": "JT4"
+          },
+          "JT9-1": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-1",
+            "Mode": "JT9"
+          },
+          "JT9-2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-2",
+            "Mode": "JT9"
+          },
+          "JT9-5": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-5",
+            "Mode": "JT9"
+          },
+          "JT9-10": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-10",
+            "Mode": "JT9"
+          },
+          "JT9-30": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-30",
+            "Mode": "JT9"
+          },
+          "JT9A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9A",
+            "Mode": "JT9"
+          },
+          "JT9B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9B",
+            "Mode": "JT9"
+          },
+          "JT9C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9C",
+            "Mode": "JT9"
+          },
+          "JT9D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9D",
+            "Mode": "JT9"
+          },
+          "JT9E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E",
+            "Mode": "JT9"
+          },
+          "JT9E FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E FAST",
+            "Mode": "JT9"
+          },
+          "JT9F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F",
+            "Mode": "JT9"
+          },
+          "JT9F FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F FAST",
+            "Mode": "JT9"
+          },
+          "JT9G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G",
+            "Mode": "JT9"
+          },
+          "JT9G FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G FAST",
+            "Mode": "JT9"
+          },
+          "JT9H": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H",
+            "Mode": "JT9"
+          },
+          "JT9H FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H FAST",
+            "Mode": "JT9"
+          },
+          "JT65A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65A",
+            "Mode": "JT65"
+          },
+          "JT65B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B",
+            "Mode": "JT65"
+          },
+          "JT65B2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B2",
+            "Mode": "JT65"
+          },
+          "JT65C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C",
+            "Mode": "JT65"
+          },
+          "JT65C2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C2",
+            "Mode": "JT65"
+          },
+          "JTMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "JTMS",
+            "Mode": "MFSK"
+          },
+          "LSB": {
+            "Enumeration Name": "Submode",
+            "Submode": "LSB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, lower-sideband, suppressed-carrier"
+          },
+          "M17": {
+            "Enumeration Name": "Submode",
+            "Submode": "M17",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital radio protocol using the Codec 2 voice encoder"
+          },
+          "MFSK4": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK4",
+            "Mode": "MFSK"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK8",
+            "Mode": "MFSK"
+          },
+          "MFSK11": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK11",
+            "Mode": "MFSK"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK16",
+            "Mode": "MFSK"
+          },
+          "MFSK22": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK22",
+            "Mode": "MFSK"
+          },
+          "MFSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK31",
+            "Mode": "MFSK"
+          },
+          "MFSK32": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK32",
+            "Mode": "MFSK"
+          },
+          "MFSK64": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64",
+            "Mode": "MFSK"
+          },
+          "MFSK64L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64L",
+            "Mode": "MFSK"
+          },
+          "MFSK128": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128",
+            "Mode": "MFSK"
+          },
+          "MFSK128L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128L",
+            "Mode": "MFSK"
+          },
+          "NAVTEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "NAVTEX",
+            "Mode": "TOR"
+          },
+          "OLIVIA 4/125": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/125",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 4/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/1000",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 32/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 32/1000",
+            "Mode": "OLIVIA"
+          },
+          "OPERA-BEACON": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-BEACON",
+            "Mode": "OPERA"
+          },
+          "OPERA-QSO": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-QSO",
+            "Mode": "OPERA"
+          },
+          "PAC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC2",
+            "Mode": "PAC"
+          },
+          "PAC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC3",
+            "Mode": "PAC"
+          },
+          "PAC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC4",
+            "Mode": "PAC"
+          },
+          "PAX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAX2",
+            "Mode": "PAX"
+          },
+          "PCW": {
+            "Enumeration Name": "Submode",
+            "Submode": "PCW",
+            "Mode": "CW",
+            "Description": "Coherent CW"
+          },
+          "PSK10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK10",
+            "Mode": "PSK"
+          },
+          "PSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK31",
+            "Mode": "PSK"
+          },
+          "PSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63",
+            "Mode": "PSK"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63F",
+            "Mode": "PSK"
+          },
+          "PSK63RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC10",
+            "Mode": "PSK"
+          },
+          "PSK63RC20": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC20",
+            "Mode": "PSK"
+          },
+          "PSK63RC32": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC32",
+            "Mode": "PSK"
+          },
+          "PSK63RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC4",
+            "Mode": "PSK"
+          },
+          "PSK63RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC5",
+            "Mode": "PSK"
+          },
+          "PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125",
+            "Mode": "PSK"
+          },
+          "PSK125RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC10",
+            "Mode": "PSK"
+          },
+          "PSK125RC12": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC12",
+            "Mode": "PSK"
+          },
+          "PSK125RC16": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC16",
+            "Mode": "PSK"
+          },
+          "PSK125RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC4",
+            "Mode": "PSK"
+          },
+          "PSK125RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC5",
+            "Mode": "PSK"
+          },
+          "PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250",
+            "Mode": "PSK"
+          },
+          "PSK250RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC2",
+            "Mode": "PSK"
+          },
+          "PSK250RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC3",
+            "Mode": "PSK"
+          },
+          "PSK250RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC5",
+            "Mode": "PSK"
+          },
+          "PSK250RC6": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC6",
+            "Mode": "PSK"
+          },
+          "PSK250RC7": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC7",
+            "Mode": "PSK"
+          },
+          "PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500",
+            "Mode": "PSK"
+          },
+          "PSK500RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC2",
+            "Mode": "PSK"
+          },
+          "PSK500RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC3",
+            "Mode": "PSK"
+          },
+          "PSK500RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC4",
+            "Mode": "PSK"
+          },
+          "PSK800RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK800RC2",
+            "Mode": "PSK"
+          },
+          "PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000",
+            "Mode": "PSK"
+          },
+          "PSK1000RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000RC2",
+            "Mode": "PSK"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM10",
+            "Mode": "PSK"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM31",
+            "Mode": "PSK"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM50",
+            "Mode": "PSK"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKFEC31",
+            "Mode": "PSK"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKHELL",
+            "Mode": "HELL"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK31",
+            "Mode": "PSK"
+          },
+          "Q65": {
+            "Enumeration Name": "Submode",
+            "Submode": "Q65",
+            "Mode": "MFSK"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK63",
+            "Mode": "PSK"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK125",
+            "Mode": "PSK"
+          },
+          "QPSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK250",
+            "Mode": "PSK"
+          },
+          "QPSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK500",
+            "Mode": "PSK"
+          },
+          "QRA64A": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64A",
+            "Mode": "QRA64"
+          },
+          "QRA64B": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64B",
+            "Mode": "QRA64"
+          },
+          "QRA64C": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64C",
+            "Mode": "QRA64"
+          },
+          "QRA64D": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64D",
+            "Mode": "QRA64"
+          },
+          "QRA64E": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64E",
+            "Mode": "QRA64"
+          },
+          "RIBBIT_PIX": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_PIX",
+            "Mode": "OFDM",
+            "Description": "Images transmitted using Ribbit"
+          },
+          "RIBBIT_SMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_SMS",
+            "Mode": "OFDM",
+            "Description": "Short text messages transmitted using Ribbit"
+          },
+          "ROS-EME": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-EME",
+            "Mode": "ROS"
+          },
+          "ROS-HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-HF",
+            "Mode": "ROS"
+          },
+          "ROS-MF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-MF",
+            "Mode": "ROS"
+          },
+          "SCAMP_FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_FAST",
+            "Mode": "FSK",
+            "Description": "SCAMP fast FSK"
+          },
+          "SCAMP_OO": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off keying"
+          },
+          "SCAMP_OO_SLW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO_SLW",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off slow keying"
+          },
+          "SCAMP_SLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_SLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP slow FSK"
+          },
+          "SCAMP_VSLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_VSLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP very slow FSK"
+          },
+          "SIM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "SIM31",
+            "Mode": "PSK"
+          },
+          "SITORB": {
+            "Enumeration Name": "Submode",
+            "Submode": "SITORB",
+            "Mode": "TOR"
+          },
+          "SLOWHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "SLOWHELL",
+            "Mode": "HELL"
+          },
+          "THOR-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR-M",
+            "Mode": "THOR"
+          },
+          "THOR4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR4",
+            "Mode": "THOR"
+          },
+          "THOR5": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR5",
+            "Mode": "THOR"
+          },
+          "THOR8": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR8",
+            "Mode": "THOR"
+          },
+          "THOR11": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR11",
+            "Mode": "THOR"
+          },
+          "THOR16": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR16",
+            "Mode": "THOR"
+          },
+          "THOR22": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR22",
+            "Mode": "THOR"
+          },
+          "THOR25X4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR25X4",
+            "Mode": "THOR"
+          },
+          "THOR50X1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X1",
+            "Mode": "THOR"
+          },
+          "THOR50X2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X2",
+            "Mode": "THOR"
+          },
+          "THOR100": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR100",
+            "Mode": "THOR"
+          },
+          "THRBX": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX",
+            "Mode": "THRB"
+          },
+          "THRBX1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX1",
+            "Mode": "THRB"
+          },
+          "THRBX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX2",
+            "Mode": "THRB"
+          },
+          "THRBX4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX4",
+            "Mode": "THRB"
+          },
+          "THROB1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB1",
+            "Mode": "THRB"
+          },
+          "THROB2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB2",
+            "Mode": "THRB"
+          },
+          "THROB4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB4",
+            "Mode": "THRB"
+          },
+          "USB": {
+            "Enumeration Name": "Submode",
+            "Submode": "USB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, upper-sideband, suppressed-carrier"
+          },
+          "VARA HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA HF",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for HF"
+          },
+          "VARA SATELLITE": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA SATELLITE",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for satellite operations"
+          },
+          "VARA FM 1200": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 1200",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          },
+          "VARA FM 9600": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 9600",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_ant_path.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_ant_path.json
@@ -1,0 +1,43 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:32Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Ant_Path": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "G": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "G",
+            "Meaning": "grayline"
+          },
+          "O": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "O",
+            "Meaning": "other"
+          },
+          "S": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "S",
+            "Meaning": "short path"
+          },
+          "L": {
+            "Enumeration Name": "Ant_Path",
+            "Abbreviation": "L",
+            "Meaning": "long path"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_arrl_section.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_arrl_section.json
@@ -1,0 +1,586 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:33Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "ARRL_Section": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Section Name",
+          "DXCC Entity Code",
+          "From Date",
+          "Deleted Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AL",
+            "Section Name": "Alabama",
+            "DXCC Entity Code": "291"
+          },
+          "AK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AK",
+            "Section Name": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AB",
+            "Section Name": "Alberta",
+            "DXCC Entity Code": "1"
+          },
+          "AR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AR",
+            "Section Name": "Arkansas",
+            "DXCC Entity Code": "291"
+          },
+          "AZ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "AZ",
+            "Section Name": "Arizona",
+            "DXCC Entity Code": "291"
+          },
+          "BC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "BC",
+            "Section Name": "British Columbia",
+            "DXCC Entity Code": "1"
+          },
+          "CO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CO",
+            "Section Name": "Colorado",
+            "DXCC Entity Code": "291"
+          },
+          "CT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "CT",
+            "Section Name": "Connecticut",
+            "DXCC Entity Code": "291"
+          },
+          "DE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "DE",
+            "Section Name": "Delaware",
+            "DXCC Entity Code": "291"
+          },
+          "EB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EB",
+            "Section Name": "East Bay",
+            "DXCC Entity Code": "291"
+          },
+          "EMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EMA",
+            "Section Name": "Eastern Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "ENY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ENY",
+            "Section Name": "Eastern New York",
+            "DXCC Entity Code": "291"
+          },
+          "EPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EPA",
+            "Section Name": "Eastern Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "EWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "EWA",
+            "Section Name": "Eastern Washington",
+            "DXCC Entity Code": "291"
+          },
+          "GA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GA",
+            "Section Name": "Georgia",
+            "DXCC Entity Code": "291"
+          },
+          "GH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GH",
+            "Section Name": "Golden Horseshoe",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "GTA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "GTA",
+            "Section Name": "Greater Toronto Area",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by GH"
+          },
+          "ID": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ID",
+            "Section Name": "Idaho",
+            "DXCC Entity Code": "291"
+          },
+          "IL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IL",
+            "Section Name": "Illinois",
+            "DXCC Entity Code": "291"
+          },
+          "IN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IN",
+            "Section Name": "Indiana",
+            "DXCC Entity Code": "291"
+          },
+          "IA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "IA",
+            "Section Name": "Iowa",
+            "DXCC Entity Code": "291"
+          },
+          "KS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KS",
+            "Section Name": "Kansas",
+            "DXCC Entity Code": "291"
+          },
+          "KY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "KY",
+            "Section Name": "Kentucky",
+            "DXCC Entity Code": "291"
+          },
+          "LAX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LAX",
+            "Section Name": "Los Angeles",
+            "DXCC Entity Code": "291"
+          },
+          "LA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "LA",
+            "Section Name": "Louisiana",
+            "DXCC Entity Code": "291"
+          },
+          "ME": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ME",
+            "Section Name": "Maine",
+            "DXCC Entity Code": "291"
+          },
+          "MB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MB",
+            "Section Name": "Manitoba",
+            "DXCC Entity Code": "1"
+          },
+          "MAR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MAR",
+            "Section Name": "Maritime",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by NB and NS"
+          },
+          "MDC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MDC",
+            "Section Name": "Maryland-DC",
+            "DXCC Entity Code": "291"
+          },
+          "MI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MI",
+            "Section Name": "Michigan",
+            "DXCC Entity Code": "291"
+          },
+          "MN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MN",
+            "Section Name": "Minnesota",
+            "DXCC Entity Code": "291"
+          },
+          "MS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MS",
+            "Section Name": "Mississippi",
+            "DXCC Entity Code": "291"
+          },
+          "MO": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MO",
+            "Section Name": "Missouri",
+            "DXCC Entity Code": "291"
+          },
+          "MT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "MT",
+            "Section Name": "Montana",
+            "DXCC Entity Code": "291"
+          },
+          "NE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NE",
+            "Section Name": "Nebraska",
+            "DXCC Entity Code": "291"
+          },
+          "NV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NV",
+            "Section Name": "Nevada",
+            "DXCC Entity Code": "291"
+          },
+          "NB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NB",
+            "Section Name": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "NH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NH",
+            "Section Name": "New Hampshire",
+            "DXCC Entity Code": "291"
+          },
+          "NM": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NM",
+            "Section Name": "New Mexico",
+            "DXCC Entity Code": "291"
+          },
+          "NLI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NLI",
+            "Section Name": "New York City-Long Island",
+            "DXCC Entity Code": "291"
+          },
+          "NL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NL",
+            "Section Name": "Newfoundland/Labrador",
+            "DXCC Entity Code": "1"
+          },
+          "NC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NC",
+            "Section Name": "North Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "ND": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ND",
+            "Section Name": "North Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "NTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NTX",
+            "Section Name": "North Texas",
+            "DXCC Entity Code": "291"
+          },
+          "NFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NFL",
+            "Section Name": "Northern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "NNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNJ",
+            "Section Name": "Northern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "NNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NNY",
+            "Section Name": "Northern New York",
+            "DXCC Entity Code": "291"
+          },
+          "NT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "From Date": "2003-11-01T00:00:00Z",
+            "Deleted Date": "2023-01-01T00:00:00Z",
+            "Comments": "replaced by TER"
+          },
+          "NWT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NWT",
+            "Section Name": "Northwest Territories/Yukon/Nunavut",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2003-11-01T00:00:00Z",
+            "Comments": "replaced by NT"
+          },
+          "NS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "NS",
+            "Section Name": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "OH": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OH",
+            "Section Name": "Ohio",
+            "DXCC Entity Code": "291"
+          },
+          "OK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OK",
+            "Section Name": "Oklahoma",
+            "DXCC Entity Code": "291"
+          },
+          "ON": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ON",
+            "Section Name": "Ontario",
+            "DXCC Entity Code": "1",
+            "Deleted Date": "2012-09-01T00:00:00Z",
+            "Comments": "replaced by GTA, ONE, ONN, and ONS"
+          },
+          "ONE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONE",
+            "Section Name": "Ontario East",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONN",
+            "Section Name": "Ontario North",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ONS": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ONS",
+            "Section Name": "Ontario South",
+            "DXCC Entity Code": "1",
+            "From Date": "2012-09-01T00:00:00Z"
+          },
+          "ORG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "ORG",
+            "Section Name": "Orange",
+            "DXCC Entity Code": "291"
+          },
+          "OR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "OR",
+            "Section Name": "Oregon",
+            "DXCC Entity Code": "291"
+          },
+          "PAC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PAC",
+            "Section Name": "Pacific",
+            "DXCC Entity Code": "9,20,103,110,123,138,166,174,197,297,515"
+          },
+          "PE": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PE",
+            "Section Name": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "From Date": "2020-04-01T00:00:00Z"
+          },
+          "PR": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "PR",
+            "Section Name": "Puerto Rico",
+            "DXCC Entity Code": "43,202"
+          },
+          "QC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "QC",
+            "Section Name": "Quebec",
+            "DXCC Entity Code": "1"
+          },
+          "RI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "RI",
+            "Section Name": "Rhode Island",
+            "DXCC Entity Code": "291"
+          },
+          "SV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SV",
+            "Section Name": "Sacramento Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SDG": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SDG",
+            "Section Name": "San Diego",
+            "DXCC Entity Code": "291"
+          },
+          "SF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SF",
+            "Section Name": "San Francisco",
+            "DXCC Entity Code": "291"
+          },
+          "SJV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SJV",
+            "Section Name": "San Joaquin Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SB": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SB",
+            "Section Name": "Santa Barbara",
+            "DXCC Entity Code": "291"
+          },
+          "SCV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SCV",
+            "Section Name": "Santa Clara Valley",
+            "DXCC Entity Code": "291"
+          },
+          "SK": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SK",
+            "Section Name": "Saskatchewan",
+            "DXCC Entity Code": "1"
+          },
+          "SC": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SC",
+            "Section Name": "South Carolina",
+            "DXCC Entity Code": "291"
+          },
+          "SD": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SD",
+            "Section Name": "South Dakota",
+            "DXCC Entity Code": "291"
+          },
+          "STX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "STX",
+            "Section Name": "South Texas",
+            "DXCC Entity Code": "291"
+          },
+          "SFL": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SFL",
+            "Section Name": "Southern Florida",
+            "DXCC Entity Code": "291"
+          },
+          "SNJ": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "SNJ",
+            "Section Name": "Southern New Jersey",
+            "DXCC Entity Code": "291"
+          },
+          "TN": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TN",
+            "Section Name": "Tennessee",
+            "DXCC Entity Code": "291"
+          },
+          "TER": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "TER",
+            "Section Name": "Territories",
+            "DXCC Entity Code": "1",
+            "From Date": "2023-01-01T00:00:00Z"
+          },
+          "VI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VI",
+            "Section Name": "US Virgin Islands",
+            "DXCC Entity Code": "105,182,285"
+          },
+          "UT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "UT",
+            "Section Name": "Utah",
+            "DXCC Entity Code": "291"
+          },
+          "VT": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VT",
+            "Section Name": "Vermont",
+            "DXCC Entity Code": "291"
+          },
+          "VA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "VA",
+            "Section Name": "Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WCF": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WCF",
+            "Section Name": "West Central Florida",
+            "DXCC Entity Code": "291"
+          },
+          "WTX": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WTX",
+            "Section Name": "West Texas",
+            "DXCC Entity Code": "291"
+          },
+          "WV": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WV",
+            "Section Name": "West Virginia",
+            "DXCC Entity Code": "291"
+          },
+          "WMA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WMA",
+            "Section Name": "Western Massachusetts",
+            "DXCC Entity Code": "291"
+          },
+          "WNY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WNY",
+            "Section Name": "Western New York",
+            "DXCC Entity Code": "291"
+          },
+          "WPA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WPA",
+            "Section Name": "Western Pennsylvania",
+            "DXCC Entity Code": "291"
+          },
+          "WWA": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WWA",
+            "Section Name": "Western Washington",
+            "DXCC Entity Code": "291"
+          },
+          "WI": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WI",
+            "Section Name": "Wisconsin",
+            "DXCC Entity Code": "291"
+          },
+          "WY": {
+            "Enumeration Name": "ARRL_Section",
+            "Abbreviation": "WY",
+            "Section Name": "Wyoming",
+            "DXCC Entity Code": "291"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_award.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_award.json
@@ -1,0 +1,167 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:34Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Award": {
+        "Header": [
+          "Enumeration Name",
+          "Award",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AJA": {
+            "Enumeration Name": "Award",
+            "Award": "AJA",
+            "Import-only": "true"
+          },
+          "CQDX": {
+            "Enumeration Name": "Award",
+            "Award": "CQDX",
+            "Import-only": "true"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Award",
+            "Award": "CQDXFIELD",
+            "Import-only": "true"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_MIXED",
+            "Import-only": "true"
+          },
+          "CQWAZ_CW": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_CW",
+            "Import-only": "true"
+          },
+          "CQWAZ_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_PHONE",
+            "Import-only": "true"
+          },
+          "CQWAZ_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_RTTY",
+            "Import-only": "true"
+          },
+          "CQWAZ_160m": {
+            "Enumeration Name": "Award",
+            "Award": "CQWAZ_160m",
+            "Import-only": "true"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Award",
+            "Award": "CQWPX",
+            "Import-only": "true"
+          },
+          "DARC_DOK": {
+            "Enumeration Name": "Award",
+            "Award": "DARC_DOK",
+            "Import-only": "true"
+          },
+          "DXCC": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC",
+            "Import-only": "true"
+          },
+          "DXCC_MIXED": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_MIXED",
+            "Import-only": "true"
+          },
+          "DXCC_CW": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_CW",
+            "Import-only": "true"
+          },
+          "DXCC_PHONE": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_PHONE",
+            "Import-only": "true"
+          },
+          "DXCC_RTTY": {
+            "Enumeration Name": "Award",
+            "Award": "DXCC_RTTY",
+            "Import-only": "true"
+          },
+          "IOTA": {
+            "Enumeration Name": "Award",
+            "Award": "IOTA",
+            "Import-only": "true"
+          },
+          "JCC": {
+            "Enumeration Name": "Award",
+            "Award": "JCC",
+            "Import-only": "true"
+          },
+          "JCG": {
+            "Enumeration Name": "Award",
+            "Award": "JCG",
+            "Import-only": "true"
+          },
+          "MARATHON": {
+            "Enumeration Name": "Award",
+            "Award": "MARATHON",
+            "Import-only": "true"
+          },
+          "RDA": {
+            "Enumeration Name": "Award",
+            "Award": "RDA",
+            "Import-only": "true"
+          },
+          "WAB": {
+            "Enumeration Name": "Award",
+            "Award": "WAB",
+            "Import-only": "true"
+          },
+          "WAC": {
+            "Enumeration Name": "Award",
+            "Award": "WAC",
+            "Import-only": "true"
+          },
+          "WAE": {
+            "Enumeration Name": "Award",
+            "Award": "WAE",
+            "Import-only": "true"
+          },
+          "WAIP": {
+            "Enumeration Name": "Award",
+            "Award": "WAIP",
+            "Import-only": "true"
+          },
+          "WAJA": {
+            "Enumeration Name": "Award",
+            "Award": "WAJA",
+            "Import-only": "true"
+          },
+          "WAS": {
+            "Enumeration Name": "Award",
+            "Award": "WAS",
+            "Import-only": "true"
+          },
+          "WAZ": {
+            "Enumeration Name": "Award",
+            "Award": "WAZ",
+            "Import-only": "true"
+          },
+          "USACA": {
+            "Enumeration Name": "Award",
+            "Award": "USACA",
+            "Import-only": "true"
+          },
+          "VUCC": {
+            "Enumeration Name": "Award",
+            "Award": "VUCC",
+            "Import-only": "true"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_award_sponsor.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_award_sponsor.json
@@ -1,0 +1,78 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:34Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Award_Sponsor": {
+        "Header": [
+          "Enumeration Name",
+          "Sponsor",
+          "Sponsoring Organization",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "ADIF_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ADIF_",
+            "Sponsoring Organization": "ADIF Development Group"
+          },
+          "ARI_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARI_",
+            "Sponsoring Organization": "ARI - l\u0027Associazione Radioamatori Italiani"
+          },
+          "ARRL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "ARRL_",
+            "Sponsoring Organization": "ARRL - American Radio Relay League"
+          },
+          "CQ_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "CQ_",
+            "Sponsoring Organization": "CQ Magazine"
+          },
+          "DARC_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "DARC_",
+            "Sponsoring Organization": "DARC - Deutscher Amateur-Radio-Club e.V."
+          },
+          "EQSL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "EQSL_",
+            "Sponsoring Organization": "eQSL"
+          },
+          "IARU_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "IARU_",
+            "Sponsoring Organization": "IARU - International Amateur Radio Union"
+          },
+          "JARL_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "JARL_",
+            "Sponsoring Organization": "JARL - Japan Amateur Radio League"
+          },
+          "RSGB_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "RSGB_",
+            "Sponsoring Organization": "RSGB - Radio Society of Great Britain"
+          },
+          "TAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "TAG_",
+            "Sponsoring Organization": "TAG - Tambov award group"
+          },
+          "WABAG_": {
+            "Enumeration Name": "Award_Sponsor",
+            "Sponsor": "WABAG_",
+            "Sponsoring Organization": "WAB - Worked all Britain"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_band.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_band.json
@@ -1,0 +1,222 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:35Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Band": {
+        "Header": [
+          "Enumeration Name",
+          "Band",
+          "Lower Freq (MHz)",
+          "Upper Freq (MHz)",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "2190m": {
+            "Enumeration Name": "Band",
+            "Band": "2190m",
+            "Lower Freq (MHz)": ".1357",
+            "Upper Freq (MHz)": ".1378"
+          },
+          "630m": {
+            "Enumeration Name": "Band",
+            "Band": "630m",
+            "Lower Freq (MHz)": ".472",
+            "Upper Freq (MHz)": ".479"
+          },
+          "560m": {
+            "Enumeration Name": "Band",
+            "Band": "560m",
+            "Lower Freq (MHz)": ".501",
+            "Upper Freq (MHz)": ".504"
+          },
+          "160m": {
+            "Enumeration Name": "Band",
+            "Band": "160m",
+            "Lower Freq (MHz)": "1.8",
+            "Upper Freq (MHz)": "2.0"
+          },
+          "80m": {
+            "Enumeration Name": "Band",
+            "Band": "80m",
+            "Lower Freq (MHz)": "3.5",
+            "Upper Freq (MHz)": "4.0"
+          },
+          "60m": {
+            "Enumeration Name": "Band",
+            "Band": "60m",
+            "Lower Freq (MHz)": "5.06",
+            "Upper Freq (MHz)": "5.45"
+          },
+          "40m": {
+            "Enumeration Name": "Band",
+            "Band": "40m",
+            "Lower Freq (MHz)": "7.0",
+            "Upper Freq (MHz)": "7.3"
+          },
+          "30m": {
+            "Enumeration Name": "Band",
+            "Band": "30m",
+            "Lower Freq (MHz)": "10.1",
+            "Upper Freq (MHz)": "10.15"
+          },
+          "20m": {
+            "Enumeration Name": "Band",
+            "Band": "20m",
+            "Lower Freq (MHz)": "14.0",
+            "Upper Freq (MHz)": "14.35"
+          },
+          "17m": {
+            "Enumeration Name": "Band",
+            "Band": "17m",
+            "Lower Freq (MHz)": "18.068",
+            "Upper Freq (MHz)": "18.168"
+          },
+          "15m": {
+            "Enumeration Name": "Band",
+            "Band": "15m",
+            "Lower Freq (MHz)": "21.0",
+            "Upper Freq (MHz)": "21.45"
+          },
+          "12m": {
+            "Enumeration Name": "Band",
+            "Band": "12m",
+            "Lower Freq (MHz)": "24.890",
+            "Upper Freq (MHz)": "24.99"
+          },
+          "10m": {
+            "Enumeration Name": "Band",
+            "Band": "10m",
+            "Lower Freq (MHz)": "28.0",
+            "Upper Freq (MHz)": "29.7"
+          },
+          "8m": {
+            "Enumeration Name": "Band",
+            "Band": "8m",
+            "Lower Freq (MHz)": "40",
+            "Upper Freq (MHz)": "45"
+          },
+          "6m": {
+            "Enumeration Name": "Band",
+            "Band": "6m",
+            "Lower Freq (MHz)": "50",
+            "Upper Freq (MHz)": "54"
+          },
+          "5m": {
+            "Enumeration Name": "Band",
+            "Band": "5m",
+            "Lower Freq (MHz)": "54.000001",
+            "Upper Freq (MHz)": "69.9"
+          },
+          "4m": {
+            "Enumeration Name": "Band",
+            "Band": "4m",
+            "Lower Freq (MHz)": "70",
+            "Upper Freq (MHz)": "71"
+          },
+          "2m": {
+            "Enumeration Name": "Band",
+            "Band": "2m",
+            "Lower Freq (MHz)": "144",
+            "Upper Freq (MHz)": "148"
+          },
+          "1.25m": {
+            "Enumeration Name": "Band",
+            "Band": "1.25m",
+            "Lower Freq (MHz)": "222",
+            "Upper Freq (MHz)": "225"
+          },
+          "70cm": {
+            "Enumeration Name": "Band",
+            "Band": "70cm",
+            "Lower Freq (MHz)": "420",
+            "Upper Freq (MHz)": "450"
+          },
+          "33cm": {
+            "Enumeration Name": "Band",
+            "Band": "33cm",
+            "Lower Freq (MHz)": "902",
+            "Upper Freq (MHz)": "928"
+          },
+          "23cm": {
+            "Enumeration Name": "Band",
+            "Band": "23cm",
+            "Lower Freq (MHz)": "1240",
+            "Upper Freq (MHz)": "1300"
+          },
+          "13cm": {
+            "Enumeration Name": "Band",
+            "Band": "13cm",
+            "Lower Freq (MHz)": "2300",
+            "Upper Freq (MHz)": "2450"
+          },
+          "9cm": {
+            "Enumeration Name": "Band",
+            "Band": "9cm",
+            "Lower Freq (MHz)": "3300",
+            "Upper Freq (MHz)": "3500"
+          },
+          "6cm": {
+            "Enumeration Name": "Band",
+            "Band": "6cm",
+            "Lower Freq (MHz)": "5650",
+            "Upper Freq (MHz)": "5925"
+          },
+          "3cm": {
+            "Enumeration Name": "Band",
+            "Band": "3cm",
+            "Lower Freq (MHz)": "10000",
+            "Upper Freq (MHz)": "10500"
+          },
+          "1.25cm": {
+            "Enumeration Name": "Band",
+            "Band": "1.25cm",
+            "Lower Freq (MHz)": "24000",
+            "Upper Freq (MHz)": "24250"
+          },
+          "6mm": {
+            "Enumeration Name": "Band",
+            "Band": "6mm",
+            "Lower Freq (MHz)": "47000",
+            "Upper Freq (MHz)": "47200"
+          },
+          "4mm": {
+            "Enumeration Name": "Band",
+            "Band": "4mm",
+            "Lower Freq (MHz)": "75500",
+            "Upper Freq (MHz)": "81000"
+          },
+          "2.5mm": {
+            "Enumeration Name": "Band",
+            "Band": "2.5mm",
+            "Lower Freq (MHz)": "119980",
+            "Upper Freq (MHz)": "123000"
+          },
+          "2mm": {
+            "Enumeration Name": "Band",
+            "Band": "2mm",
+            "Lower Freq (MHz)": "134000",
+            "Upper Freq (MHz)": "149000"
+          },
+          "1mm": {
+            "Enumeration Name": "Band",
+            "Band": "1mm",
+            "Lower Freq (MHz)": "241000",
+            "Upper Freq (MHz)": "250000"
+          },
+          "submm": {
+            "Enumeration Name": "Band",
+            "Band": "submm",
+            "Lower Freq (MHz)": "300000",
+            "Upper Freq (MHz)": "7500000"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_contest_id.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_contest_id.json
@@ -1,0 +1,1307 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:36Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Contest_ID": {
+        "Header": [
+          "Enumeration Name",
+          "Contest-ID",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "070-160M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-160M-SPRINT",
+            "Description": "PODXS Great Pumpkin Sprint"
+          },
+          "070-3-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-3-DAY",
+            "Description": "PODXS Three Day Weekend"
+          },
+          "070-31-FLAVORS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-31-FLAVORS",
+            "Description": "PODXS 31 Flavors"
+          },
+          "070-40M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-40M-SPRINT",
+            "Description": "PODXS 40m Firecracker Sprint"
+          },
+          "070-80M-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-80M-SPRINT",
+            "Description": "PODXS 80m Jay Hudak Memorial Sprint"
+          },
+          "070-PSKFEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-PSKFEST",
+            "Description": "PODXS PSKFest"
+          },
+          "070-ST-PATS-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-ST-PATS-DAY",
+            "Description": "PODXS St. Patricks Day"
+          },
+          "070-VALENTINE-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "070-VALENTINE-SPRINT",
+            "Description": "PODXS Valentine Sprint"
+          },
+          "10-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "10-RTTY",
+            "Description": "Ten-Meter RTTY Contest (2011 onwards)"
+          },
+          "1010-OPEN-SEASON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "1010-OPEN-SEASON",
+            "Description": "Open Season Ten Meter QSO Party"
+          },
+          "7QP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "7QP",
+            "Description": "7th-Area QSO Party"
+          },
+          "AL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AL-QSO-PARTY",
+            "Description": "Alabama QSO Party"
+          },
+          "ALL-ASIAN-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-CW",
+            "Description": "JARL All Asian DX Contest (CW)"
+          },
+          "ALL-ASIAN-DX-PHONE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ALL-ASIAN-DX-PHONE",
+            "Description": "JARL All Asian DX Contest (PHONE)"
+          },
+          "ANARTS-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANARTS-RTTY",
+            "Description": "ANARTS WW RTTY"
+          },
+          "ANATOLIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ANATOLIAN-RTTY",
+            "Description": "Anatolian WW RTTY"
+          },
+          "AP-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AP-SPRINT",
+            "Description": "Asia - Pacific Sprint"
+          },
+          "AR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AR-QSO-PARTY",
+            "Description": "Arkansas QSO Party"
+          },
+          "ARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-DX",
+            "Description": "ARI DX Contest"
+          },
+          "ARI-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-EME",
+            "Description": "ARI Italian EME Trophy"
+          },
+          "ARI-IAC-13CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-13CM",
+            "Description": "ARI Italian Activity Contest (13cm\u002B)"
+          },
+          "ARI-IAC-23CM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-23CM",
+            "Description": "ARI Italian Activity Contest (23cm)"
+          },
+          "ARI-IAC-6M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-6M",
+            "Description": "ARI Italian Activity Contest (6m)"
+          },
+          "ARI-IAC-UHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-UHF",
+            "Description": "ARI Italian Activity Contest (UHF)"
+          },
+          "ARI-IAC-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARI-IAC-VHF",
+            "Description": "ARI Italian Activity Contest (VHF)"
+          },
+          "ARRL-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10",
+            "Description": "ARRL 10 Meter Contest"
+          },
+          "ARRL-10-GHZ": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-10-GHZ",
+            "Description": "ARRL 10 GHz and Up Contest"
+          },
+          "ARRL-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-160",
+            "Description": "ARRL 160 Meter Contest"
+          },
+          "ARRL-222": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-222",
+            "Description": "ARRL 222 MHz and Up Distance Contest"
+          },
+          "ARRL-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DIGI",
+            "Description": "ARRL International Digital Contest"
+          },
+          "ARRL-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-CW",
+            "Description": "ARRL International DX Contest (CW)"
+          },
+          "ARRL-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-DX-SSB",
+            "Description": "ARRL International DX Contest (Phone)"
+          },
+          "ARRL-EME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-EME",
+            "Description": "ARRL EME contest"
+          },
+          "ARRL-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-FIELD-DAY",
+            "Description": "ARRL Field Day"
+          },
+          "ARRL-RR-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-CW",
+            "Description": "ARRL Rookie Roundup (CW)"
+          },
+          "ARRL-RR-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-RTTY",
+            "Description": "ARRL Rookie Roundup (RTTY)"
+          },
+          "ARRL-RR-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RR-SSB",
+            "Description": "ARRL Rookie Roundup (Phone)"
+          },
+          "ARRL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-RTTY",
+            "Description": "ARRL RTTY Round-Up"
+          },
+          "ARRL-SCR": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SCR",
+            "Description": "ARRL School Club Roundup"
+          },
+          "ARRL-SS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-CW",
+            "Description": "ARRL November Sweepstakes (CW)"
+          },
+          "ARRL-SS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-SS-SSB",
+            "Description": "ARRL November Sweepstakes (Phone)"
+          },
+          "ARRL-UHF-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-UHF-AUG",
+            "Description": "ARRL August UHF Contest"
+          },
+          "ARRL-VHF-JAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JAN",
+            "Description": "ARRL January VHF Sweepstakes"
+          },
+          "ARRL-VHF-JUN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-JUN",
+            "Description": "ARRL June VHF QSO Party"
+          },
+          "ARRL-VHF-SEP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ARRL-VHF-SEP",
+            "Description": "ARRL September VHF QSO Party"
+          },
+          "AZ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "AZ-QSO-PARTY",
+            "Description": "Arizona QSO Party"
+          },
+          "BANGGAI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BANGGAI-DX",
+            "Description": "ORARI Banggai DX Contest"
+          },
+          "BARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-RTTY",
+            "Description": "BARTG Spring RTTY Contest"
+          },
+          "BARTG-SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BARTG-SPRINT",
+            "Description": "BARTG Sprint Contest"
+          },
+          "BC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BC-QSO-PARTY",
+            "Description": "British Columbia QSO Party"
+          },
+          "BEKASI-MERDEKA-CONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "BEKASI-MERDEKA-CONTEST",
+            "Description": "ORARI Bekasi Merdeka Contest"
+          },
+          "CA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CA-QSO-PARTY",
+            "Description": "California QSO Party"
+          },
+          "CIS-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CIS-DX",
+            "Description": "CIS DX Contest"
+          },
+          "CO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CO-QSO-PARTY",
+            "Description": "Colorado QSO Party"
+          },
+          "CQ-160-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-CW",
+            "Description": "CQ WW 160 Meter DX Contest (CW)"
+          },
+          "CQ-160-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-160-SSB",
+            "Description": "CQ WW 160 Meter DX Contest (SSB)"
+          },
+          "CQ-M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-M",
+            "Description": "CQ-M International DX Contest"
+          },
+          "CQ-VHF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-VHF",
+            "Description": "CQ World-Wide VHF Contest"
+          },
+          "CQ-WPX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-CW",
+            "Description": "CQ WW WPX Contest (CW)"
+          },
+          "CQ-WPX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-RTTY",
+            "Description": "CQ/RJ WW RTTY WPX Contest"
+          },
+          "CQ-WPX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WPX-SSB",
+            "Description": "CQ WW WPX Contest (SSB)"
+          },
+          "CQ-WW-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-CW",
+            "Description": "CQ WW DX Contest (CW)"
+          },
+          "CQ-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-RTTY",
+            "Description": "CQ/RJ WW RTTY DX Contest"
+          },
+          "CQ-WW-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CQ-WW-SSB",
+            "Description": "CQ WW DX Contest (SSB)"
+          },
+          "CT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CT-QSO-PARTY",
+            "Description": "Connecticut QSO Party"
+          },
+          "CVA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-CW",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CVA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CVA-DX-SSB",
+            "Description": "Concurso Verde e Amarelo DX CW Contest"
+          },
+          "CWOPS-CW-OPEN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CW-OPEN",
+            "Description": "CWops CW Open Competition"
+          },
+          "CWOPS-CWT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "CWOPS-CWT",
+            "Description": "CWops Mini-CWT Test"
+          },
+          "DARC-10": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-10",
+            "Description": "DARC 10m Contest"
+          },
+          "DARC-CWA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-CWA",
+            "Description": "DARC CW Trainee Contest"
+          },
+          "DARC-FT4": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-FT4",
+            "Description": "DARC FT4 Contest"
+          },
+          "DARC-HELL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-HELL",
+            "Description": "DARC Hell Contest"
+          },
+          "DARC-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-MICROWAVE",
+            "Description": "DARC Microwave Contest"
+          },
+          "DARC-TRAINEE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-TRAINEE",
+            "Description": "DARC Trainee Contest"
+          },
+          "DARC-UKW-SPRING": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-SPRING",
+            "Description": "DARC UKW Spring Contest"
+          },
+          "DARC-UKW-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-UKW-FIELD-DAY",
+            "Description": "DARC UKW Summer Contest"
+          },
+          "DARC-VHF-UHF-MICROWAVE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-VHF-UHF-MICROWAVE",
+            "Description": "DARC VHF-, UHF-, Microwave Contest (May)"
+          },
+          "DARC-WAEDC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-CW",
+            "Description": "WAE DX Contest (CW)"
+          },
+          "DARC-WAEDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-RTTY",
+            "Description": "WAE DX Contest (RTTY)"
+          },
+          "DARC-WAEDC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAEDC-SSB",
+            "Description": "WAE DX Contest (SSB)"
+          },
+          "DARC-WAG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DARC-WAG",
+            "Description": "DARC Worked All Germany"
+          },
+          "DE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DE-QSO-PARTY",
+            "Description": "Delaware QSO Party"
+          },
+          "DL-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DL-DX-RTTY",
+            "Description": "DL-DX RTTY Contest"
+          },
+          "DMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "DMC-RTTY",
+            "Description": "DMC RTTY Contest"
+          },
+          "EA-CNCW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-CNCW",
+            "Description": "Concurso Nacional de Telegrafía"
+          },
+          "EA-DME": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-DME",
+            "Description": "Municipios Españoles"
+          },
+          "EA-MAJESTAD-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-CW",
+            "Description": "His Majesty The King of Spain CW Contest (2022 and later)"
+          },
+          "EA-MAJESTAD-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-MAJESTAD-SSB",
+            "Description": "His Majesty The King of Spain SSB Contest (2022 and later)"
+          },
+          "EA-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-PSK63",
+            "Description": "EA PSK63"
+          },
+          "EA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest",
+            "Import-only": "true"
+          },
+          "EA-SMRE-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-CW",
+            "Description": "Su Majestad El Rey de España - CW (2021 and earlier)"
+          },
+          "EA-SMRE-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-SMRE-SSB",
+            "Description": "Su Majestad El Rey de España - SSB (2021 and earlier)"
+          },
+          "EA-VHF-ATLANTIC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-ATLANTIC",
+            "Description": "Atlántico V-UHF"
+          },
+          "EA-VHF-COM": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COM",
+            "Description": "Combinado de V-UHF"
+          },
+          "EA-VHF-COSTA-SOL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-COSTA-SOL",
+            "Description": "Costa del Sol V-UHF"
+          },
+          "EA-VHF-EA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA",
+            "Description": "Nacional VHF"
+          },
+          "EA-VHF-EA1RCS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-EA1RCS",
+            "Description": "Segovia EA1RCS V-UHF"
+          },
+          "EA-VHF-QSL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-QSL",
+            "Description": "QSL V-UHF \u0026 50MHz"
+          },
+          "EA-VHF-SADURNI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-VHF-SADURNI",
+            "Description": "Sant Sadurni V-UHF"
+          },
+          "EA-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EA-WW-RTTY",
+            "Description": "Unión de Radioaficionados Españoles RTTY Contest"
+          },
+          "EASTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EASTER",
+            "Description": "DARC Easter Contest"
+          },
+          "EPC-PSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EPC-PSK63",
+            "Description": "PSK63 QSO Party"
+          },
+          "EU SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU SPRINT",
+            "Description": "EU Sprint"
+          },
+          "EU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-HF",
+            "Description": "EU HF Championship"
+          },
+          "EU-PSK-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EU-PSK-DX",
+            "Description": "EU PSK DX Contest"
+          },
+          "EUCW160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "EUCW160M",
+            "Description": "European CW Association 160m CW Party"
+          },
+          "FALL SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FALL SPRINT",
+            "Description": "FISTS Fall Sprint"
+          },
+          "FL-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "FL-QSO-PARTY",
+            "Description": "Florida QSO Party"
+          },
+          "GA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "GA-QSO-PARTY",
+            "Description": "Georgia QSO Party"
+          },
+          "HA-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HA-DX",
+            "Description": "Hungarian DX Contest"
+          },
+          "HELVETIA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HELVETIA",
+            "Description": "Helvetia Contest"
+          },
+          "HI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HI-QSO-PARTY",
+            "Description": "Hawaiian QSO Party"
+          },
+          "HOLYLAND": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "HOLYLAND",
+            "Description": "IARC Holyland Contest"
+          },
+          "IA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IA-QSO-PARTY",
+            "Description": "Iowa QSO Party"
+          },
+          "IARU-FIELD-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-FIELD-DAY",
+            "Description": "DARC IARU Region 1 Field Day"
+          },
+          "IARU-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IARU-HF",
+            "Description": "IARU HF World Championship"
+          },
+          "ICWC-MST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ICWC-MST",
+            "Description": "ICWC Medium Speed Test"
+          },
+          "ID-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ID-QSO-PARTY",
+            "Description": "Idaho QSO Party"
+          },
+          "IL QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IL QSO PARTY",
+            "Description": "Illinois QSO Party"
+          },
+          "IN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "IN-QSO-PARTY",
+            "Description": "Indiana QSO Party"
+          },
+          "JARTS-WW-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JARTS-WW-RTTY",
+            "Description": "JARTS WW RTTY"
+          },
+          "JIDX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-CW",
+            "Description": "Japan International DX Contest (CW)"
+          },
+          "JIDX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JIDX-SSB",
+            "Description": "Japan International DX Contest (SSB)"
+          },
+          "JT-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "JT-DX-RTTY",
+            "Description": "Mongolian RTTY DX Contest"
+          },
+          "K1USN-SSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SSO",
+            "Description": "K1USN Slow Speed Open"
+          },
+          "K1USN-SST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "K1USN-SST",
+            "Description": "K1USN Slow Speed Test"
+          },
+          "KS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KS-QSO-PARTY",
+            "Description": "Kansas QSO Party"
+          },
+          "KY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "KY-QSO-PARTY",
+            "Description": "Kentucky QSO Party"
+          },
+          "LA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LA-QSO-PARTY",
+            "Description": "Louisiana QSO Party"
+          },
+          "LDC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LDC-RTTY",
+            "Description": "DRCG Long Distance Contest (RTTY)"
+          },
+          "LZ DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "LZ DX",
+            "Description": "LZ DX Contest"
+          },
+          "MAR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MAR-QSO-PARTY",
+            "Description": "Maritimes QSO Party"
+          },
+          "MD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MD-QSO-PARTY",
+            "Description": "Maryland QSO Party"
+          },
+          "ME-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ME-QSO-PARTY",
+            "Description": "Maine QSO Party"
+          },
+          "MI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MI-QSO-PARTY",
+            "Description": "Michigan QSO Party"
+          },
+          "MIDATLANTIC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MIDATLANTIC-QSO-PARTY",
+            "Description": "Mid-Atlantic QSO Party"
+          },
+          "MN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MN-QSO-PARTY",
+            "Description": "Minnesota QSO Party"
+          },
+          "MO-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MO-QSO-PARTY",
+            "Description": "Missouri QSO Party"
+          },
+          "MS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MS-QSO-PARTY",
+            "Description": "Mississippi QSO Party"
+          },
+          "MT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "MT-QSO-PARTY",
+            "Description": "Montana QSO Party"
+          },
+          "NA-SPRINT-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-CW",
+            "Description": "North America Sprint (CW)"
+          },
+          "NA-SPRINT-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-RTTY",
+            "Description": "North America Sprint (RTTY)"
+          },
+          "NA-SPRINT-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NA-SPRINT-SSB",
+            "Description": "North America Sprint (Phone)"
+          },
+          "NAQP-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-CW",
+            "Description": "North America QSO Party (CW)"
+          },
+          "NAQP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-RTTY",
+            "Description": "North America QSO Party (RTTY)"
+          },
+          "NAQP-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAQP-SSB",
+            "Description": "North America QSO Party (Phone)"
+          },
+          "NAVAL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NAVAL",
+            "Description": "International Naval Contest (INC)"
+          },
+          "NC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NC-QSO-PARTY",
+            "Description": "North Carolina QSO Party"
+          },
+          "ND-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ND-QSO-PARTY",
+            "Description": "North Dakota QSO Party"
+          },
+          "NE-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NE-QSO-PARTY",
+            "Description": "Nebraska QSO Party"
+          },
+          "NEQP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NEQP",
+            "Description": "New England QSO Party"
+          },
+          "NH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NH-QSO-PARTY",
+            "Description": "New Hampshire QSO Party"
+          },
+          "NJ-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NJ-QSO-PARTY",
+            "Description": "New Jersey QSO Party"
+          },
+          "NM-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NM-QSO-PARTY",
+            "Description": "New Mexico QSO Party"
+          },
+          "NRAU-BALTIC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-CW",
+            "Description": "NRAU-Baltic Contest (CW)"
+          },
+          "NRAU-BALTIC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NRAU-BALTIC-SSB",
+            "Description": "NRAU-Baltic Contest (SSB)"
+          },
+          "NV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NV-QSO-PARTY",
+            "Description": "Nevada QSO Party"
+          },
+          "NY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "NY-QSO-PARTY",
+            "Description": "New York QSO Party"
+          },
+          "OCEANIA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-CW",
+            "Description": "Oceania DX Contest (CW)"
+          },
+          "OCEANIA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OCEANIA-DX-SSB",
+            "Description": "Oceania DX Contest (SSB)"
+          },
+          "OH-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OH-QSO-PARTY",
+            "Description": "Ohio QSO Party"
+          },
+          "OK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-DX-RTTY",
+            "Description": "Czech Radio Club OK DX Contest"
+          },
+          "OK-OM-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-OM-DX",
+            "Description": "Czech Radio Club OK-OM DX Contest"
+          },
+          "OK-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OK-QSO-PARTY",
+            "Description": "Oklahoma QSO Party"
+          },
+          "OMISS-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OMISS-QSO-PARTY",
+            "Description": "Old Man International Sideband Society QSO Party"
+          },
+          "ON-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ON-QSO-PARTY",
+            "Description": "Ontario QSO Party"
+          },
+          "OR-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "OR-QSO-PARTY",
+            "Description": "Oregon QSO Party"
+          },
+          "ORARI-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "ORARI-DX",
+            "Description": "ORARI DX Contest"
+          },
+          "PA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PA-QSO-PARTY",
+            "Description": "Pennsylvania QSO Party"
+          },
+          "PACC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PACC",
+            "Description": "Dutch PACC Contest"
+          },
+          "PCC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PCC",
+            "Description": "PCCPro CW Contest"
+          },
+          "PSK-DEATHMATCH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "PSK-DEATHMATCH",
+            "Description": "MDXA PSK DeathMatch (2005-2010)"
+          },
+          "QC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "QC-QSO-PARTY",
+            "Description": "Quebec QSO Party"
+          },
+          "RAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC",
+            "Description": "Canadian Amateur Radio Society Contest",
+            "Import-only": "true"
+          },
+          "RAC-CANADA-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-DAY",
+            "Description": "RAC Canada Day Contest"
+          },
+          "RAC-CANADA-WINTER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RAC-CANADA-WINTER",
+            "Description": "RAC Canada Winter Contest"
+          },
+          "RDAC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDAC",
+            "Description": "Russian District Award Contest"
+          },
+          "RDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RDXC",
+            "Description": "Russian DX Contest"
+          },
+          "REF-160M": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-160M",
+            "Description": "Reseau des Emetteurs Francais 160m Contest"
+          },
+          "REF-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-CW",
+            "Description": "Reseau des Emetteurs Francais Contest (CW)"
+          },
+          "REF-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REF-SSB",
+            "Description": "Reseau des Emetteurs Francais Contest (SSB)"
+          },
+          "REP-PORTUGAL-DAY-HF": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "REP-PORTUGAL-DAY-HF",
+            "Description": "Rede dos Emissores Portugueses Portugal Day HF Contest"
+          },
+          "RI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RI-QSO-PARTY",
+            "Description": "Rhode Island QSO Party"
+          },
+          "RSGB-160": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-160",
+            "Description": "1.8MHz Contest"
+          },
+          "RSGB-21/28-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-CW",
+            "Description": "21/28 MHz Contest (CW)"
+          },
+          "RSGB-21/28-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-21/28-SSB",
+            "Description": "21/28 MHz Contest (SSB)"
+          },
+          "RSGB-80M-CC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-80M-CC",
+            "Description": "80m Club Championships"
+          },
+          "RSGB-AFS-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-CW",
+            "Description": "Affiliated Societies Team Contest (CW)"
+          },
+          "RSGB-AFS-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-AFS-SSB",
+            "Description": "Affiliated Societies Team Contest (SSB)"
+          },
+          "RSGB-CLUB-CALLS": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-CLUB-CALLS",
+            "Description": "Club Calls"
+          },
+          "RSGB-COMMONWEALTH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-COMMONWEALTH",
+            "Description": "Commonwealth Contest"
+          },
+          "RSGB-IOTA": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-IOTA",
+            "Description": "IOTA Contest"
+          },
+          "RSGB-LOW-POWER": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-LOW-POWER",
+            "Description": "Low Power Field Day"
+          },
+          "RSGB-NFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-NFD",
+            "Description": "National Field Day"
+          },
+          "RSGB-ROPOCO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-ROPOCO",
+            "Description": "RoPoCo"
+          },
+          "RSGB-SSB-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RSGB-SSB-FD",
+            "Description": "SSB Field Day"
+          },
+          "RUSSIAN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "RUSSIAN-RTTY",
+            "Description": "Russian Radio RTTY Worldwide Contest"
+          },
+          "SAC-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-CW",
+            "Description": "Scandinavian Activity Contest (CW)"
+          },
+          "SAC-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SAC-SSB",
+            "Description": "Scandinavian Activity Contest (SSB)"
+          },
+          "SARTG-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SARTG-RTTY",
+            "Description": "SARTG WW RTTY"
+          },
+          "SC-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SC-QSO-PARTY",
+            "Description": "South Carolina QSO Party"
+          },
+          "SCC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SCC-RTTY",
+            "Description": "SCC RTTY Championship"
+          },
+          "SD-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SD-QSO-PARTY",
+            "Description": "South Dakota QSO Party"
+          },
+          "SHORTRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SHORTRY",
+            "Description": "DARC RTTY Short Contest"
+          },
+          "SMP-AUG": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-AUG",
+            "Description": "SSA Portabeltest"
+          },
+          "SMP-MAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SMP-MAY",
+            "Description": "SSA Portabeltest"
+          },
+          "SP-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SP-DX-RTTY",
+            "Description": "PRC SPDX Contest (RTTY)"
+          },
+          "SPAR-WINTER-FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPAR-WINTER-FD",
+            "Description": "SPAR Winter Field Day(2016 and earlier)"
+          },
+          "SPDXCONTEST": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPDXCONTEST",
+            "Description": "SP DX Contest"
+          },
+          "SPRING SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SPRING SPRINT",
+            "Description": "FISTS Spring Sprint"
+          },
+          "SR-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SR-MARATHON",
+            "Description": "Scottish-Russian Marathon"
+          },
+          "STEW-PERRY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "STEW-PERRY",
+            "Description": "Stew Perry Topband Distance Challenge"
+          },
+          "SUMMER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "SUMMER SPRINT",
+            "Description": "FISTS Summer Sprint"
+          },
+          "TARA-GRID-DIP": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-GRID-DIP",
+            "Description": "TARA Grid Dip PSK-RTTY Shindig"
+          },
+          "TARA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RTTY",
+            "Description": "TARA RTTY Mêlée"
+          },
+          "TARA-RUMBLE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-RUMBLE",
+            "Description": "TARA Rumble PSK Contest"
+          },
+          "TARA-SKIRMISH": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TARA-SKIRMISH",
+            "Description": "TARA Skirmish Digital Prefix Contest"
+          },
+          "TEN-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TEN-RTTY",
+            "Description": "Ten-Meter RTTY Contest (before 2011)"
+          },
+          "TMC-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TMC-RTTY",
+            "Description": "The Makrothen Contest"
+          },
+          "TN-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TN-QSO-PARTY",
+            "Description": "Tennessee QSO Party"
+          },
+          "TX-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "TX-QSO-PARTY",
+            "Description": "Texas QSO Party"
+          },
+          "UBA-DX-CW": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-CW",
+            "Description": "UBA Contest (CW)"
+          },
+          "UBA-DX-SSB": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UBA-DX-SSB",
+            "Description": "UBA Contest (SSB)"
+          },
+          "UK-DX-BPSK63": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-BPSK63",
+            "Description": "European PSK Club BPSK63 Contest"
+          },
+          "UK-DX-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UK-DX-RTTY",
+            "Description": "UK DX RTTY Contest"
+          },
+          "UKR-CHAMP-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKR-CHAMP-RTTY",
+            "Description": "Open Ukraine RTTY Championship"
+          },
+          "UKRAINIAN DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKRAINIAN DX",
+            "Description": "Ukrainian DX"
+          },
+          "UKSMG-6M-MARATHON": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-6M-MARATHON",
+            "Description": "UKSMG 6m Marathon"
+          },
+          "UKSMG-SUMMER-ES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UKSMG-SUMMER-ES",
+            "Description": "UKSMG Summer Es Contest"
+          },
+          "URE-DX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "URE-DX",
+            "Description": "Ukrainian DX Contest",
+            "Import-only": "true"
+          },
+          "US-COUNTIES-QSO": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "US-COUNTIES-QSO",
+            "Description": "Mobile Amateur Awards Club"
+          },
+          "UT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "UT-QSO-PARTY",
+            "Description": "Utah QSO Party"
+          },
+          "VA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VA-QSO-PARTY",
+            "Description": "Virginia QSO Party"
+          },
+          "VENEZ-IND-DAY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VENEZ-IND-DAY",
+            "Description": "RCV Venezuelan Independence Day Contest"
+          },
+          "VIRGINIA QSO PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VIRGINIA QSO PARTY",
+            "Description": "Virginia QSO Party",
+            "Import-only": "true"
+          },
+          "VOLTA-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VOLTA-RTTY",
+            "Description": "Alessandro Volta RTTY DX Contest"
+          },
+          "VT-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "VT-QSO-PARTY",
+            "Description": "Vermont QSO Party"
+          },
+          "WA-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WA-QSO-PARTY",
+            "Description": "Washington QSO Party"
+          },
+          "WFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WFD",
+            "Description": "Winter Field Day (2017 and later)"
+          },
+          "WI-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WI-QSO-PARTY",
+            "Description": "Wisconsin QSO Party"
+          },
+          "WIA-HARRY ANGEL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-HARRY ANGEL",
+            "Description": "WIA Harry Angel Memorial 80m Sprint"
+          },
+          "WIA-JMMFD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-JMMFD",
+            "Description": "WIA John Moyle Memorial Field Day"
+          },
+          "WIA-OCDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-OCDX",
+            "Description": "WIA Oceania DX (OCDX) Contest"
+          },
+          "WIA-REMEMBRANCE": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-REMEMBRANCE",
+            "Description": "WIA Remembrance Day"
+          },
+          "WIA-ROSS HULL": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-ROSS HULL",
+            "Description": "WIA Ross Hull Memorial VHF/UHF Contest"
+          },
+          "WIA-TRANS TASMAN": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-TRANS TASMAN",
+            "Description": "WIA Trans Tasman Low Bands Challenge"
+          },
+          "WIA-VHF/UHF FD": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VHF/UHF FD",
+            "Description": "WIA VHF UHF Field Days"
+          },
+          "WIA-VK SHIRES": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WIA-VK SHIRES",
+            "Description": "WIA VK Shires"
+          },
+          "WINTER SPRINT": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WINTER SPRINT",
+            "Description": "FISTS Winter Sprint"
+          },
+          "WV-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WV-QSO-PARTY",
+            "Description": "West Virginia QSO Party"
+          },
+          "WW-DIGI": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WW-DIGI",
+            "Description": "World Wide Digi DX Contest"
+          },
+          "WY-QSO-PARTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "WY-QSO-PARTY",
+            "Description": "Wyoming QSO Party"
+          },
+          "XE-INTL-RTTY": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "XE-INTL-RTTY",
+            "Description": "Mexico International Contest (RTTY)"
+          },
+          "YOHFDX": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YOHFDX",
+            "Description": "YODX HF contest"
+          },
+          "YUDXC": {
+            "Enumeration Name": "Contest_ID",
+            "Contest-ID": "YUDXC",
+            "Description": "YU DX Contest"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_continent.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_continent.json
@@ -1,0 +1,58 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:36Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Continent": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Continent",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "NA",
+            "Continent": "North America"
+          },
+          "SA": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "SA",
+            "Continent": "South America"
+          },
+          "EU": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "EU",
+            "Continent": "Europe"
+          },
+          "AF": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AF",
+            "Continent": "Africa"
+          },
+          "OC": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "OC",
+            "Continent": "Oceania"
+          },
+          "AS": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AS",
+            "Continent": "Asia"
+          },
+          "AN": {
+            "Enumeration Name": "Continent",
+            "Abbreviation": "AN",
+            "Continent": "Antarctica"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_country.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_country.json
@@ -1,0 +1,2076 @@
+{
+  "Adif": {
+    "Enumerations": {
+      "Country": {
+        "Header": [
+          "Enumeration Name",
+          "Country Name",
+          "DXCC Entity Code",
+          "Import-only"
+        ],
+        "Records": {
+          "CANADA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CANADA",
+            "DXCC Entity Code": "1"
+          },
+          "ABU AIL IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ABU AIL IS.",
+            "DXCC Entity Code": "2",
+            "Import-only": "true"
+          },
+          "AFGHANISTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "AFGHANISTAN",
+            "DXCC Entity Code": "3"
+          },
+          "AGALEGA & ST. BRANDON IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "AGALEGA & ST. BRANDON IS.",
+            "DXCC Entity Code": "4"
+          },
+          "ALAND IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ALAND IS.",
+            "DXCC Entity Code": "5"
+          },
+          "ALASKA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ALASKA",
+            "DXCC Entity Code": "6"
+          },
+          "ALBANIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ALBANIA",
+            "DXCC Entity Code": "7"
+          },
+          "ALDABRA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ALDABRA",
+            "DXCC Entity Code": "8",
+            "Import-only": "true"
+          },
+          "AMERICAN SAMOA": {
+            "Enumeration Name": "Country",
+            "Country Name": "AMERICAN SAMOA",
+            "DXCC Entity Code": "9"
+          },
+          "AMSTERDAM & ST. PAUL IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "AMSTERDAM & ST. PAUL IS.",
+            "DXCC Entity Code": "10"
+          },
+          "ANDAMAN & NICOBAR IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANDAMAN & NICOBAR IS.",
+            "DXCC Entity Code": "11"
+          },
+          "ANGUILLA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANGUILLA",
+            "DXCC Entity Code": "12"
+          },
+          "ANTARCTICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANTARCTICA",
+            "DXCC Entity Code": "13"
+          },
+          "ARMENIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ARMENIA",
+            "DXCC Entity Code": "14"
+          },
+          "ASIATIC RUSSIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ASIATIC RUSSIA",
+            "DXCC Entity Code": "15"
+          },
+          "NEW ZEALAND SUBANTARCTIC ISLANDS": {
+            "Enumeration Name": "Country",
+            "Country Name": "NEW ZEALAND SUBANTARCTIC ISLANDS",
+            "DXCC Entity Code": "16"
+          },
+          "AVES I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "AVES I.",
+            "DXCC Entity Code": "17"
+          },
+          "AZERBAIJAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "AZERBAIJAN",
+            "DXCC Entity Code": "18"
+          },
+          "BAJO NUEVO": {
+            "Enumeration Name": "Country",
+            "Country Name": "BAJO NUEVO",
+            "DXCC Entity Code": "19",
+            "Import-only": "true"
+          },
+          "BAKER & HOWLAND IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "BAKER & HOWLAND IS.",
+            "DXCC Entity Code": "20"
+          },
+          "BALEARIC IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "BALEARIC IS.",
+            "DXCC Entity Code": "21"
+          },
+          "PALAU": {
+            "Enumeration Name": "Country",
+            "Country Name": "PALAU",
+            "DXCC Entity Code": "22"
+          },
+          "BLENHEIM REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "BLENHEIM REEF",
+            "DXCC Entity Code": "23",
+            "Import-only": "true"
+          },
+          "BOUVET": {
+            "Enumeration Name": "Country",
+            "Country Name": "BOUVET",
+            "DXCC Entity Code": "24"
+          },
+          "BRITISH NORTH BORNEO": {
+            "Enumeration Name": "Country",
+            "Country Name": "BRITISH NORTH BORNEO",
+            "DXCC Entity Code": "25",
+            "Import-only": "true"
+          },
+          "BRITISH SOMALILAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "BRITISH SOMALILAND",
+            "DXCC Entity Code": "26",
+            "Import-only": "true"
+          },
+          "BELARUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "BELARUS",
+            "DXCC Entity Code": "27"
+          },
+          "CANAL ZONE": {
+            "Enumeration Name": "Country",
+            "Country Name": "CANAL ZONE",
+            "DXCC Entity Code": "28",
+            "Import-only": "true"
+          },
+          "CANARY IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CANARY IS.",
+            "DXCC Entity Code": "29"
+          },
+          "CELEBE & MOLUCCA IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CELEBE & MOLUCCA IS.",
+            "DXCC Entity Code": "30",
+            "Import-only": "true"
+          },
+          "C. KIRIBATI (BRITISH PHOENIX IS.)": {
+            "Enumeration Name": "Country",
+            "Country Name": "C. KIRIBATI (BRITISH PHOENIX IS.)",
+            "DXCC Entity Code": "31"
+          },
+          "CEUTA & MELILLA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CEUTA & MELILLA",
+            "DXCC Entity Code": "32"
+          },
+          "CHAGOS IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHAGOS IS.",
+            "DXCC Entity Code": "33"
+          },
+          "CHATHAM IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHATHAM IS.",
+            "DXCC Entity Code": "34"
+          },
+          "CHRISTMAS I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHRISTMAS I.",
+            "DXCC Entity Code": "35"
+          },
+          "CLIPPERTON I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CLIPPERTON I.",
+            "DXCC Entity Code": "36"
+          },
+          "COCOS I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "COCOS I.",
+            "DXCC Entity Code": "37"
+          },
+          "COCOS (KEELING) IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "COCOS (KEELING) IS.",
+            "DXCC Entity Code": "38"
+          },
+          "COMOROS": {
+            "Enumeration Name": "Country",
+            "Country Name": "COMOROS",
+            "DXCC Entity Code": "411"
+          },
+          "CRETE": {
+            "Enumeration Name": "Country",
+            "Country Name": "CRETE",
+            "DXCC Entity Code": "40"
+          },
+          "CROZET I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CROZET I.",
+            "DXCC Entity Code": "41"
+          },
+          "DAMAO, DIU": {
+            "Enumeration Name": "Country",
+            "Country Name": "DAMAO, DIU",
+            "DXCC Entity Code": "42",
+            "Import-only": "true"
+          },
+          "DESECHEO I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "DESECHEO I.",
+            "DXCC Entity Code": "43"
+          },
+          "DESROCHES": {
+            "Enumeration Name": "Country",
+            "Country Name": "DESROCHES",
+            "DXCC Entity Code": "44",
+            "Import-only": "true"
+          },
+          "DODECANESE": {
+            "Enumeration Name": "Country",
+            "Country Name": "DODECANESE",
+            "DXCC Entity Code": "45"
+          },
+          "EAST MALAYSIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "EAST MALAYSIA",
+            "DXCC Entity Code": "46"
+          },
+          "EASTER I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "EASTER I.",
+            "DXCC Entity Code": "47"
+          },
+          "E. KIRIBATI (LINE IS.)": {
+            "Enumeration Name": "Country",
+            "Country Name": "E. KIRIBATI (LINE IS.)",
+            "DXCC Entity Code": "48"
+          },
+          "EQUATORIAL GUINEA": {
+            "Enumeration Name": "Country",
+            "Country Name": "EQUATORIAL GUINEA",
+            "DXCC Entity Code": "49"
+          },
+          "MEXICO": {
+            "Enumeration Name": "Country",
+            "Country Name": "MEXICO",
+            "DXCC Entity Code": "50"
+          },
+          "ERITREA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ERITREA",
+            "DXCC Entity Code": "51"
+          },
+          "ESTONIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ESTONIA",
+            "DXCC Entity Code": "52"
+          },
+          "ETHIOPIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ETHIOPIA",
+            "DXCC Entity Code": "53"
+          },
+          "EUROPEAN RUSSIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "EUROPEAN RUSSIA",
+            "DXCC Entity Code": "54"
+          },
+          "FARQUHAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "FARQUHAR",
+            "DXCC Entity Code": "55",
+            "Import-only": "true"
+          },
+          "FERNANDO DE NORONHA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FERNANDO DE NORONHA",
+            "DXCC Entity Code": "56"
+          },
+          "FRENCH EQUATORIAL AFRICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH EQUATORIAL AFRICA",
+            "DXCC Entity Code": "57",
+            "Import-only": "true"
+          },
+          "FRENCH INDO-CHINA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH INDO-CHINA",
+            "DXCC Entity Code": "58",
+            "Import-only": "true"
+          },
+          "FRENCH WEST AFRICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH WEST AFRICA",
+            "DXCC Entity Code": "59",
+            "Import-only": "true"
+          },
+          "BAHAMAS": {
+            "Enumeration Name": "Country",
+            "Country Name": "BAHAMAS",
+            "DXCC Entity Code": "60"
+          },
+          "FRANZ JOSEF LAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRANZ JOSEF LAND",
+            "DXCC Entity Code": "61"
+          },
+          "BARBADOS": {
+            "Enumeration Name": "Country",
+            "Country Name": "BARBADOS",
+            "DXCC Entity Code": "62"
+          },
+          "FRENCH GUIANA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH GUIANA",
+            "DXCC Entity Code": "63"
+          },
+          "BERMUDA": {
+            "Enumeration Name": "Country",
+            "Country Name": "BERMUDA",
+            "DXCC Entity Code": "64"
+          },
+          "BRITISH VIRGIN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "BRITISH VIRGIN IS.",
+            "DXCC Entity Code": "65"
+          },
+          "BELIZE": {
+            "Enumeration Name": "Country",
+            "Country Name": "BELIZE",
+            "DXCC Entity Code": "66"
+          },
+          "FRENCH INDIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH INDIA",
+            "DXCC Entity Code": "67",
+            "Import-only": "true"
+          },
+          "KUWAIT/SAUDI ARABIA NEUTRAL ZONE": {
+            "Enumeration Name": "Country",
+            "Country Name": "KUWAIT/SAUDI ARABIA NEUTRAL ZONE",
+            "DXCC Entity Code": "68",
+            "Import-only": "true"
+          },
+          "CAYMAN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CAYMAN IS.",
+            "DXCC Entity Code": "69"
+          },
+          "CUBA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CUBA",
+            "DXCC Entity Code": "70"
+          },
+          "GALAPAGOS IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "GALAPAGOS IS.",
+            "DXCC Entity Code": "71"
+          },
+          "DOMINICAN REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "DOMINICAN REPUBLIC",
+            "DXCC Entity Code": "72"
+          },
+          "EL SALVADOR": {
+            "Enumeration Name": "Country",
+            "Country Name": "EL SALVADOR",
+            "DXCC Entity Code": "74"
+          },
+          "GEORGIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GEORGIA",
+            "DXCC Entity Code": "75"
+          },
+          "GUATEMALA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUATEMALA",
+            "DXCC Entity Code": "76"
+          },
+          "GRENADA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GRENADA",
+            "DXCC Entity Code": "77"
+          },
+          "HAITI": {
+            "Enumeration Name": "Country",
+            "Country Name": "HAITI",
+            "DXCC Entity Code": "78"
+          },
+          "GUADELOUPE": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUADELOUPE",
+            "DXCC Entity Code": "79"
+          },
+          "HONDURAS": {
+            "Enumeration Name": "Country",
+            "Country Name": "HONDURAS",
+            "DXCC Entity Code": "80"
+          },
+          "GERMANY": {
+            "Enumeration Name": "Country",
+            "Country Name": "GERMANY",
+            "DXCC Entity Code": "81",
+            "Import-only": "true"
+          },
+          "JAMAICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "JAMAICA",
+            "DXCC Entity Code": "82"
+          },
+          "MARTINIQUE": {
+            "Enumeration Name": "Country",
+            "Country Name": "MARTINIQUE",
+            "DXCC Entity Code": "84"
+          },
+          "BONAIRE, CURACAO": {
+            "Enumeration Name": "Country",
+            "Country Name": "BONAIRE, CURACAO",
+            "DXCC Entity Code": "85",
+            "Import-only": "true"
+          },
+          "NICARAGUA": {
+            "Enumeration Name": "Country",
+            "Country Name": "NICARAGUA",
+            "DXCC Entity Code": "86"
+          },
+          "PANAMA": {
+            "Enumeration Name": "Country",
+            "Country Name": "PANAMA",
+            "DXCC Entity Code": "88"
+          },
+          "TURKS & CAICOS IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "TURKS & CAICOS IS.",
+            "DXCC Entity Code": "89"
+          },
+          "TRINIDAD & TOBAGO": {
+            "Enumeration Name": "Country",
+            "Country Name": "TRINIDAD & TOBAGO",
+            "DXCC Entity Code": "90"
+          },
+          "ARUBA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ARUBA",
+            "DXCC Entity Code": "91"
+          },
+          "GEYSER REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "GEYSER REEF",
+            "DXCC Entity Code": "93",
+            "Import-only": "true"
+          },
+          "ANTIGUA & BARBUDA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANTIGUA & BARBUDA",
+            "DXCC Entity Code": "94"
+          },
+          "DOMINICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "DOMINICA",
+            "DXCC Entity Code": "95"
+          },
+          "MONTSERRAT": {
+            "Enumeration Name": "Country",
+            "Country Name": "MONTSERRAT",
+            "DXCC Entity Code": "96"
+          },
+          "ST. LUCIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. LUCIA",
+            "DXCC Entity Code": "97"
+          },
+          "ST. VINCENT": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. VINCENT",
+            "DXCC Entity Code": "98"
+          },
+          "GLORIOSO IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "GLORIOSO IS.",
+            "DXCC Entity Code": "99"
+          },
+          "ARGENTINA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ARGENTINA",
+            "DXCC Entity Code": "100"
+          },
+          "GOA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GOA",
+            "DXCC Entity Code": "101",
+            "Import-only": "true"
+          },
+          "GOLD COAST, TOGOLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "GOLD COAST, TOGOLAND",
+            "DXCC Entity Code": "102",
+            "Import-only": "true"
+          },
+          "GUAM": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUAM",
+            "DXCC Entity Code": "103"
+          },
+          "BOLIVIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "BOLIVIA",
+            "DXCC Entity Code": "104"
+          },
+          "GUANTANAMO BAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUANTANAMO BAY",
+            "DXCC Entity Code": "105"
+          },
+          "GUERNSEY": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUERNSEY",
+            "DXCC Entity Code": "106"
+          },
+          "GUINEA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUINEA",
+            "DXCC Entity Code": "107"
+          },
+          "BRAZIL": {
+            "Enumeration Name": "Country",
+            "Country Name": "BRAZIL",
+            "DXCC Entity Code": "108"
+          },
+          "GUINEA-BISSAU": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUINEA-BISSAU",
+            "DXCC Entity Code": "109"
+          },
+          "HAWAII": {
+            "Enumeration Name": "Country",
+            "Country Name": "HAWAII",
+            "DXCC Entity Code": "110"
+          },
+          "HEARD I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "HEARD I.",
+            "DXCC Entity Code": "111"
+          },
+          "CHILE": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHILE",
+            "DXCC Entity Code": "112"
+          },
+          "IFNI": {
+            "Enumeration Name": "Country",
+            "Country Name": "IFNI",
+            "DXCC Entity Code": "113",
+            "Import-only": "true"
+          },
+          "ISLE OF MAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "ISLE OF MAN",
+            "DXCC Entity Code": "114"
+          },
+          "ITALIAN SOMALILAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "ITALIAN SOMALILAND",
+            "DXCC Entity Code": "115",
+            "Import-only": "true"
+          },
+          "COLOMBIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "COLOMBIA",
+            "DXCC Entity Code": "116"
+          },
+          "ITU HQ": {
+            "Enumeration Name": "Country",
+            "Country Name": "ITU HQ",
+            "DXCC Entity Code": "117"
+          },
+          "JAN MAYEN": {
+            "Enumeration Name": "Country",
+            "Country Name": "JAN MAYEN",
+            "DXCC Entity Code": "118"
+          },
+          "JAVA": {
+            "Enumeration Name": "Country",
+            "Country Name": "JAVA",
+            "DXCC Entity Code": "119",
+            "Import-only": "true"
+          },
+          "ECUADOR": {
+            "Enumeration Name": "Country",
+            "Country Name": "ECUADOR",
+            "DXCC Entity Code": "120"
+          },
+          "JERSEY": {
+            "Enumeration Name": "Country",
+            "Country Name": "JERSEY",
+            "DXCC Entity Code": "122"
+          },
+          "JOHNSTON I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "JOHNSTON I.",
+            "DXCC Entity Code": "123"
+          },
+          "JUAN DE NOVA, EUROPA": {
+            "Enumeration Name": "Country",
+            "Country Name": "JUAN DE NOVA, EUROPA",
+            "DXCC Entity Code": "124"
+          },
+          "JUAN FERNANDEZ IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "JUAN FERNANDEZ IS.",
+            "DXCC Entity Code": "125"
+          },
+          "KALININGRAD": {
+            "Enumeration Name": "Country",
+            "Country Name": "KALININGRAD",
+            "DXCC Entity Code": "126"
+          },
+          "KAMARAN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "KAMARAN IS.",
+            "DXCC Entity Code": "127",
+            "Import-only": "true"
+          },
+          "KARELO-FINNISH REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "KARELO-FINNISH REPUBLIC",
+            "DXCC Entity Code": "128",
+            "Import-only": "true"
+          },
+          "GUYANA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GUYANA",
+            "DXCC Entity Code": "129"
+          },
+          "KAZAKHSTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "KAZAKHSTAN",
+            "DXCC Entity Code": "130"
+          },
+          "KERGUELEN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "KERGUELEN IS.",
+            "DXCC Entity Code": "131"
+          },
+          "PARAGUAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "PARAGUAY",
+            "DXCC Entity Code": "132"
+          },
+          "KERMADEC IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "KERMADEC IS.",
+            "DXCC Entity Code": "133"
+          },
+          "KINGMAN REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "KINGMAN REEF",
+            "DXCC Entity Code": "134",
+            "Import-only": "true"
+          },
+          "KYRGYZSTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "KYRGYZSTAN",
+            "DXCC Entity Code": "135"
+          },
+          "PERU": {
+            "Enumeration Name": "Country",
+            "Country Name": "PERU",
+            "DXCC Entity Code": "136"
+          },
+          "REPUBLIC OF KOREA": {
+            "Enumeration Name": "Country",
+            "Country Name": "REPUBLIC OF KOREA",
+            "DXCC Entity Code": "137"
+          },
+          "KURE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "KURE I.",
+            "DXCC Entity Code": "138"
+          },
+          "KURIA MURIA I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "KURIA MURIA I.",
+            "DXCC Entity Code": "139",
+            "Import-only": "true"
+          },
+          "SURINAME": {
+            "Enumeration Name": "Country",
+            "Country Name": "SURINAME",
+            "DXCC Entity Code": "140"
+          },
+          "FALKLAND IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "FALKLAND IS.",
+            "DXCC Entity Code": "141"
+          },
+          "LAKSHADWEEP IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "LAKSHADWEEP IS.",
+            "DXCC Entity Code": "142"
+          },
+          "LAOS": {
+            "Enumeration Name": "Country",
+            "Country Name": "LAOS",
+            "DXCC Entity Code": "143"
+          },
+          "URUGUAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "URUGUAY",
+            "DXCC Entity Code": "144"
+          },
+          "LATVIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "LATVIA",
+            "DXCC Entity Code": "145"
+          },
+          "LITHUANIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "LITHUANIA",
+            "DXCC Entity Code": "146"
+          },
+          "LORD HOWE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "LORD HOWE I.",
+            "DXCC Entity Code": "147"
+          },
+          "VENEZUELA": {
+            "Enumeration Name": "Country",
+            "Country Name": "VENEZUELA",
+            "DXCC Entity Code": "148"
+          },
+          "AZORES": {
+            "Enumeration Name": "Country",
+            "Country Name": "AZORES",
+            "DXCC Entity Code": "149"
+          },
+          "AUSTRALIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "AUSTRALIA",
+            "DXCC Entity Code": "150"
+          },
+          "MALYJ VYSOTSKIJ I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALYJ VYSOTSKIJ I.",
+            "DXCC Entity Code": "151",
+            "Import-only": "true"
+          },
+          "MACAO": {
+            "Enumeration Name": "Country",
+            "Country Name": "MACAO",
+            "DXCC Entity Code": "152"
+          },
+          "MACQUARIE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MACQUARIE I.",
+            "DXCC Entity Code": "153"
+          },
+          "YEMEN ARAB REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "YEMEN ARAB REPUBLIC",
+            "DXCC Entity Code": "154",
+            "Import-only": "true"
+          },
+          "MALAYA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALAYA",
+            "DXCC Entity Code": "155",
+            "Import-only": "true"
+          },
+          "NAURU": {
+            "Enumeration Name": "Country",
+            "Country Name": "NAURU",
+            "DXCC Entity Code": "157"
+          },
+          "VANUATU": {
+            "Enumeration Name": "Country",
+            "Country Name": "VANUATU",
+            "DXCC Entity Code": "158"
+          },
+          "MALDIVES": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALDIVES",
+            "DXCC Entity Code": "159"
+          },
+          "TONGA": {
+            "Enumeration Name": "Country",
+            "Country Name": "TONGA",
+            "DXCC Entity Code": "160"
+          },
+          "MALPELO I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALPELO I.",
+            "DXCC Entity Code": "161"
+          },
+          "NEW CALEDONIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "NEW CALEDONIA",
+            "DXCC Entity Code": "162"
+          },
+          "PAPUA NEW GUINEA": {
+            "Enumeration Name": "Country",
+            "Country Name": "PAPUA NEW GUINEA",
+            "DXCC Entity Code": "163"
+          },
+          "MANCHURIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MANCHURIA",
+            "DXCC Entity Code": "164",
+            "Import-only": "true"
+          },
+          "MAURITIUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "MAURITIUS",
+            "DXCC Entity Code": "165"
+          },
+          "MARIANA IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MARIANA IS.",
+            "DXCC Entity Code": "166"
+          },
+          "MARKET REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "MARKET REEF",
+            "DXCC Entity Code": "167"
+          },
+          "MARSHALL IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MARSHALL IS.",
+            "DXCC Entity Code": "168"
+          },
+          "MAYOTTE": {
+            "Enumeration Name": "Country",
+            "Country Name": "MAYOTTE",
+            "DXCC Entity Code": "169"
+          },
+          "NEW ZEALAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "NEW ZEALAND",
+            "DXCC Entity Code": "170"
+          },
+          "MELLISH REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "MELLISH REEF",
+            "DXCC Entity Code": "171"
+          },
+          "PITCAIRN I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PITCAIRN I.",
+            "DXCC Entity Code": "172"
+          },
+          "MICRONESIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MICRONESIA",
+            "DXCC Entity Code": "173"
+          },
+          "MIDWAY I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MIDWAY I.",
+            "DXCC Entity Code": "174"
+          },
+          "FRENCH POLYNESIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRENCH POLYNESIA",
+            "DXCC Entity Code": "175"
+          },
+          "FIJI": {
+            "Enumeration Name": "Country",
+            "Country Name": "FIJI",
+            "DXCC Entity Code": "176"
+          },
+          "MINAMI TORISHIMA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MINAMI TORISHIMA",
+            "DXCC Entity Code": "177"
+          },
+          "MINERVA REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "MINERVA REEF",
+            "DXCC Entity Code": "178",
+            "Import-only": "true"
+          },
+          "MOLDOVA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MOLDOVA",
+            "DXCC Entity Code": "179"
+          },
+          "MOUNT ATHOS": {
+            "Enumeration Name": "Country",
+            "Country Name": "MOUNT ATHOS",
+            "DXCC Entity Code": "180"
+          },
+          "MOZAMBIQUE": {
+            "Enumeration Name": "Country",
+            "Country Name": "MOZAMBIQUE",
+            "DXCC Entity Code": "181"
+          },
+          "NAVASSA I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "NAVASSA I.",
+            "DXCC Entity Code": "182"
+          },
+          "NETHERLANDS BORNEO": {
+            "Enumeration Name": "Country",
+            "Country Name": "NETHERLANDS BORNEO",
+            "DXCC Entity Code": "183",
+            "Import-only": "true"
+          },
+          "NETHERLANDS NEW GUINEA": {
+            "Enumeration Name": "Country",
+            "Country Name": "NETHERLANDS NEW GUINEA",
+            "DXCC Entity Code": "184",
+            "Import-only": "true"
+          },
+          "SOLOMON IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOLOMON IS.",
+            "DXCC Entity Code": "185"
+          },
+          "NEWFOUNDLAND, LABRADOR": {
+            "Enumeration Name": "Country",
+            "Country Name": "NEWFOUNDLAND, LABRADOR",
+            "DXCC Entity Code": "186",
+            "Import-only": "true"
+          },
+          "NIGER": {
+            "Enumeration Name": "Country",
+            "Country Name": "NIGER",
+            "DXCC Entity Code": "187"
+          },
+          "NIUE": {
+            "Enumeration Name": "Country",
+            "Country Name": "NIUE",
+            "DXCC Entity Code": "188"
+          },
+          "NORFOLK I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "NORFOLK I.",
+            "DXCC Entity Code": "189"
+          },
+          "SAMOA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAMOA",
+            "DXCC Entity Code": "190"
+          },
+          "NORTH COOK IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "NORTH COOK IS.",
+            "DXCC Entity Code": "191"
+          },
+          "OGASAWARA": {
+            "Enumeration Name": "Country",
+            "Country Name": "OGASAWARA",
+            "DXCC Entity Code": "192"
+          },
+          "OKINAWA (RYUKYU IS.)": {
+            "Enumeration Name": "Country",
+            "Country Name": "OKINAWA (RYUKYU IS.)",
+            "DXCC Entity Code": "193",
+            "Import-only": "true"
+          },
+          "OKINO TORI-SHIMA": {
+            "Enumeration Name": "Country",
+            "Country Name": "OKINO TORI-SHIMA",
+            "DXCC Entity Code": "194",
+            "Import-only": "true"
+          },
+          "ANNOBON I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANNOBON I.",
+            "DXCC Entity Code": "195"
+          },
+          "PALESTINE": {
+            "Enumeration Name": "Country",
+            "Country Name": "PALESTINE",
+            "DXCC Entity Code": "510"
+          },
+          "PALMYRA & JARVIS IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PALMYRA & JARVIS IS.",
+            "DXCC Entity Code": "197"
+          },
+          "PAPUA TERRITORY": {
+            "Enumeration Name": "Country",
+            "Country Name": "PAPUA TERRITORY",
+            "DXCC Entity Code": "198",
+            "Import-only": "true"
+          },
+          "PETER 1 I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PETER 1 I.",
+            "DXCC Entity Code": "199"
+          },
+          "PORTUGUESE TIMOR": {
+            "Enumeration Name": "Country",
+            "Country Name": "PORTUGUESE TIMOR",
+            "DXCC Entity Code": "200",
+            "Import-only": "true"
+          },
+          "PRINCE EDWARD & MARION IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PRINCE EDWARD & MARION IS.",
+            "DXCC Entity Code": "201"
+          },
+          "PUERTO RICO": {
+            "Enumeration Name": "Country",
+            "Country Name": "PUERTO RICO",
+            "DXCC Entity Code": "202"
+          },
+          "ANDORRA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANDORRA",
+            "DXCC Entity Code": "203"
+          },
+          "REVILLAGIGEDO": {
+            "Enumeration Name": "Country",
+            "Country Name": "REVILLAGIGEDO",
+            "DXCC Entity Code": "204"
+          },
+          "ASCENSION I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ASCENSION I.",
+            "DXCC Entity Code": "205"
+          },
+          "AUSTRIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "AUSTRIA",
+            "DXCC Entity Code": "206"
+          },
+          "RODRIGUES I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "RODRIGUES I.",
+            "DXCC Entity Code": "207"
+          },
+          "RUANDA-URUNDI": {
+            "Enumeration Name": "Country",
+            "Country Name": "RUANDA-URUNDI",
+            "DXCC Entity Code": "208",
+            "Import-only": "true"
+          },
+          "BELGIUM": {
+            "Enumeration Name": "Country",
+            "Country Name": "BELGIUM",
+            "DXCC Entity Code": "209"
+          },
+          "SAAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAAR",
+            "DXCC Entity Code": "210",
+            "Import-only": "true"
+          },
+          "SABLE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SABLE I.",
+            "DXCC Entity Code": "211"
+          },
+          "BULGARIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "BULGARIA",
+            "DXCC Entity Code": "212"
+          },
+          "SAINT MARTIN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAINT MARTIN",
+            "DXCC Entity Code": "213"
+          },
+          "CORSICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CORSICA",
+            "DXCC Entity Code": "214"
+          },
+          "CYPRUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "CYPRUS",
+            "DXCC Entity Code": "215"
+          },
+          "SAN ANDRES & PROVIDENCIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAN ANDRES & PROVIDENCIA",
+            "DXCC Entity Code": "216"
+          },
+          "SAN FELIX & SAN AMBROSIO": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAN FELIX & SAN AMBROSIO",
+            "DXCC Entity Code": "217"
+          },
+          "CZECHOSLOVAKIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CZECHOSLOVAKIA",
+            "DXCC Entity Code": "218",
+            "Import-only": "true"
+          },
+          "SAO TOME & PRINCIPE": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAO TOME & PRINCIPE",
+            "DXCC Entity Code": "219"
+          },
+          "SARAWAK": {
+            "Enumeration Name": "Country",
+            "Country Name": "SARAWAK",
+            "DXCC Entity Code": "220",
+            "Import-only": "true"
+          },
+          "DENMARK": {
+            "Enumeration Name": "Country",
+            "Country Name": "DENMARK",
+            "DXCC Entity Code": "221"
+          },
+          "FAROE IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "FAROE IS.",
+            "DXCC Entity Code": "222"
+          },
+          "ENGLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "ENGLAND",
+            "DXCC Entity Code": "223"
+          },
+          "FINLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "FINLAND",
+            "DXCC Entity Code": "224"
+          },
+          "SARDINIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SARDINIA",
+            "DXCC Entity Code": "225"
+          },
+          "SAUDI ARABIA/IRAQ NEUTRAL ZONE": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAUDI ARABIA/IRAQ NEUTRAL ZONE",
+            "DXCC Entity Code": "226",
+            "Import-only": "true"
+          },
+          "FRANCE": {
+            "Enumeration Name": "Country",
+            "Country Name": "FRANCE",
+            "DXCC Entity Code": "227"
+          },
+          "SERRANA BANK & RONCADOR CAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "SERRANA BANK & RONCADOR CAY",
+            "DXCC Entity Code": "228",
+            "Import-only": "true"
+          },
+          "GERMAN DEMOCRATIC REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "GERMAN DEMOCRATIC REPUBLIC",
+            "DXCC Entity Code": "229",
+            "Import-only": "true"
+          },
+          "FEDERAL REPUBLIC OF GERMANY": {
+            "Enumeration Name": "Country",
+            "Country Name": "FEDERAL REPUBLIC OF GERMANY",
+            "DXCC Entity Code": "230"
+          },
+          "SIKKIM": {
+            "Enumeration Name": "Country",
+            "Country Name": "SIKKIM",
+            "DXCC Entity Code": "231",
+            "Import-only": "true"
+          },
+          "SOMALIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOMALIA",
+            "DXCC Entity Code": "232"
+          },
+          "GIBRALTAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "GIBRALTAR",
+            "DXCC Entity Code": "233"
+          },
+          "SOUTH COOK IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH COOK IS.",
+            "DXCC Entity Code": "234"
+          },
+          "SOUTH GEORGIA I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH GEORGIA I.",
+            "DXCC Entity Code": "235"
+          },
+          "GREECE": {
+            "Enumeration Name": "Country",
+            "Country Name": "GREECE",
+            "DXCC Entity Code": "236"
+          },
+          "GREENLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "GREENLAND",
+            "DXCC Entity Code": "237"
+          },
+          "SOUTH ORKNEY IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH ORKNEY IS.",
+            "DXCC Entity Code": "238"
+          },
+          "HUNGARY": {
+            "Enumeration Name": "Country",
+            "Country Name": "HUNGARY",
+            "DXCC Entity Code": "239"
+          },
+          "SOUTH SANDWICH IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH SANDWICH IS.",
+            "DXCC Entity Code": "240"
+          },
+          "SOUTH SHETLAND IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH SHETLAND IS.",
+            "DXCC Entity Code": "241"
+          },
+          "ICELAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "ICELAND",
+            "DXCC Entity Code": "242"
+          },
+          "PEOPLE'S DEMOCRATIC REP. OF YEMEN": {
+            "Enumeration Name": "Country",
+            "Country Name": "PEOPLE'S DEMOCRATIC REP. OF YEMEN",
+            "DXCC Entity Code": "243",
+            "Import-only": "true"
+          },
+          "SOUTHERN SUDAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTHERN SUDAN",
+            "DXCC Entity Code": "244",
+            "Import-only": "true"
+          },
+          "IRELAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "IRELAND",
+            "DXCC Entity Code": "245"
+          },
+          "SOVEREIGN MILITARY ORDER OF MALTA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOVEREIGN MILITARY ORDER OF MALTA",
+            "DXCC Entity Code": "246"
+          },
+          "SPRATLY IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SPRATLY IS.",
+            "DXCC Entity Code": "247"
+          },
+          "ITALY": {
+            "Enumeration Name": "Country",
+            "Country Name": "ITALY",
+            "DXCC Entity Code": "248"
+          },
+          "ST. KITTS & NEVIS": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. KITTS & NEVIS",
+            "DXCC Entity Code": "249"
+          },
+          "ST. HELENA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. HELENA",
+            "DXCC Entity Code": "250"
+          },
+          "LIECHTENSTEIN": {
+            "Enumeration Name": "Country",
+            "Country Name": "LIECHTENSTEIN",
+            "DXCC Entity Code": "251"
+          },
+          "ST. PAUL I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. PAUL I.",
+            "DXCC Entity Code": "252"
+          },
+          "ST. PETER & ST. PAUL ROCKS": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. PETER & ST. PAUL ROCKS",
+            "DXCC Entity Code": "253"
+          },
+          "LUXEMBOURG": {
+            "Enumeration Name": "Country",
+            "Country Name": "LUXEMBOURG",
+            "DXCC Entity Code": "254"
+          },
+          "ST. MAARTEN, SABA, ST. EUSTATIUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. MAARTEN, SABA, ST. EUSTATIUS",
+            "DXCC Entity Code": "255",
+            "Import-only": "true"
+          },
+          "MADEIRA IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MADEIRA IS.",
+            "DXCC Entity Code": "256"
+          },
+          "MALTA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALTA",
+            "DXCC Entity Code": "257"
+          },
+          "SUMATRA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SUMATRA",
+            "DXCC Entity Code": "258",
+            "Import-only": "true"
+          },
+          "SVALBARD": {
+            "Enumeration Name": "Country",
+            "Country Name": "SVALBARD",
+            "DXCC Entity Code": "259"
+          },
+          "MONACO": {
+            "Enumeration Name": "Country",
+            "Country Name": "MONACO",
+            "DXCC Entity Code": "260"
+          },
+          "SWAN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SWAN IS.",
+            "DXCC Entity Code": "261",
+            "Import-only": "true"
+          },
+          "TAJIKISTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "TAJIKISTAN",
+            "DXCC Entity Code": "262"
+          },
+          "NETHERLANDS": {
+            "Enumeration Name": "Country",
+            "Country Name": "NETHERLANDS",
+            "DXCC Entity Code": "263"
+          },
+          "TANGIER": {
+            "Enumeration Name": "Country",
+            "Country Name": "TANGIER",
+            "DXCC Entity Code": "264",
+            "Import-only": "true"
+          },
+          "NORTHERN IRELAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "NORTHERN IRELAND",
+            "DXCC Entity Code": "265"
+          },
+          "NORWAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "NORWAY",
+            "DXCC Entity Code": "266"
+          },
+          "TERRITORY OF NEW GUINEA": {
+            "Enumeration Name": "Country",
+            "Country Name": "TERRITORY OF NEW GUINEA",
+            "DXCC Entity Code": "267",
+            "Import-only": "true"
+          },
+          "TIBET": {
+            "Enumeration Name": "Country",
+            "Country Name": "TIBET",
+            "DXCC Entity Code": "268",
+            "Import-only": "true"
+          },
+          "POLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "POLAND",
+            "DXCC Entity Code": "269"
+          },
+          "TOKELAU IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "TOKELAU IS.",
+            "DXCC Entity Code": "270"
+          },
+          "TRIESTE": {
+            "Enumeration Name": "Country",
+            "Country Name": "TRIESTE",
+            "DXCC Entity Code": "271",
+            "Import-only": "true"
+          },
+          "PORTUGAL": {
+            "Enumeration Name": "Country",
+            "Country Name": "PORTUGAL",
+            "DXCC Entity Code": "272"
+          },
+          "TRINDADE & MARTIM VAZ IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "TRINDADE & MARTIM VAZ IS.",
+            "DXCC Entity Code": "273"
+          },
+          "TRISTAN DA CUNHA & GOUGH I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "TRISTAN DA CUNHA & GOUGH I.",
+            "DXCC Entity Code": "274"
+          },
+          "ROMANIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ROMANIA",
+            "DXCC Entity Code": "275"
+          },
+          "TROMELIN I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "TROMELIN I.",
+            "DXCC Entity Code": "276"
+          },
+          "ST. PIERRE & MIQUELON": {
+            "Enumeration Name": "Country",
+            "Country Name": "ST. PIERRE & MIQUELON",
+            "DXCC Entity Code": "277"
+          },
+          "SAN MARINO": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAN MARINO",
+            "DXCC Entity Code": "278"
+          },
+          "SCOTLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "SCOTLAND",
+            "DXCC Entity Code": "279"
+          },
+          "TURKMENISTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "TURKMENISTAN",
+            "DXCC Entity Code": "280"
+          },
+          "SPAIN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SPAIN",
+            "DXCC Entity Code": "281"
+          },
+          "TUVALU": {
+            "Enumeration Name": "Country",
+            "Country Name": "TUVALU",
+            "DXCC Entity Code": "282"
+          },
+          "UK SOVEREIGN BASE AREAS ON CYPRUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "UK SOVEREIGN BASE AREAS ON CYPRUS",
+            "DXCC Entity Code": "283"
+          },
+          "SWEDEN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SWEDEN",
+            "DXCC Entity Code": "284"
+          },
+          "VIRGIN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "VIRGIN IS.",
+            "DXCC Entity Code": "285"
+          },
+          "UGANDA": {
+            "Enumeration Name": "Country",
+            "Country Name": "UGANDA",
+            "DXCC Entity Code": "286"
+          },
+          "SWITZERLAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "SWITZERLAND",
+            "DXCC Entity Code": "287"
+          },
+          "UKRAINE": {
+            "Enumeration Name": "Country",
+            "Country Name": "UKRAINE",
+            "DXCC Entity Code": "288"
+          },
+          "UNITED NATIONS HQ": {
+            "Enumeration Name": "Country",
+            "Country Name": "UNITED NATIONS HQ",
+            "DXCC Entity Code": "289"
+          },
+          "UNITED STATES OF AMERICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "UNITED STATES OF AMERICA",
+            "DXCC Entity Code": "291"
+          },
+          "UZBEKISTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "UZBEKISTAN",
+            "DXCC Entity Code": "292"
+          },
+          "VIET NAM": {
+            "Enumeration Name": "Country",
+            "Country Name": "VIET NAM",
+            "DXCC Entity Code": "293"
+          },
+          "WALES": {
+            "Enumeration Name": "Country",
+            "Country Name": "WALES",
+            "DXCC Entity Code": "294"
+          },
+          "VATICAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "VATICAN",
+            "DXCC Entity Code": "295"
+          },
+          "SERBIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SERBIA",
+            "DXCC Entity Code": "296"
+          },
+          "WAKE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "WAKE I.",
+            "DXCC Entity Code": "297"
+          },
+          "WALLIS & FUTUNA IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "WALLIS & FUTUNA IS.",
+            "DXCC Entity Code": "298"
+          },
+          "WEST MALAYSIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "WEST MALAYSIA",
+            "DXCC Entity Code": "299"
+          },
+          "W. KIRIBATI (GILBERT IS. )": {
+            "Enumeration Name": "Country",
+            "Country Name": "W. KIRIBATI (GILBERT IS. )",
+            "DXCC Entity Code": "301"
+          },
+          "WESTERN SAHARA": {
+            "Enumeration Name": "Country",
+            "Country Name": "WESTERN SAHARA",
+            "DXCC Entity Code": "302"
+          },
+          "WILLIS I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "WILLIS I.",
+            "DXCC Entity Code": "303"
+          },
+          "BAHRAIN": {
+            "Enumeration Name": "Country",
+            "Country Name": "BAHRAIN",
+            "DXCC Entity Code": "304"
+          },
+          "BANGLADESH": {
+            "Enumeration Name": "Country",
+            "Country Name": "BANGLADESH",
+            "DXCC Entity Code": "305"
+          },
+          "BHUTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "BHUTAN",
+            "DXCC Entity Code": "306"
+          },
+          "ZANZIBAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "ZANZIBAR",
+            "DXCC Entity Code": "307",
+            "Import-only": "true"
+          },
+          "COSTA RICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "COSTA RICA",
+            "DXCC Entity Code": "308"
+          },
+          "MYANMAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "MYANMAR",
+            "DXCC Entity Code": "309"
+          },
+          "CAMBODIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CAMBODIA",
+            "DXCC Entity Code": "312"
+          },
+          "SRI LANKA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SRI LANKA",
+            "DXCC Entity Code": "315"
+          },
+          "CHINA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHINA",
+            "DXCC Entity Code": "318"
+          },
+          "HONG KONG": {
+            "Enumeration Name": "Country",
+            "Country Name": "HONG KONG",
+            "DXCC Entity Code": "321"
+          },
+          "INDIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "INDIA",
+            "DXCC Entity Code": "324"
+          },
+          "INDONESIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "INDONESIA",
+            "DXCC Entity Code": "327"
+          },
+          "IRAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "IRAN",
+            "DXCC Entity Code": "330"
+          },
+          "IRAQ": {
+            "Enumeration Name": "Country",
+            "Country Name": "IRAQ",
+            "DXCC Entity Code": "333"
+          },
+          "ISRAEL": {
+            "Enumeration Name": "Country",
+            "Country Name": "ISRAEL",
+            "DXCC Entity Code": "336"
+          },
+          "JAPAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "JAPAN",
+            "DXCC Entity Code": "339"
+          },
+          "JORDAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "JORDAN",
+            "DXCC Entity Code": "342"
+          },
+          "DEMOCRATIC PEOPLE'S REP. OF KOREA": {
+            "Enumeration Name": "Country",
+            "Country Name": "DEMOCRATIC PEOPLE'S REP. OF KOREA",
+            "DXCC Entity Code": "344"
+          },
+          "BRUNEI DARUSSALAM": {
+            "Enumeration Name": "Country",
+            "Country Name": "BRUNEI DARUSSALAM",
+            "DXCC Entity Code": "345"
+          },
+          "KUWAIT": {
+            "Enumeration Name": "Country",
+            "Country Name": "KUWAIT",
+            "DXCC Entity Code": "348"
+          },
+          "LEBANON": {
+            "Enumeration Name": "Country",
+            "Country Name": "LEBANON",
+            "DXCC Entity Code": "354"
+          },
+          "MONGOLIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MONGOLIA",
+            "DXCC Entity Code": "363"
+          },
+          "NEPAL": {
+            "Enumeration Name": "Country",
+            "Country Name": "NEPAL",
+            "DXCC Entity Code": "369"
+          },
+          "OMAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "OMAN",
+            "DXCC Entity Code": "370"
+          },
+          "PAKISTAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "PAKISTAN",
+            "DXCC Entity Code": "372"
+          },
+          "PHILIPPINES": {
+            "Enumeration Name": "Country",
+            "Country Name": "PHILIPPINES",
+            "DXCC Entity Code": "375"
+          },
+          "QATAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "QATAR",
+            "DXCC Entity Code": "376"
+          },
+          "SAUDI ARABIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAUDI ARABIA",
+            "DXCC Entity Code": "378"
+          },
+          "SEYCHELLES": {
+            "Enumeration Name": "Country",
+            "Country Name": "SEYCHELLES",
+            "DXCC Entity Code": "379"
+          },
+          "SINGAPORE": {
+            "Enumeration Name": "Country",
+            "Country Name": "SINGAPORE",
+            "DXCC Entity Code": "381"
+          },
+          "DJIBOUTI": {
+            "Enumeration Name": "Country",
+            "Country Name": "DJIBOUTI",
+            "DXCC Entity Code": "382"
+          },
+          "SYRIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SYRIA",
+            "DXCC Entity Code": "384"
+          },
+          "TAIWAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "TAIWAN",
+            "DXCC Entity Code": "386"
+          },
+          "THAILAND": {
+            "Enumeration Name": "Country",
+            "Country Name": "THAILAND",
+            "DXCC Entity Code": "387"
+          },
+          "TURKEY": {
+            "Enumeration Name": "Country",
+            "Country Name": "TURKEY",
+            "DXCC Entity Code": "390"
+          },
+          "UNITED ARAB EMIRATES": {
+            "Enumeration Name": "Country",
+            "Country Name": "UNITED ARAB EMIRATES",
+            "DXCC Entity Code": "391"
+          },
+          "ALGERIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ALGERIA",
+            "DXCC Entity Code": "400"
+          },
+          "ANGOLA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ANGOLA",
+            "DXCC Entity Code": "401"
+          },
+          "BOTSWANA": {
+            "Enumeration Name": "Country",
+            "Country Name": "BOTSWANA",
+            "DXCC Entity Code": "402"
+          },
+          "BURUNDI": {
+            "Enumeration Name": "Country",
+            "Country Name": "BURUNDI",
+            "DXCC Entity Code": "404"
+          },
+          "CAMEROON": {
+            "Enumeration Name": "Country",
+            "Country Name": "CAMEROON",
+            "DXCC Entity Code": "406"
+          },
+          "CENTRAL AFRICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CENTRAL AFRICA",
+            "DXCC Entity Code": "408"
+          },
+          "CAPE VERDE": {
+            "Enumeration Name": "Country",
+            "Country Name": "CAPE VERDE",
+            "DXCC Entity Code": "409"
+          },
+          "CHAD": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHAD",
+            "DXCC Entity Code": "410"
+          },
+          "REPUBLIC OF THE CONGO": {
+            "Enumeration Name": "Country",
+            "Country Name": "REPUBLIC OF THE CONGO",
+            "DXCC Entity Code": "412"
+          },
+          "DEMOCRATIC REPUBLIC OF THE CONGO": {
+            "Enumeration Name": "Country",
+            "Country Name": "DEMOCRATIC REPUBLIC OF THE CONGO",
+            "DXCC Entity Code": "414"
+          },
+          "BENIN": {
+            "Enumeration Name": "Country",
+            "Country Name": "BENIN",
+            "DXCC Entity Code": "416"
+          },
+          "GABON": {
+            "Enumeration Name": "Country",
+            "Country Name": "GABON",
+            "DXCC Entity Code": "420"
+          },
+          "THE GAMBIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "THE GAMBIA",
+            "DXCC Entity Code": "422"
+          },
+          "GHANA": {
+            "Enumeration Name": "Country",
+            "Country Name": "GHANA",
+            "DXCC Entity Code": "424"
+          },
+          "COTE D'IVOIRE": {
+            "Enumeration Name": "Country",
+            "Country Name": "COTE D'IVOIRE",
+            "DXCC Entity Code": "428"
+          },
+          "KENYA": {
+            "Enumeration Name": "Country",
+            "Country Name": "KENYA",
+            "DXCC Entity Code": "430"
+          },
+          "LESOTHO": {
+            "Enumeration Name": "Country",
+            "Country Name": "LESOTHO",
+            "DXCC Entity Code": "432"
+          },
+          "LIBERIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "LIBERIA",
+            "DXCC Entity Code": "434"
+          },
+          "LIBYA": {
+            "Enumeration Name": "Country",
+            "Country Name": "LIBYA",
+            "DXCC Entity Code": "436"
+          },
+          "MADAGASCAR": {
+            "Enumeration Name": "Country",
+            "Country Name": "MADAGASCAR",
+            "DXCC Entity Code": "438"
+          },
+          "MALAWI": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALAWI",
+            "DXCC Entity Code": "440"
+          },
+          "MALI": {
+            "Enumeration Name": "Country",
+            "Country Name": "MALI",
+            "DXCC Entity Code": "442"
+          },
+          "MAURITANIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "MAURITANIA",
+            "DXCC Entity Code": "444"
+          },
+          "MOROCCO": {
+            "Enumeration Name": "Country",
+            "Country Name": "MOROCCO",
+            "DXCC Entity Code": "446"
+          },
+          "NIGERIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "NIGERIA",
+            "DXCC Entity Code": "450"
+          },
+          "ZIMBABWE": {
+            "Enumeration Name": "Country",
+            "Country Name": "ZIMBABWE",
+            "DXCC Entity Code": "452"
+          },
+          "REUNION I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "REUNION I.",
+            "DXCC Entity Code": "453"
+          },
+          "RWANDA": {
+            "Enumeration Name": "Country",
+            "Country Name": "RWANDA",
+            "DXCC Entity Code": "454"
+          },
+          "SENEGAL": {
+            "Enumeration Name": "Country",
+            "Country Name": "SENEGAL",
+            "DXCC Entity Code": "456"
+          },
+          "SIERRA LEONE": {
+            "Enumeration Name": "Country",
+            "Country Name": "SIERRA LEONE",
+            "DXCC Entity Code": "458"
+          },
+          "ROTUMA I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "ROTUMA I.",
+            "DXCC Entity Code": "460"
+          },
+          "REPUBLIC OF SOUTH AFRICA": {
+            "Enumeration Name": "Country",
+            "Country Name": "REPUBLIC OF SOUTH AFRICA",
+            "DXCC Entity Code": "462"
+          },
+          "NAMIBIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "NAMIBIA",
+            "DXCC Entity Code": "464"
+          },
+          "SUDAN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SUDAN",
+            "DXCC Entity Code": "466"
+          },
+          "KINGDOM OF ESWATINI": {
+            "Enumeration Name": "Country",
+            "Country Name": "KINGDOM OF ESWATINI",
+            "DXCC Entity Code": "468"
+          },
+          "TANZANIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "TANZANIA",
+            "DXCC Entity Code": "470"
+          },
+          "TUNISIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "TUNISIA",
+            "DXCC Entity Code": "474"
+          },
+          "EGYPT": {
+            "Enumeration Name": "Country",
+            "Country Name": "EGYPT",
+            "DXCC Entity Code": "478"
+          },
+          "BURKINA FASO": {
+            "Enumeration Name": "Country",
+            "Country Name": "BURKINA FASO",
+            "DXCC Entity Code": "480"
+          },
+          "ZAMBIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "ZAMBIA",
+            "DXCC Entity Code": "482"
+          },
+          "TOGO": {
+            "Enumeration Name": "Country",
+            "Country Name": "TOGO",
+            "DXCC Entity Code": "483"
+          },
+          "WALVIS BAY": {
+            "Enumeration Name": "Country",
+            "Country Name": "WALVIS BAY",
+            "DXCC Entity Code": "488",
+            "Import-only": "true"
+          },
+          "CONWAY REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "CONWAY REEF",
+            "DXCC Entity Code": "489"
+          },
+          "BANABA I. (OCEAN I.)": {
+            "Enumeration Name": "Country",
+            "Country Name": "BANABA I. (OCEAN I.)",
+            "DXCC Entity Code": "490"
+          },
+          "YEMEN": {
+            "Enumeration Name": "Country",
+            "Country Name": "YEMEN",
+            "DXCC Entity Code": "492"
+          },
+          "PENGUIN IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PENGUIN IS.",
+            "DXCC Entity Code": "493",
+            "Import-only": "true"
+          },
+          "CROATIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "CROATIA",
+            "DXCC Entity Code": "497"
+          },
+          "SLOVENIA": {
+            "Enumeration Name": "Country",
+            "Country Name": "SLOVENIA",
+            "DXCC Entity Code": "499"
+          },
+          "BOSNIA-HERZEGOVINA": {
+            "Enumeration Name": "Country",
+            "Country Name": "BOSNIA-HERZEGOVINA",
+            "DXCC Entity Code": "501"
+          },
+          "NORTH MACEDONIA (REPUBLIC OF)": {
+            "Enumeration Name": "Country",
+            "Country Name": "NORTH MACEDONIA (REPUBLIC OF)",
+            "DXCC Entity Code": "502"
+          },
+          "CZECH REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "CZECH REPUBLIC",
+            "DXCC Entity Code": "503"
+          },
+          "SLOVAK REPUBLIC": {
+            "Enumeration Name": "Country",
+            "Country Name": "SLOVAK REPUBLIC",
+            "DXCC Entity Code": "504"
+          },
+          "PRATAS I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "PRATAS I.",
+            "DXCC Entity Code": "505"
+          },
+          "SCARBOROUGH REEF": {
+            "Enumeration Name": "Country",
+            "Country Name": "SCARBOROUGH REEF",
+            "DXCC Entity Code": "506"
+          },
+          "TEMOTU PROVINCE": {
+            "Enumeration Name": "Country",
+            "Country Name": "TEMOTU PROVINCE",
+            "DXCC Entity Code": "507"
+          },
+          "AUSTRAL I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "AUSTRAL I.",
+            "DXCC Entity Code": "508"
+          },
+          "MARQUESAS IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "MARQUESAS IS.",
+            "DXCC Entity Code": "509"
+          },
+          "TIMOR-LESTE": {
+            "Enumeration Name": "Country",
+            "Country Name": "TIMOR-LESTE",
+            "DXCC Entity Code": "511"
+          },
+          "CHESTERFIELD IS.": {
+            "Enumeration Name": "Country",
+            "Country Name": "CHESTERFIELD IS.",
+            "DXCC Entity Code": "512"
+          },
+          "DUCIE I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "DUCIE I.",
+            "DXCC Entity Code": "513"
+          },
+          "MONTENEGRO": {
+            "Enumeration Name": "Country",
+            "Country Name": "MONTENEGRO",
+            "DXCC Entity Code": "514"
+          },
+          "SWAINS I.": {
+            "Enumeration Name": "Country",
+            "Country Name": "SWAINS I.",
+            "DXCC Entity Code": "515"
+          },
+          "SAINT BARTHELEMY": {
+            "Enumeration Name": "Country",
+            "Country Name": "SAINT BARTHELEMY",
+            "DXCC Entity Code": "516"
+          },
+          "CURACAO": {
+            "Enumeration Name": "Country",
+            "Country Name": "CURACAO",
+            "DXCC Entity Code": "517"
+          },
+          "SINT MAARTEN": {
+            "Enumeration Name": "Country",
+            "Country Name": "SINT MAARTEN",
+            "DXCC Entity Code": "518"
+          },
+          "SABA & ST. EUSTATIUS": {
+            "Enumeration Name": "Country",
+            "Country Name": "SABA & ST. EUSTATIUS",
+            "DXCC Entity Code": "519"
+          },
+          "BONAIRE": {
+            "Enumeration Name": "Country",
+            "Country Name": "BONAIRE",
+            "DXCC Entity Code": "520"
+          },
+          "SOUTH SUDAN (REPUBLIC OF)": {
+            "Enumeration Name": "Country",
+            "Country Name": "SOUTH SUDAN (REPUBLIC OF)",
+            "DXCC Entity Code": "521"
+          },
+          "REPUBLIC OF KOSOVO": {
+            "Enumeration Name": "Country",
+            "Country Name": "REPUBLIC OF KOSOVO",
+            "DXCC Entity Code": "522"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_credit.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_credit.json
@@ -1,0 +1,522 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:37Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Credit": {
+        "Header": [
+          "Enumeration Name",
+          "Credit For",
+          "Sponsor",
+          "Award",
+          "Facet",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CQDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mixed"
+          },
+          "CQDX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Band"
+          },
+          "CQDX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mode"
+          },
+          "CQDX_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Mobile"
+          },
+          "CQDX_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "QRP"
+          },
+          "CQDX_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDX_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX",
+            "Facet": "Satellite"
+          },
+          "CQDXFIELD": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mixed"
+          },
+          "CQDXFIELD_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Band"
+          },
+          "CQDXFIELD_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mode"
+          },
+          "CQDXFIELD_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Mobile"
+          },
+          "CQDXFIELD_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "QRP"
+          },
+          "CQDXFIELD_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQDXFIELD_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "DX Field",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_MIXED": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MIXED",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mixed"
+          },
+          "CQWAZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Band"
+          },
+          "CQWAZ_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mode"
+          },
+          "CQWAZ_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_SATELLITE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Satellite"
+          },
+          "CQWAZ_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_EME",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "EME"
+          },
+          "CQWAZ_MOBILE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_MOBILE",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "Mobile"
+          },
+          "CQWAZ_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWAZ_QRP",
+            "Sponsor": "CQ Magazine",
+            "Award": "Worked All Zones (WAZ)",
+            "Facet": "QRP"
+          },
+          "CQWPX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mixed"
+          },
+          "CQWPX_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_BAND",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Band"
+          },
+          "CQWPX_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "CQWPX_MODE",
+            "Sponsor": "CQ Magazine",
+            "Award": "WPX",
+            "Facet": "Mode"
+          },
+          "DXCC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mixed"
+          },
+          "DXCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Band"
+          },
+          "DXCC_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_MODE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Mode"
+          },
+          "DXCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "DXCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "DX Century Club (DXCC)",
+            "Facet": "Satellite"
+          },
+          "EAUSTRALIA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EAUSTRALIA",
+            "Sponsor": "eQSL",
+            "Award": "eAustralia",
+            "Facet": "Mixed"
+          },
+          "ECANADA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECANADA",
+            "Sponsor": "eQSL",
+            "Award": "eCanada",
+            "Facet": "Mixed"
+          },
+          "ECOUNTY_STATE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "ECOUNTY_STATE",
+            "Sponsor": "eQSL",
+            "Award": "eCounty",
+            "Facet": "State"
+          },
+          "EDX": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX",
+            "Sponsor": "eQSL",
+            "Award": "eDX",
+            "Facet": "Mixed"
+          },
+          "EDX100": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mixed"
+          },
+          "EDX100_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Band"
+          },
+          "EDX100_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EDX100_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eDX100",
+            "Facet": "Mode"
+          },
+          "EECHOLINK50": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EECHOLINK50",
+            "Sponsor": "eQSL",
+            "Award": "eEcholink50",
+            "Facet": "Echolink"
+          },
+          "EGRID_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Band"
+          },
+          "EGRID_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EGRID_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eGrid",
+            "Facet": "Satellite"
+          },
+          "EPFX300": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mixed"
+          },
+          "EPFX300_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EPFX300_MODE",
+            "Sponsor": "eQSL",
+            "Award": "ePfx300",
+            "Facet": "Mode"
+          },
+          "EWAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mixed"
+          },
+          "EWAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_BAND",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Band"
+          },
+          "EWAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Mode"
+          },
+          "EWAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EWAS_SATELLITE",
+            "Sponsor": "eQSL",
+            "Award": "eWAS",
+            "Facet": "Satellite"
+          },
+          "EZ40": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mixed"
+          },
+          "EZ40_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "EZ40_MODE",
+            "Sponsor": "eQSL",
+            "Award": "eZ40",
+            "Facet": "Mode"
+          },
+          "FFMA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "FFMA",
+            "Sponsor": "ARRL",
+            "Award": "Fred Fish Memorial Award (FFMA)",
+            "Facet": "Mixed"
+          },
+          "IOTA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_BASIC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_BASIC",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Mixed"
+          },
+          "IOTA_CONT": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_CONT",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Continent"
+          },
+          "IOTA_GROUP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "IOTA_GROUP",
+            "Sponsor": "RSGB",
+            "Award": "Islands on the Air (IOTA)",
+            "Facet": "Group"
+          },
+          "RDA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "RDA",
+            "Sponsor": "TAG",
+            "Award": "Russian Districts Award (RDA)",
+            "Facet": "Mixed"
+          },
+          "USACA": {
+            "Enumeration Name": "Credit",
+            "Credit For": "USACA",
+            "Sponsor": "CQ Magazine",
+            "Award": "United States of America Counties (USA-CA)",
+            "Facet": "Mixed"
+          },
+          "VUCC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_BAND",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Band"
+          },
+          "VUCC_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "VUCC_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "VHF/UHF Century Club Program (VUCC)",
+            "Facet": "Satellite"
+          },
+          "WAB": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAB",
+            "Sponsor": "WAB AG",
+            "Award": "Worked All Britain (WAB)",
+            "Facet": "Mixed"
+          },
+          "WAC": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Mixed"
+          },
+          "WAC_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAC_BAND",
+            "Sponsor": "IARU",
+            "Award": "Worked All Continents (WAC)",
+            "Facet": "Band"
+          },
+          "WAE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mixed"
+          },
+          "WAE_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_BAND",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Band"
+          },
+          "WAE_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAE_MODE",
+            "Sponsor": "DARC",
+            "Award": "Worked All Europe (WAE)",
+            "Facet": "Mode"
+          },
+          "WAIP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mixed"
+          },
+          "WAIP_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_BAND",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Band"
+          },
+          "WAIP_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAIP_MODE",
+            "Sponsor": "ARI",
+            "Award": "Worked All Italian Provinces (WAIP)",
+            "Facet": "Mode"
+          },
+          "WAS": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mixed"
+          },
+          "WAS_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_BAND",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Band"
+          },
+          "WAS_EME": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_EME",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "EME"
+          },
+          "WAS_MODE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_MODE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Mode"
+          },
+          "WAS_NOVICE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_NOVICE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Novice"
+          },
+          "WAS_QRP": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_QRP",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "QRP"
+          },
+          "WAS_SATELLITE": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WAS_SATELLITE",
+            "Sponsor": "ARRL",
+            "Award": "Worked All States (WAS)",
+            "Facet": "Satellite"
+          },
+          "WITUZ": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Mixed"
+          },
+          "WITUZ_BAND": {
+            "Enumeration Name": "Credit",
+            "Credit For": "WITUZ_BAND",
+            "Sponsor": "RSGB",
+            "Award": "Worked ITU Zones (WITUZ)",
+            "Facet": "Band"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_dxcc_entity_code.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_dxcc_entity_code.json
@@ -1,0 +1,2101 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:38Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "DXCC_Entity_Code": {
+        "Header": [
+          "Enumeration Name",
+          "Entity Code",
+          "Entity Name",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "0": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "0",
+            "Entity Name": "None (the contacted station is known to not be within a DXCC entity)"
+          },
+          "1": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "1",
+            "Entity Name": "CANADA"
+          },
+          "2": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "2",
+            "Entity Name": "ABU AIL IS.",
+            "Deleted": "true"
+          },
+          "3": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "3",
+            "Entity Name": "AFGHANISTAN"
+          },
+          "4": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "4",
+            "Entity Name": "AGALEGA \u0026 ST. BRANDON IS."
+          },
+          "5": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "5",
+            "Entity Name": "ALAND IS."
+          },
+          "6": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "6",
+            "Entity Name": "ALASKA"
+          },
+          "7": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "7",
+            "Entity Name": "ALBANIA"
+          },
+          "8": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "8",
+            "Entity Name": "ALDABRA",
+            "Deleted": "true"
+          },
+          "9": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "9",
+            "Entity Name": "AMERICAN SAMOA"
+          },
+          "10": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "10",
+            "Entity Name": "AMSTERDAM \u0026 ST. PAUL IS."
+          },
+          "11": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "11",
+            "Entity Name": "ANDAMAN \u0026 NICOBAR IS."
+          },
+          "12": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "12",
+            "Entity Name": "ANGUILLA"
+          },
+          "13": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "13",
+            "Entity Name": "ANTARCTICA"
+          },
+          "14": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "14",
+            "Entity Name": "ARMENIA"
+          },
+          "15": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "15",
+            "Entity Name": "ASIATIC RUSSIA"
+          },
+          "16": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "16",
+            "Entity Name": "NEW ZEALAND SUBANTARCTIC ISLANDS"
+          },
+          "17": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "17",
+            "Entity Name": "AVES I."
+          },
+          "18": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "18",
+            "Entity Name": "AZERBAIJAN"
+          },
+          "19": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "19",
+            "Entity Name": "BAJO NUEVO",
+            "Deleted": "true"
+          },
+          "20": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "20",
+            "Entity Name": "BAKER \u0026 HOWLAND IS."
+          },
+          "21": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "21",
+            "Entity Name": "BALEARIC IS."
+          },
+          "22": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "22",
+            "Entity Name": "PALAU"
+          },
+          "23": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "23",
+            "Entity Name": "BLENHEIM REEF",
+            "Deleted": "true"
+          },
+          "24": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "24",
+            "Entity Name": "BOUVET"
+          },
+          "25": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "25",
+            "Entity Name": "BRITISH NORTH BORNEO",
+            "Deleted": "true"
+          },
+          "26": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "26",
+            "Entity Name": "BRITISH SOMALILAND",
+            "Deleted": "true"
+          },
+          "27": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "27",
+            "Entity Name": "BELARUS"
+          },
+          "28": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "28",
+            "Entity Name": "CANAL ZONE",
+            "Deleted": "true"
+          },
+          "29": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "29",
+            "Entity Name": "CANARY IS."
+          },
+          "30": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "30",
+            "Entity Name": "CELEBE \u0026 MOLUCCA IS.",
+            "Deleted": "true"
+          },
+          "31": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "31",
+            "Entity Name": "C. KIRIBATI (BRITISH PHOENIX IS.)"
+          },
+          "32": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "32",
+            "Entity Name": "CEUTA \u0026 MELILLA"
+          },
+          "33": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "33",
+            "Entity Name": "CHAGOS IS."
+          },
+          "34": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "34",
+            "Entity Name": "CHATHAM IS."
+          },
+          "35": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "35",
+            "Entity Name": "CHRISTMAS I."
+          },
+          "36": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "36",
+            "Entity Name": "CLIPPERTON I."
+          },
+          "37": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "37",
+            "Entity Name": "COCOS I."
+          },
+          "38": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "38",
+            "Entity Name": "COCOS (KEELING) IS."
+          },
+          "39": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "39",
+            "Entity Name": "COMOROS",
+            "Deleted": "true"
+          },
+          "40": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "40",
+            "Entity Name": "CRETE"
+          },
+          "41": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "41",
+            "Entity Name": "CROZET I."
+          },
+          "42": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "42",
+            "Entity Name": "DAMAO, DIU",
+            "Deleted": "true"
+          },
+          "43": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "43",
+            "Entity Name": "DESECHEO I."
+          },
+          "44": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "44",
+            "Entity Name": "DESROCHES",
+            "Deleted": "true"
+          },
+          "45": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "45",
+            "Entity Name": "DODECANESE"
+          },
+          "46": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "46",
+            "Entity Name": "EAST MALAYSIA"
+          },
+          "47": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "47",
+            "Entity Name": "EASTER I."
+          },
+          "48": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "48",
+            "Entity Name": "E. KIRIBATI (LINE IS.)"
+          },
+          "49": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "49",
+            "Entity Name": "EQUATORIAL GUINEA"
+          },
+          "50": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "50",
+            "Entity Name": "MEXICO"
+          },
+          "51": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "51",
+            "Entity Name": "ERITREA"
+          },
+          "52": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "52",
+            "Entity Name": "ESTONIA"
+          },
+          "53": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "53",
+            "Entity Name": "ETHIOPIA"
+          },
+          "54": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "54",
+            "Entity Name": "EUROPEAN RUSSIA"
+          },
+          "55": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "55",
+            "Entity Name": "FARQUHAR",
+            "Deleted": "true"
+          },
+          "56": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "56",
+            "Entity Name": "FERNANDO DE NORONHA"
+          },
+          "57": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "57",
+            "Entity Name": "FRENCH EQUATORIAL AFRICA",
+            "Deleted": "true"
+          },
+          "58": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "58",
+            "Entity Name": "FRENCH INDO-CHINA",
+            "Deleted": "true"
+          },
+          "59": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "59",
+            "Entity Name": "FRENCH WEST AFRICA",
+            "Deleted": "true"
+          },
+          "60": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "60",
+            "Entity Name": "BAHAMAS"
+          },
+          "61": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "61",
+            "Entity Name": "FRANZ JOSEF LAND"
+          },
+          "62": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "62",
+            "Entity Name": "BARBADOS"
+          },
+          "63": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "63",
+            "Entity Name": "FRENCH GUIANA"
+          },
+          "64": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "64",
+            "Entity Name": "BERMUDA"
+          },
+          "65": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "65",
+            "Entity Name": "BRITISH VIRGIN IS."
+          },
+          "66": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "66",
+            "Entity Name": "BELIZE"
+          },
+          "67": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "67",
+            "Entity Name": "FRENCH INDIA",
+            "Deleted": "true"
+          },
+          "68": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "68",
+            "Entity Name": "KUWAIT/SAUDI ARABIA NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "69": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "69",
+            "Entity Name": "CAYMAN IS."
+          },
+          "70": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "70",
+            "Entity Name": "CUBA"
+          },
+          "71": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "71",
+            "Entity Name": "GALAPAGOS IS."
+          },
+          "72": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "72",
+            "Entity Name": "DOMINICAN REPUBLIC"
+          },
+          "74": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "74",
+            "Entity Name": "EL SALVADOR"
+          },
+          "75": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "75",
+            "Entity Name": "GEORGIA"
+          },
+          "76": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "76",
+            "Entity Name": "GUATEMALA"
+          },
+          "77": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "77",
+            "Entity Name": "GRENADA"
+          },
+          "78": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "78",
+            "Entity Name": "HAITI"
+          },
+          "79": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "79",
+            "Entity Name": "GUADELOUPE"
+          },
+          "80": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "80",
+            "Entity Name": "HONDURAS"
+          },
+          "81": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "81",
+            "Entity Name": "GERMANY",
+            "Deleted": "true"
+          },
+          "82": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "82",
+            "Entity Name": "JAMAICA"
+          },
+          "84": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "84",
+            "Entity Name": "MARTINIQUE"
+          },
+          "85": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "85",
+            "Entity Name": "BONAIRE, CURACAO",
+            "Deleted": "true"
+          },
+          "86": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "86",
+            "Entity Name": "NICARAGUA"
+          },
+          "88": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "88",
+            "Entity Name": "PANAMA"
+          },
+          "89": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "89",
+            "Entity Name": "TURKS \u0026 CAICOS IS."
+          },
+          "90": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "90",
+            "Entity Name": "TRINIDAD \u0026 TOBAGO"
+          },
+          "91": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "91",
+            "Entity Name": "ARUBA"
+          },
+          "93": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "93",
+            "Entity Name": "GEYSER REEF",
+            "Deleted": "true"
+          },
+          "94": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "94",
+            "Entity Name": "ANTIGUA \u0026 BARBUDA"
+          },
+          "95": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "95",
+            "Entity Name": "DOMINICA"
+          },
+          "96": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "96",
+            "Entity Name": "MONTSERRAT"
+          },
+          "97": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "97",
+            "Entity Name": "ST. LUCIA"
+          },
+          "98": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "98",
+            "Entity Name": "ST. VINCENT"
+          },
+          "99": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "99",
+            "Entity Name": "GLORIOSO IS."
+          },
+          "100": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "100",
+            "Entity Name": "ARGENTINA"
+          },
+          "101": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "101",
+            "Entity Name": "GOA",
+            "Deleted": "true"
+          },
+          "102": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "102",
+            "Entity Name": "GOLD COAST, TOGOLAND",
+            "Deleted": "true"
+          },
+          "103": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "103",
+            "Entity Name": "GUAM"
+          },
+          "104": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "104",
+            "Entity Name": "BOLIVIA"
+          },
+          "105": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "105",
+            "Entity Name": "GUANTANAMO BAY"
+          },
+          "106": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "106",
+            "Entity Name": "GUERNSEY"
+          },
+          "107": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "107",
+            "Entity Name": "GUINEA"
+          },
+          "108": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "108",
+            "Entity Name": "BRAZIL"
+          },
+          "109": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "109",
+            "Entity Name": "GUINEA-BISSAU"
+          },
+          "110": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "110",
+            "Entity Name": "HAWAII"
+          },
+          "111": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "111",
+            "Entity Name": "HEARD I."
+          },
+          "112": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "112",
+            "Entity Name": "CHILE"
+          },
+          "113": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "113",
+            "Entity Name": "IFNI",
+            "Deleted": "true"
+          },
+          "114": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "114",
+            "Entity Name": "ISLE OF MAN"
+          },
+          "115": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "115",
+            "Entity Name": "ITALIAN SOMALILAND",
+            "Deleted": "true"
+          },
+          "116": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "116",
+            "Entity Name": "COLOMBIA"
+          },
+          "117": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "117",
+            "Entity Name": "ITU HQ"
+          },
+          "118": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "118",
+            "Entity Name": "JAN MAYEN"
+          },
+          "119": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "119",
+            "Entity Name": "JAVA",
+            "Deleted": "true"
+          },
+          "120": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "120",
+            "Entity Name": "ECUADOR"
+          },
+          "122": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "122",
+            "Entity Name": "JERSEY"
+          },
+          "123": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "123",
+            "Entity Name": "JOHNSTON I."
+          },
+          "124": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "124",
+            "Entity Name": "JUAN DE NOVA, EUROPA"
+          },
+          "125": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "125",
+            "Entity Name": "JUAN FERNANDEZ IS."
+          },
+          "126": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "126",
+            "Entity Name": "KALININGRAD"
+          },
+          "127": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "127",
+            "Entity Name": "KAMARAN IS.",
+            "Deleted": "true"
+          },
+          "128": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "128",
+            "Entity Name": "KARELO-FINNISH REPUBLIC",
+            "Deleted": "true"
+          },
+          "129": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "129",
+            "Entity Name": "GUYANA"
+          },
+          "130": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "130",
+            "Entity Name": "KAZAKHSTAN"
+          },
+          "131": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "131",
+            "Entity Name": "KERGUELEN IS."
+          },
+          "132": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "132",
+            "Entity Name": "PARAGUAY"
+          },
+          "133": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "133",
+            "Entity Name": "KERMADEC IS."
+          },
+          "134": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "134",
+            "Entity Name": "KINGMAN REEF",
+            "Deleted": "true"
+          },
+          "135": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "135",
+            "Entity Name": "KYRGYZSTAN"
+          },
+          "136": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "136",
+            "Entity Name": "PERU"
+          },
+          "137": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "137",
+            "Entity Name": "REPUBLIC OF KOREA"
+          },
+          "138": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "138",
+            "Entity Name": "KURE I."
+          },
+          "139": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "139",
+            "Entity Name": "KURIA MURIA I.",
+            "Deleted": "true"
+          },
+          "140": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "140",
+            "Entity Name": "SURINAME"
+          },
+          "141": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "141",
+            "Entity Name": "FALKLAND IS."
+          },
+          "142": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "142",
+            "Entity Name": "LAKSHADWEEP IS."
+          },
+          "143": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "143",
+            "Entity Name": "LAOS"
+          },
+          "144": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "144",
+            "Entity Name": "URUGUAY"
+          },
+          "145": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "145",
+            "Entity Name": "LATVIA"
+          },
+          "146": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "146",
+            "Entity Name": "LITHUANIA"
+          },
+          "147": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "147",
+            "Entity Name": "LORD HOWE I."
+          },
+          "148": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "148",
+            "Entity Name": "VENEZUELA"
+          },
+          "149": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "149",
+            "Entity Name": "AZORES"
+          },
+          "150": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "150",
+            "Entity Name": "AUSTRALIA"
+          },
+          "151": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "151",
+            "Entity Name": "MALYJ VYSOTSKIJ I.",
+            "Deleted": "true"
+          },
+          "152": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "152",
+            "Entity Name": "MACAO"
+          },
+          "153": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "153",
+            "Entity Name": "MACQUARIE I."
+          },
+          "154": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "154",
+            "Entity Name": "YEMEN ARAB REPUBLIC",
+            "Deleted": "true"
+          },
+          "155": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "155",
+            "Entity Name": "MALAYA",
+            "Deleted": "true"
+          },
+          "157": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "157",
+            "Entity Name": "NAURU"
+          },
+          "158": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "158",
+            "Entity Name": "VANUATU"
+          },
+          "159": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "159",
+            "Entity Name": "MALDIVES"
+          },
+          "160": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "160",
+            "Entity Name": "TONGA"
+          },
+          "161": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "161",
+            "Entity Name": "MALPELO I."
+          },
+          "162": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "162",
+            "Entity Name": "NEW CALEDONIA"
+          },
+          "163": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "163",
+            "Entity Name": "PAPUA NEW GUINEA"
+          },
+          "164": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "164",
+            "Entity Name": "MANCHURIA",
+            "Deleted": "true"
+          },
+          "165": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "165",
+            "Entity Name": "MAURITIUS"
+          },
+          "166": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "166",
+            "Entity Name": "MARIANA IS."
+          },
+          "167": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "167",
+            "Entity Name": "MARKET REEF"
+          },
+          "168": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "168",
+            "Entity Name": "MARSHALL IS."
+          },
+          "169": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "169",
+            "Entity Name": "MAYOTTE"
+          },
+          "170": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "170",
+            "Entity Name": "NEW ZEALAND"
+          },
+          "171": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "171",
+            "Entity Name": "MELLISH REEF"
+          },
+          "172": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "172",
+            "Entity Name": "PITCAIRN I."
+          },
+          "173": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "173",
+            "Entity Name": "MICRONESIA"
+          },
+          "174": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "174",
+            "Entity Name": "MIDWAY I."
+          },
+          "175": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "175",
+            "Entity Name": "FRENCH POLYNESIA"
+          },
+          "176": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "176",
+            "Entity Name": "FIJI"
+          },
+          "177": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "177",
+            "Entity Name": "MINAMI TORISHIMA"
+          },
+          "178": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "178",
+            "Entity Name": "MINERVA REEF",
+            "Deleted": "true"
+          },
+          "179": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "179",
+            "Entity Name": "MOLDOVA"
+          },
+          "180": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "180",
+            "Entity Name": "MOUNT ATHOS"
+          },
+          "181": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "181",
+            "Entity Name": "MOZAMBIQUE"
+          },
+          "182": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "182",
+            "Entity Name": "NAVASSA I."
+          },
+          "183": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "183",
+            "Entity Name": "NETHERLANDS BORNEO",
+            "Deleted": "true"
+          },
+          "184": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "184",
+            "Entity Name": "NETHERLANDS NEW GUINEA",
+            "Deleted": "true"
+          },
+          "185": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "185",
+            "Entity Name": "SOLOMON IS."
+          },
+          "186": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "186",
+            "Entity Name": "NEWFOUNDLAND, LABRADOR",
+            "Deleted": "true"
+          },
+          "187": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "187",
+            "Entity Name": "NIGER"
+          },
+          "188": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "188",
+            "Entity Name": "NIUE"
+          },
+          "189": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "189",
+            "Entity Name": "NORFOLK I."
+          },
+          "190": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "190",
+            "Entity Name": "SAMOA"
+          },
+          "191": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "191",
+            "Entity Name": "NORTH COOK IS."
+          },
+          "192": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "192",
+            "Entity Name": "OGASAWARA"
+          },
+          "193": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "193",
+            "Entity Name": "OKINAWA (RYUKYU IS.)",
+            "Deleted": "true"
+          },
+          "194": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "194",
+            "Entity Name": "OKINO TORI-SHIMA",
+            "Deleted": "true"
+          },
+          "195": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "195",
+            "Entity Name": "ANNOBON I."
+          },
+          "196": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "196",
+            "Entity Name": "PALESTINE",
+            "Deleted": "true"
+          },
+          "197": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "197",
+            "Entity Name": "PALMYRA \u0026 JARVIS IS."
+          },
+          "198": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "198",
+            "Entity Name": "PAPUA TERRITORY",
+            "Deleted": "true"
+          },
+          "199": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "199",
+            "Entity Name": "PETER 1 I."
+          },
+          "200": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "200",
+            "Entity Name": "PORTUGUESE TIMOR",
+            "Deleted": "true"
+          },
+          "201": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "201",
+            "Entity Name": "PRINCE EDWARD \u0026 MARION IS."
+          },
+          "202": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "202",
+            "Entity Name": "PUERTO RICO"
+          },
+          "203": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "203",
+            "Entity Name": "ANDORRA"
+          },
+          "204": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "204",
+            "Entity Name": "REVILLAGIGEDO"
+          },
+          "205": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "205",
+            "Entity Name": "ASCENSION I."
+          },
+          "206": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "206",
+            "Entity Name": "AUSTRIA"
+          },
+          "207": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "207",
+            "Entity Name": "RODRIGUES I."
+          },
+          "208": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "208",
+            "Entity Name": "RUANDA-URUNDI",
+            "Deleted": "true"
+          },
+          "209": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "209",
+            "Entity Name": "BELGIUM"
+          },
+          "210": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "210",
+            "Entity Name": "SAAR",
+            "Deleted": "true"
+          },
+          "211": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "211",
+            "Entity Name": "SABLE I."
+          },
+          "212": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "212",
+            "Entity Name": "BULGARIA"
+          },
+          "213": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "213",
+            "Entity Name": "SAINT MARTIN"
+          },
+          "214": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "214",
+            "Entity Name": "CORSICA"
+          },
+          "215": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "215",
+            "Entity Name": "CYPRUS"
+          },
+          "216": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "216",
+            "Entity Name": "SAN ANDRES \u0026 PROVIDENCIA"
+          },
+          "217": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "217",
+            "Entity Name": "SAN FELIX \u0026 SAN AMBROSIO"
+          },
+          "218": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "218",
+            "Entity Name": "CZECHOSLOVAKIA",
+            "Deleted": "true"
+          },
+          "219": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "219",
+            "Entity Name": "SAO TOME \u0026 PRINCIPE"
+          },
+          "220": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "220",
+            "Entity Name": "SARAWAK",
+            "Deleted": "true"
+          },
+          "221": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "221",
+            "Entity Name": "DENMARK"
+          },
+          "222": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "222",
+            "Entity Name": "FAROE IS."
+          },
+          "223": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "223",
+            "Entity Name": "ENGLAND"
+          },
+          "224": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "224",
+            "Entity Name": "FINLAND"
+          },
+          "225": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "225",
+            "Entity Name": "SARDINIA"
+          },
+          "226": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "226",
+            "Entity Name": "SAUDI ARABIA/IRAQ NEUTRAL ZONE",
+            "Deleted": "true"
+          },
+          "227": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "227",
+            "Entity Name": "FRANCE"
+          },
+          "228": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "228",
+            "Entity Name": "SERRANA BANK \u0026 RONCADOR CAY",
+            "Deleted": "true"
+          },
+          "229": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "229",
+            "Entity Name": "GERMAN DEMOCRATIC REPUBLIC",
+            "Deleted": "true"
+          },
+          "230": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "230",
+            "Entity Name": "FEDERAL REPUBLIC OF GERMANY"
+          },
+          "231": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "231",
+            "Entity Name": "SIKKIM",
+            "Deleted": "true"
+          },
+          "232": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "232",
+            "Entity Name": "SOMALIA"
+          },
+          "233": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "233",
+            "Entity Name": "GIBRALTAR"
+          },
+          "234": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "234",
+            "Entity Name": "SOUTH COOK IS."
+          },
+          "235": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "235",
+            "Entity Name": "SOUTH GEORGIA I."
+          },
+          "236": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "236",
+            "Entity Name": "GREECE"
+          },
+          "237": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "237",
+            "Entity Name": "GREENLAND"
+          },
+          "238": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "238",
+            "Entity Name": "SOUTH ORKNEY IS."
+          },
+          "239": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "239",
+            "Entity Name": "HUNGARY"
+          },
+          "240": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "240",
+            "Entity Name": "SOUTH SANDWICH IS."
+          },
+          "241": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "241",
+            "Entity Name": "SOUTH SHETLAND IS."
+          },
+          "242": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "242",
+            "Entity Name": "ICELAND"
+          },
+          "243": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "243",
+            "Entity Name": "PEOPLE\u0027S DEMOCRATIC REP. OF YEMEN",
+            "Deleted": "true"
+          },
+          "244": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "244",
+            "Entity Name": "SOUTHERN SUDAN",
+            "Deleted": "true"
+          },
+          "245": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "245",
+            "Entity Name": "IRELAND"
+          },
+          "246": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "246",
+            "Entity Name": "SOVEREIGN MILITARY ORDER OF MALTA"
+          },
+          "247": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "247",
+            "Entity Name": "SPRATLY IS."
+          },
+          "248": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "248",
+            "Entity Name": "ITALY"
+          },
+          "249": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "249",
+            "Entity Name": "ST. KITTS \u0026 NEVIS"
+          },
+          "250": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "250",
+            "Entity Name": "ST. HELENA"
+          },
+          "251": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "251",
+            "Entity Name": "LIECHTENSTEIN"
+          },
+          "252": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "252",
+            "Entity Name": "ST. PAUL I."
+          },
+          "253": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "253",
+            "Entity Name": "ST. PETER \u0026 ST. PAUL ROCKS"
+          },
+          "254": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "254",
+            "Entity Name": "LUXEMBOURG"
+          },
+          "255": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "255",
+            "Entity Name": "ST. MAARTEN, SABA, ST. EUSTATIUS",
+            "Deleted": "true"
+          },
+          "256": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "256",
+            "Entity Name": "MADEIRA IS."
+          },
+          "257": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "257",
+            "Entity Name": "MALTA"
+          },
+          "258": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "258",
+            "Entity Name": "SUMATRA",
+            "Deleted": "true"
+          },
+          "259": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "259",
+            "Entity Name": "SVALBARD"
+          },
+          "260": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "260",
+            "Entity Name": "MONACO"
+          },
+          "261": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "261",
+            "Entity Name": "SWAN IS.",
+            "Deleted": "true"
+          },
+          "262": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "262",
+            "Entity Name": "TAJIKISTAN"
+          },
+          "263": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "263",
+            "Entity Name": "NETHERLANDS"
+          },
+          "264": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "264",
+            "Entity Name": "TANGIER",
+            "Deleted": "true"
+          },
+          "265": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "265",
+            "Entity Name": "NORTHERN IRELAND"
+          },
+          "266": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "266",
+            "Entity Name": "NORWAY"
+          },
+          "267": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "267",
+            "Entity Name": "TERRITORY OF NEW GUINEA",
+            "Deleted": "true"
+          },
+          "268": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "268",
+            "Entity Name": "TIBET",
+            "Deleted": "true"
+          },
+          "269": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "269",
+            "Entity Name": "POLAND"
+          },
+          "270": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "270",
+            "Entity Name": "TOKELAU IS."
+          },
+          "271": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "271",
+            "Entity Name": "TRIESTE",
+            "Deleted": "true"
+          },
+          "272": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "272",
+            "Entity Name": "PORTUGAL"
+          },
+          "273": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "273",
+            "Entity Name": "TRINDADE \u0026 MARTIM VAZ IS."
+          },
+          "274": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "274",
+            "Entity Name": "TRISTAN DA CUNHA \u0026 GOUGH I."
+          },
+          "275": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "275",
+            "Entity Name": "ROMANIA"
+          },
+          "276": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "276",
+            "Entity Name": "TROMELIN I."
+          },
+          "277": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "277",
+            "Entity Name": "ST. PIERRE \u0026 MIQUELON"
+          },
+          "278": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "278",
+            "Entity Name": "SAN MARINO"
+          },
+          "279": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "279",
+            "Entity Name": "SCOTLAND"
+          },
+          "280": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "280",
+            "Entity Name": "TURKMENISTAN"
+          },
+          "281": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "281",
+            "Entity Name": "SPAIN"
+          },
+          "282": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "282",
+            "Entity Name": "TUVALU"
+          },
+          "283": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "283",
+            "Entity Name": "UK SOVEREIGN BASE AREAS ON CYPRUS"
+          },
+          "284": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "284",
+            "Entity Name": "SWEDEN"
+          },
+          "285": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "285",
+            "Entity Name": "VIRGIN IS."
+          },
+          "286": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "286",
+            "Entity Name": "UGANDA"
+          },
+          "287": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "287",
+            "Entity Name": "SWITZERLAND"
+          },
+          "288": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "288",
+            "Entity Name": "UKRAINE"
+          },
+          "289": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "289",
+            "Entity Name": "UNITED NATIONS HQ"
+          },
+          "291": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "291",
+            "Entity Name": "UNITED STATES OF AMERICA"
+          },
+          "292": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "292",
+            "Entity Name": "UZBEKISTAN"
+          },
+          "293": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "293",
+            "Entity Name": "VIET NAM"
+          },
+          "294": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "294",
+            "Entity Name": "WALES"
+          },
+          "295": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "295",
+            "Entity Name": "VATICAN"
+          },
+          "296": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "296",
+            "Entity Name": "SERBIA"
+          },
+          "297": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "297",
+            "Entity Name": "WAKE I."
+          },
+          "298": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "298",
+            "Entity Name": "WALLIS \u0026 FUTUNA IS."
+          },
+          "299": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "299",
+            "Entity Name": "WEST MALAYSIA"
+          },
+          "301": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "301",
+            "Entity Name": "W. KIRIBATI (GILBERT IS. )"
+          },
+          "302": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "302",
+            "Entity Name": "WESTERN SAHARA"
+          },
+          "303": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "303",
+            "Entity Name": "WILLIS I."
+          },
+          "304": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "304",
+            "Entity Name": "BAHRAIN"
+          },
+          "305": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "305",
+            "Entity Name": "BANGLADESH"
+          },
+          "306": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "306",
+            "Entity Name": "BHUTAN"
+          },
+          "307": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "307",
+            "Entity Name": "ZANZIBAR",
+            "Deleted": "true"
+          },
+          "308": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "308",
+            "Entity Name": "COSTA RICA"
+          },
+          "309": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "309",
+            "Entity Name": "MYANMAR"
+          },
+          "312": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "312",
+            "Entity Name": "CAMBODIA"
+          },
+          "315": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "315",
+            "Entity Name": "SRI LANKA"
+          },
+          "318": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "318",
+            "Entity Name": "CHINA"
+          },
+          "321": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "321",
+            "Entity Name": "HONG KONG"
+          },
+          "324": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "324",
+            "Entity Name": "INDIA"
+          },
+          "327": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "327",
+            "Entity Name": "INDONESIA"
+          },
+          "330": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "330",
+            "Entity Name": "IRAN"
+          },
+          "333": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "333",
+            "Entity Name": "IRAQ"
+          },
+          "336": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "336",
+            "Entity Name": "ISRAEL"
+          },
+          "339": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "339",
+            "Entity Name": "JAPAN"
+          },
+          "342": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "342",
+            "Entity Name": "JORDAN"
+          },
+          "344": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "344",
+            "Entity Name": "DEMOCRATIC PEOPLE\u0027S REP. OF KOREA"
+          },
+          "345": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "345",
+            "Entity Name": "BRUNEI DARUSSALAM"
+          },
+          "348": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "348",
+            "Entity Name": "KUWAIT"
+          },
+          "354": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "354",
+            "Entity Name": "LEBANON"
+          },
+          "363": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "363",
+            "Entity Name": "MONGOLIA"
+          },
+          "369": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "369",
+            "Entity Name": "NEPAL"
+          },
+          "370": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "370",
+            "Entity Name": "OMAN"
+          },
+          "372": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "372",
+            "Entity Name": "PAKISTAN"
+          },
+          "375": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "375",
+            "Entity Name": "PHILIPPINES"
+          },
+          "376": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "376",
+            "Entity Name": "QATAR"
+          },
+          "378": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "378",
+            "Entity Name": "SAUDI ARABIA"
+          },
+          "379": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "379",
+            "Entity Name": "SEYCHELLES"
+          },
+          "381": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "381",
+            "Entity Name": "SINGAPORE"
+          },
+          "382": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "382",
+            "Entity Name": "DJIBOUTI"
+          },
+          "384": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "384",
+            "Entity Name": "SYRIA"
+          },
+          "386": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "386",
+            "Entity Name": "TAIWAN"
+          },
+          "387": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "387",
+            "Entity Name": "THAILAND"
+          },
+          "390": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "390",
+            "Entity Name": "TURKEY"
+          },
+          "391": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "391",
+            "Entity Name": "UNITED ARAB EMIRATES"
+          },
+          "400": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "400",
+            "Entity Name": "ALGERIA"
+          },
+          "401": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "401",
+            "Entity Name": "ANGOLA"
+          },
+          "402": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "402",
+            "Entity Name": "BOTSWANA"
+          },
+          "404": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "404",
+            "Entity Name": "BURUNDI"
+          },
+          "406": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "406",
+            "Entity Name": "CAMEROON"
+          },
+          "408": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "408",
+            "Entity Name": "CENTRAL AFRICA"
+          },
+          "409": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "409",
+            "Entity Name": "CAPE VERDE"
+          },
+          "410": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "410",
+            "Entity Name": "CHAD"
+          },
+          "411": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "411",
+            "Entity Name": "COMOROS"
+          },
+          "412": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "412",
+            "Entity Name": "REPUBLIC OF THE CONGO"
+          },
+          "414": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "414",
+            "Entity Name": "DEMOCRATIC REPUBLIC OF THE CONGO"
+          },
+          "416": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "416",
+            "Entity Name": "BENIN"
+          },
+          "420": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "420",
+            "Entity Name": "GABON"
+          },
+          "422": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "422",
+            "Entity Name": "THE GAMBIA"
+          },
+          "424": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "424",
+            "Entity Name": "GHANA"
+          },
+          "428": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "428",
+            "Entity Name": "COTE D\u0027IVOIRE"
+          },
+          "430": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "430",
+            "Entity Name": "KENYA"
+          },
+          "432": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "432",
+            "Entity Name": "LESOTHO"
+          },
+          "434": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "434",
+            "Entity Name": "LIBERIA"
+          },
+          "436": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "436",
+            "Entity Name": "LIBYA"
+          },
+          "438": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "438",
+            "Entity Name": "MADAGASCAR"
+          },
+          "440": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "440",
+            "Entity Name": "MALAWI"
+          },
+          "442": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "442",
+            "Entity Name": "MALI"
+          },
+          "444": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "444",
+            "Entity Name": "MAURITANIA"
+          },
+          "446": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "446",
+            "Entity Name": "MOROCCO"
+          },
+          "450": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "450",
+            "Entity Name": "NIGERIA"
+          },
+          "452": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "452",
+            "Entity Name": "ZIMBABWE"
+          },
+          "453": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "453",
+            "Entity Name": "REUNION I."
+          },
+          "454": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "454",
+            "Entity Name": "RWANDA"
+          },
+          "456": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "456",
+            "Entity Name": "SENEGAL"
+          },
+          "458": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "458",
+            "Entity Name": "SIERRA LEONE"
+          },
+          "460": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "460",
+            "Entity Name": "ROTUMA I."
+          },
+          "462": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "462",
+            "Entity Name": "REPUBLIC OF SOUTH AFRICA"
+          },
+          "464": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "464",
+            "Entity Name": "NAMIBIA"
+          },
+          "466": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "466",
+            "Entity Name": "SUDAN"
+          },
+          "468": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "468",
+            "Entity Name": "KINGDOM OF ESWATINI"
+          },
+          "470": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "470",
+            "Entity Name": "TANZANIA"
+          },
+          "474": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "474",
+            "Entity Name": "TUNISIA"
+          },
+          "478": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "478",
+            "Entity Name": "EGYPT"
+          },
+          "480": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "480",
+            "Entity Name": "BURKINA FASO"
+          },
+          "482": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "482",
+            "Entity Name": "ZAMBIA"
+          },
+          "483": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "483",
+            "Entity Name": "TOGO"
+          },
+          "488": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "488",
+            "Entity Name": "WALVIS BAY",
+            "Deleted": "true"
+          },
+          "489": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "489",
+            "Entity Name": "CONWAY REEF"
+          },
+          "490": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "490",
+            "Entity Name": "BANABA I. (OCEAN I.)"
+          },
+          "492": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "492",
+            "Entity Name": "YEMEN"
+          },
+          "493": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "493",
+            "Entity Name": "PENGUIN IS.",
+            "Deleted": "true"
+          },
+          "497": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "497",
+            "Entity Name": "CROATIA"
+          },
+          "499": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "499",
+            "Entity Name": "SLOVENIA"
+          },
+          "501": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "501",
+            "Entity Name": "BOSNIA-HERZEGOVINA"
+          },
+          "502": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "502",
+            "Entity Name": "NORTH MACEDONIA (REPUBLIC OF)"
+          },
+          "503": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "503",
+            "Entity Name": "CZECH REPUBLIC"
+          },
+          "504": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "504",
+            "Entity Name": "SLOVAK REPUBLIC"
+          },
+          "505": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "505",
+            "Entity Name": "PRATAS I."
+          },
+          "506": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "506",
+            "Entity Name": "SCARBOROUGH REEF"
+          },
+          "507": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "507",
+            "Entity Name": "TEMOTU PROVINCE"
+          },
+          "508": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "508",
+            "Entity Name": "AUSTRAL I."
+          },
+          "509": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "509",
+            "Entity Name": "MARQUESAS IS."
+          },
+          "510": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "510",
+            "Entity Name": "PALESTINE"
+          },
+          "511": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "511",
+            "Entity Name": "TIMOR-LESTE"
+          },
+          "512": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "512",
+            "Entity Name": "CHESTERFIELD IS."
+          },
+          "513": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "513",
+            "Entity Name": "DUCIE I."
+          },
+          "514": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "514",
+            "Entity Name": "MONTENEGRO"
+          },
+          "515": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "515",
+            "Entity Name": "SWAINS I."
+          },
+          "516": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "516",
+            "Entity Name": "SAINT BARTHELEMY"
+          },
+          "517": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "517",
+            "Entity Name": "CURACAO"
+          },
+          "518": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "518",
+            "Entity Name": "SINT MAARTEN"
+          },
+          "519": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "519",
+            "Entity Name": "SABA \u0026 ST. EUSTATIUS"
+          },
+          "520": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "520",
+            "Entity Name": "BONAIRE"
+          },
+          "521": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "521",
+            "Entity Name": "SOUTH SUDAN (REPUBLIC OF)"
+          },
+          "522": {
+            "Enumeration Name": "DXCC_Entity_Code",
+            "Entity Code": "522",
+            "Entity Name": "REPUBLIC OF KOSOVO"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_eqsl_ag.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_eqsl_ag.json
@@ -1,0 +1,38 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:39Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "EQSL_AG": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "Y",
+            "Description": "The QSO\u0027s callsign holds eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "N": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "N",
+            "Description": "The QSO\u0027s callsign does not hold eQSL.cc\u0027s \u0022Authenticity Guaranteed\u0022 status"
+          },
+          "U": {
+            "Enumeration Name": "EQSL_AG",
+            "Status": "U",
+            "Description": "Unspecified (Default)"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_mode.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_mode.json
@@ -1,0 +1,464 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:40Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Mode",
+          "Submodes",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AM": {
+            "Enumeration Name": "Mode",
+            "Mode": "AM"
+          },
+          "ARDOP": {
+            "Enumeration Name": "Mode",
+            "Mode": "ARDOP",
+            "Description": "Amateur Radio Digital Open Protocol"
+          },
+          "ATV": {
+            "Enumeration Name": "Mode",
+            "Mode": "ATV"
+          },
+          "CHIP": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP",
+            "Submodes": "CHIP64,CHIP128"
+          },
+          "CLO": {
+            "Enumeration Name": "Mode",
+            "Mode": "CLO"
+          },
+          "CONTESTI": {
+            "Enumeration Name": "Mode",
+            "Mode": "CONTESTI"
+          },
+          "CW": {
+            "Enumeration Name": "Mode",
+            "Mode": "CW",
+            "Submodes": "PCW"
+          },
+          "DIGITALVOICE": {
+            "Enumeration Name": "Mode",
+            "Mode": "DIGITALVOICE",
+            "Submodes": "C4FM,DMR,DSTAR,FREEDV,M17"
+          },
+          "DOMINO": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINO",
+            "Submodes": "DOM-M,DOM4,DOM5,DOM8,DOM11,DOM16,DOM22,DOM44,DOM88,DOMINOEX,DOMINOF"
+          },
+          "DYNAMIC": {
+            "Enumeration Name": "Mode",
+            "Mode": "DYNAMIC",
+            "Submodes": "FREEDATA,VARA HF,VARA SATELLITE,VARA FM 1200,VARA FM 9600"
+          },
+          "FAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "FAX"
+          },
+          "FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "FM"
+          },
+          "FSK441": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK441"
+          },
+          "FSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK",
+            "Submodes": "SCAMP_FAST,SCAMP_SLOW,SCAMP_VSLOW",
+            "Description": "Frequency shift keying"
+          },
+          "FT8": {
+            "Enumeration Name": "Mode",
+            "Mode": "FT8",
+            "Description": "Franke-Taylor design, 8-FSK modulation"
+          },
+          "HELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL",
+            "Submodes": "FMHELL,FSKH105,FSKH245,FSKHELL,HELL80,HELLX5,HELLX9,HFSK,PSKHELL,SLOWHELL"
+          },
+          "ISCAT": {
+            "Enumeration Name": "Mode",
+            "Mode": "ISCAT",
+            "Submodes": "ISCAT-A,ISCAT-B"
+          },
+          "JT4": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4",
+            "Submodes": "JT4A,JT4B,JT4C,JT4D,JT4E,JT4F,JT4G"
+          },
+          "JT6M": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT6M"
+          },
+          "JT9": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT9",
+            "Submodes": "JT9-1,JT9-2,JT9-5,JT9-10,JT9-30,JT9A,JT9B,JT9C,JT9D,JT9E,JT9E FAST,JT9F,JT9F FAST,JT9G,JT9G FAST,JT9H,JT9H FAST"
+          },
+          "JT44": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT44"
+          },
+          "JT65": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65",
+            "Submodes": "JT65A,JT65B,JT65B2,JT65C,JT65C2"
+          },
+          "MFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK",
+            "Submodes": "FSQCALL,FST4,FST4W,FT2,FT4,JS8,JTMS,MFSK4,MFSK8,MFSK11,MFSK16,MFSK22,MFSK31,MFSK32,MFSK64,MFSK64L,MFSK128 MFSK128L,Q65"
+          },
+          "MSK144": {
+            "Enumeration Name": "Mode",
+            "Mode": "MSK144"
+          },
+          "MTONE": {
+            "Enumeration Name": "Mode",
+            "Mode": "MTONE",
+            "Submodes": "SCAMP_OO,SCAMP_OO_SLW",
+            "Description": "Single modulated tone"
+          },
+          "MT63": {
+            "Enumeration Name": "Mode",
+            "Mode": "MT63"
+          },
+          "OFDM": {
+            "Enumeration Name": "Mode",
+            "Mode": "OFDM",
+            "Submodes": "RIBBIT_PIX,RIBBIT_SMS",
+            "Description": "Orthogonal Frequency-Division Multiplexing including COFDM"
+          },
+          "OLIVIA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OLIVIA",
+            "Submodes": "OLIVIA 4/125,OLIVIA 4/250,OLIVIA 8/250,OLIVIA 8/500,OLIVIA 16/500,OLIVIA 16/1000,OLIVIA 32/1000"
+          },
+          "OPERA": {
+            "Enumeration Name": "Mode",
+            "Mode": "OPERA",
+            "Submodes": "OPERA-BEACON,OPERA-QSO"
+          },
+          "PAC": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC",
+            "Submodes": "PAC2,PAC3,PAC4"
+          },
+          "PAX": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX",
+            "Submodes": "PAX2"
+          },
+          "PKT": {
+            "Enumeration Name": "Mode",
+            "Mode": "PKT"
+          },
+          "PSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK",
+            "Submodes": "8PSK125,8PSK125F,8PSK125FL,8PSK250,8PSK250F,8PSK250FL,8PSK500,8PSK500F,8PSK1000,8PSK1000F,8PSK1200F,FSK31,PSK10,PSK31,PSK63,PSK63F,PSK63RC4,PSK63RC5,PSK63RC10,PSK63RC20,PSK63RC32,PSK125,PSK125C12,PSK125R,PSK125RC10,PSK125RC12,PSK125RC16,PSK125RC4,PSK125RC5,PSK250,PSK250C6,PSK250R,PSK250RC2,PSK250RC3,PSK250RC5,PSK250RC6,PSK250RC7,PSK500,PSK500C2,PSK500C4,PSK500R,PSK500RC2,PSK500RC3,PSK500RC4,PSK800C2,PSK800RC2,PSK1000,PSK1000C2,PSK1000R,PSK1000RC2,PSKAM10,PSKAM31,PSKAM50,PSKFEC31,QPSK31,QPSK63,QPSK125,QPSK250,QPSK500,SIM31"
+          },
+          "PSK2K": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK2K"
+          },
+          "Q15": {
+            "Enumeration Name": "Mode",
+            "Mode": "Q15"
+          },
+          "QRA64": {
+            "Enumeration Name": "Mode",
+            "Mode": "QRA64",
+            "Submodes": "QRA64A,QRA64B,QRA64C,QRA64D,QRA64E"
+          },
+          "ROS": {
+            "Enumeration Name": "Mode",
+            "Mode": "ROS",
+            "Submodes": "ROS-EME,ROS-HF,ROS-MF"
+          },
+          "RTTY": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTY",
+            "Submodes": "ASCI"
+          },
+          "RTTYM": {
+            "Enumeration Name": "Mode",
+            "Mode": "RTTYM"
+          },
+          "SSB": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSB",
+            "Submodes": "LSB,USB"
+          },
+          "SSTV": {
+            "Enumeration Name": "Mode",
+            "Mode": "SSTV"
+          },
+          "T10": {
+            "Enumeration Name": "Mode",
+            "Mode": "T10",
+            "Description": "Tonal 10 digital mode with focus on sensitivity, band capacity and resistance to the HF Doppler frequency spread"
+          },
+          "THOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "THOR",
+            "Submodes": "THOR-M,THOR4,THOR5,THOR8,THOR11,THOR16,THOR22,THOR25X4,THOR50X1,THOR50X2,THOR100"
+          },
+          "THRB": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRB",
+            "Submodes": "THRBX,THRBX1,THRBX2,THRBX4,THROB1,THROB2,THROB4"
+          },
+          "TOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "TOR",
+            "Submodes": "AMTORFEC,GTOR,NAVTEX,SITORB"
+          },
+          "V4": {
+            "Enumeration Name": "Mode",
+            "Mode": "V4"
+          },
+          "VOI": {
+            "Enumeration Name": "Mode",
+            "Mode": "VOI"
+          },
+          "WINMOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WINMOR"
+          },
+          "WSPR": {
+            "Enumeration Name": "Mode",
+            "Mode": "WSPR"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Mode",
+            "Mode": "AMTORFEC",
+            "Import-only": "true"
+          },
+          "ASCI": {
+            "Enumeration Name": "Mode",
+            "Mode": "ASCI",
+            "Import-only": "true"
+          },
+          "C4FM": {
+            "Enumeration Name": "Mode",
+            "Mode": "C4FM",
+            "Description": "C4FM 4-level FSK Technology Imported QSOs with \u003CMODE:4\u003EC4FM\u003E must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:4\u003EC4FM",
+            "Import-only": "true"
+          },
+          "CHIP64": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP64",
+            "Import-only": "true"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Mode",
+            "Mode": "CHIP128",
+            "Import-only": "true"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Mode",
+            "Mode": "DOMINOF",
+            "Import-only": "true"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Mode",
+            "Mode": "DSTAR",
+            "Description": "Digital Smart Technologies for Amateur Radio Imported QSOs with \u003CMODE:5\u003EDSTAR must be exported as: \u003CMODE:12\u003EDIGITALVOICE \u003CSUBMODE:5\u003EDSTAR",
+            "Import-only": "true"
+          },
+          "FMHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "FMHELL",
+            "Import-only": "true"
+          },
+          "FSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "FSK31",
+            "Import-only": "true"
+          },
+          "GTOR": {
+            "Enumeration Name": "Mode",
+            "Mode": "GTOR",
+            "Import-only": "true"
+          },
+          "HELL80": {
+            "Enumeration Name": "Mode",
+            "Mode": "HELL80",
+            "Import-only": "true"
+          },
+          "HFSK": {
+            "Enumeration Name": "Mode",
+            "Mode": "HFSK",
+            "Import-only": "true"
+          },
+          "JT4A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4A",
+            "Import-only": "true"
+          },
+          "JT4B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4B",
+            "Import-only": "true"
+          },
+          "JT4C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4C",
+            "Import-only": "true"
+          },
+          "JT4D": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4D",
+            "Import-only": "true"
+          },
+          "JT4E": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4E",
+            "Import-only": "true"
+          },
+          "JT4F": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4F",
+            "Import-only": "true"
+          },
+          "JT4G": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT4G",
+            "Import-only": "true"
+          },
+          "JT65A": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65A",
+            "Import-only": "true"
+          },
+          "JT65B": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65B",
+            "Import-only": "true"
+          },
+          "JT65C": {
+            "Enumeration Name": "Mode",
+            "Mode": "JT65C",
+            "Import-only": "true"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK8",
+            "Import-only": "true"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Mode",
+            "Mode": "MFSK16",
+            "Import-only": "true"
+          },
+          "PAC2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC2",
+            "Import-only": "true"
+          },
+          "PAC3": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAC3",
+            "Import-only": "true"
+          },
+          "PAX2": {
+            "Enumeration Name": "Mode",
+            "Mode": "PAX2",
+            "Import-only": "true"
+          },
+          "PCW": {
+            "Enumeration Name": "Mode",
+            "Mode": "PCW",
+            "Import-only": "true"
+          },
+          "PSK10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK10",
+            "Import-only": "true"
+          },
+          "PSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK31",
+            "Import-only": "true"
+          },
+          "PSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63",
+            "Import-only": "true"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK63F",
+            "Import-only": "true"
+          },
+          "PSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSK125",
+            "Import-only": "true"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM10",
+            "Import-only": "true"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM31",
+            "Import-only": "true"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKAM50",
+            "Import-only": "true"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKFEC31",
+            "Import-only": "true"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Mode",
+            "Mode": "PSKHELL",
+            "Import-only": "true"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK31",
+            "Import-only": "true"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK63",
+            "Import-only": "true"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Mode",
+            "Mode": "QPSK125",
+            "Import-only": "true"
+          },
+          "THRBX": {
+            "Enumeration Name": "Mode",
+            "Mode": "THRBX",
+            "Import-only": "true"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_morse_key_type.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_morse_key_type.json
@@ -1,0 +1,82 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:40Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Morse_Key_Type": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Characteristics",
+          "Morse Composition",
+          "Examples",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "SK": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SK",
+            "Meaning": "Straight Key",
+            "Characteristics": "a single control which actuates a single switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "Lionel J-38"
+          },
+          "SS": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SS",
+            "Meaning": "Sideswiper",
+            "Characteristics": "a single control which actuates a SPDT (single poll, double throw) switch.",
+            "Morse Composition": "a human makes the dits and dahs and builds characters",
+            "Examples": "W1SFR Green Machine Torsion Bar Cootie"
+          },
+          "BUG": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "BUG",
+            "Meaning": "Mechanical semi-automatic keyer or Bug",
+            "Characteristics": "a control which actuates a switch as well as a control which actuates a spring and pendulum mechanism which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and a human makes the dahs and builds characters.",
+            "Examples": "Vibroplex Blue Racer Deluxe"
+          },
+          "FAB": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "FAB",
+            "Meaning": "Mechanical fully-automatic keyer or Bug",
+            "Characteristics": "a control which actuates one of two separate spring and pendulum mechanisms at a time, each of which actuates a switch. Both switches are wired in parallel.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds characters.",
+            "Examples": "GHD GN209FA fully-automatic bug"
+          },
+          "SP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "SP",
+            "Meaning": "Single Paddle",
+            "Characteristics": "a single control which actuates two independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "American Morse Mini-B"
+          },
+          "DP": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "DP",
+            "Meaning": "Dual Paddle",
+            "Characteristics": "two controls which actuate independent switches.",
+            "Morse Composition": "a machine makes the dits and the dahs and a human builds the characters.",
+            "Examples": "Begali Sculpture, VK3IL pressure paddles, M0UKD capacitive touch paddles"
+          },
+          "CPU": {
+            "Enumeration Name": "Morse_Key_Type",
+            "Abbreviation": "CPU",
+            "Meaning": "Computer Driven",
+            "Characteristics": "an electronic device performs the actuation of the switch.",
+            "Morse Composition": "a machine makes the dits and dahs to build the characters.",
+            "Examples": "N1MM\u002B Logging Software"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_primary_administrative_subdivision.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_primary_administrative_subdivision.json
@@ -1,0 +1,13460 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:47Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Primary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Primary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Contained Within",
+          "Oblast #",
+          "CQ Zone",
+          "ITU Zone",
+          "Prefix",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NS.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Nova Scotia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "QC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QC",
+            "Primary Administrative Subdivision": "Québec",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "04,09"
+          },
+          "ON.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ON",
+            "Primary Administrative Subdivision": "Ontario",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "MB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Manitoba",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03,04"
+          },
+          "SK.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Saskatchewan",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "03"
+          },
+          "AB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alberta",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "04",
+            "ITU Zone": "02"
+          },
+          "BC.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "British Columbia",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "03",
+            "ITU Zone": "02"
+          },
+          "NT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northwest Territories",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01,02,04",
+            "ITU Zone": "03,04,75"
+          },
+          "NB.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "New Brunswick",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NL.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Newfoundland and Labrador",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02,05",
+            "ITU Zone": "09"
+          },
+          "YT.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YT",
+            "Primary Administrative Subdivision": "Yukon",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "01",
+            "ITU Zone": "02"
+          },
+          "PE.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Prince Edward Island",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "05",
+            "ITU Zone": "09"
+          },
+          "NU.1": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nunavut",
+            "DXCC Entity Code": "1",
+            "CQ Zone": "02",
+            "ITU Zone": "04,09"
+          },
+          "001.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "001",
+            "Primary Administrative Subdivision": "Brändö",
+            "DXCC Entity Code": "5"
+          },
+          "002.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "002",
+            "Primary Administrative Subdivision": "Eckerö",
+            "DXCC Entity Code": "5"
+          },
+          "003.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "003",
+            "Primary Administrative Subdivision": "Finström",
+            "DXCC Entity Code": "5"
+          },
+          "004.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "004",
+            "Primary Administrative Subdivision": "Föglö",
+            "DXCC Entity Code": "5"
+          },
+          "005.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "005",
+            "Primary Administrative Subdivision": "Geta",
+            "DXCC Entity Code": "5"
+          },
+          "006.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "006",
+            "Primary Administrative Subdivision": "Hammarland",
+            "DXCC Entity Code": "5"
+          },
+          "007.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "007",
+            "Primary Administrative Subdivision": "Jomala",
+            "DXCC Entity Code": "5"
+          },
+          "008.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "008",
+            "Primary Administrative Subdivision": "Kumlinge",
+            "DXCC Entity Code": "5"
+          },
+          "009.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "009",
+            "Primary Administrative Subdivision": "Kökar",
+            "DXCC Entity Code": "5"
+          },
+          "010.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "010",
+            "Primary Administrative Subdivision": "Lemland",
+            "DXCC Entity Code": "5"
+          },
+          "011.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "011",
+            "Primary Administrative Subdivision": "Lumparland",
+            "DXCC Entity Code": "5"
+          },
+          "012.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "012",
+            "Primary Administrative Subdivision": "Maarianhamina",
+            "DXCC Entity Code": "5"
+          },
+          "013.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "013",
+            "Primary Administrative Subdivision": "Saltvik",
+            "DXCC Entity Code": "5"
+          },
+          "014.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "014",
+            "Primary Administrative Subdivision": "Sottunga",
+            "DXCC Entity Code": "5"
+          },
+          "015.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Sund",
+            "DXCC Entity Code": "5"
+          },
+          "016.5": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "016",
+            "Primary Administrative Subdivision": "Vårdö",
+            "DXCC Entity Code": "5"
+          },
+          "051.5.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "051",
+            "Primary Administrative Subdivision": "Märket",
+            "DXCC Entity Code": "5",
+            "Deleted": "true"
+          },
+          "AK.6": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AK",
+            "Primary Administrative Subdivision": "Alaska",
+            "DXCC Entity Code": "6"
+          },
+          "AN.11": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Andaman and Nicobar Islands",
+            "DXCC Entity Code": "11",
+            "Comments": "Union territory"
+          },
+          "UO.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UO",
+            "Primary Administrative Subdivision": "Ust’-Ordynsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "174",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-01-01"
+          },
+          "AB.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Aginsky Buryatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "175",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2008-03-01"
+          },
+          "CB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Chelyabinsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "165",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Chelyabinskaya oblast"
+          },
+          "SV.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Sverdlovskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "154",
+            "CQ Zone": "17",
+            "ITU Zone": "30"
+          },
+          "PM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Perm\u0060",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "for contacts made on or after 2005-12-01; Permskaya oblast"
+          },
+          "PM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PM",
+            "Primary Administrative Subdivision": "Permskaya Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "140",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "KP.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KP",
+            "Primary Administrative Subdivision": "Komi-Permyatsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "141",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2005-12-01"
+          },
+          "TO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tomsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "158",
+            "CQ Zone": "18",
+            "ITU Zone": "30",
+            "Comments": "Tomskaya oblast"
+          },
+          "HM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khanty-Mansyisky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "162",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "YN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yamalo-Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "163",
+            "CQ Zone": "17",
+            "ITU Zone": "21"
+          },
+          "TN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tyumen\u0027",
+            "DXCC Entity Code": "15",
+            "Oblast #": "161",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Tyumenskaya oblast"
+          },
+          "OM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OM",
+            "Primary Administrative Subdivision": "Omsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "146",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Omskaya oblast"
+          },
+          "NS.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NS",
+            "Primary Administrative Subdivision": "Novosibirsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "145",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Novosibirskaya oblast"
+          },
+          "KN.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KN",
+            "Primary Administrative Subdivision": "Kurgan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "134",
+            "CQ Zone": "17",
+            "ITU Zone": "30",
+            "Comments": "Kurganskaya oblast"
+          },
+          "OB.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OB",
+            "Primary Administrative Subdivision": "Orenburg",
+            "DXCC Entity Code": "15",
+            "Oblast #": "167",
+            "CQ Zone": "S=16 T=17",
+            "ITU Zone": "30",
+            "Comments": "Orenburgskaya oblast"
+          },
+          "KE.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kemerovo",
+            "DXCC Entity Code": "15",
+            "Oblast #": "130",
+            "CQ Zone": "18",
+            "ITU Zone": "31",
+            "Comments": "Kemerovskaya oblast"
+          },
+          "BA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Republic of Bashkortostan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "84",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "KO.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Republic of Komi",
+            "DXCC Entity Code": "15",
+            "Oblast #": "90",
+            "CQ Zone": "17",
+            "ITU Zone": "20"
+          },
+          "AL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Altaysky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "99",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "GA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Republic Gorny Altay",
+            "DXCC Entity Code": "15",
+            "Oblast #": "100",
+            "CQ Zone": "18",
+            "ITU Zone": "31"
+          },
+          "KK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Krasnoyarsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "103",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Krasnoyarsk Kraj"
+          },
+          "TM.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Taymyr Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "105",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "HK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HK",
+            "Primary Administrative Subdivision": "Khabarovsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "110",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Khabarovsky Kraj"
+          },
+          "EA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EA",
+            "Primary Administrative Subdivision": "Yevreyskaya Autonomous Oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "111",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "SL.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sakhalin",
+            "DXCC Entity Code": "15",
+            "Oblast #": "153",
+            "CQ Zone": "19",
+            "ITU Zone": "34",
+            "Comments": "Sakhalinskaya oblast"
+          },
+          "EV.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evenkiysky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "106",
+            "CQ Zone": "18",
+            "ITU Zone": "22",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "MG.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Magadan",
+            "DXCC Entity Code": "15",
+            "Oblast #": "138",
+            "CQ Zone": "19",
+            "ITU Zone": "24",
+            "Comments": "Magadanskaya oblast"
+          },
+          "AM.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amurskaya oblast",
+            "DXCC Entity Code": "15",
+            "Oblast #": "112",
+            "CQ Zone": "19",
+            "ITU Zone": "33"
+          },
+          "CK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CK",
+            "Primary Administrative Subdivision": "Chukotka Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "139",
+            "CQ Zone": "19",
+            "ITU Zone": "26"
+          },
+          "PK.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Primorsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "107",
+            "CQ Zone": "19",
+            "ITU Zone": "34"
+          },
+          "BU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Republic of Buryatia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "85",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "YA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Republic of Sakha",
+            "DXCC Entity Code": "15",
+            "Oblast #": "98",
+            "CQ Zone": "19",
+            "ITU Zone": "32"
+          },
+          "IR.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IR",
+            "Primary Administrative Subdivision": "Irkutsk",
+            "DXCC Entity Code": "15",
+            "Oblast #": "124",
+            "CQ Zone": "18",
+            "ITU Zone": "32",
+            "Comments": "Irkutskaya oblast"
+          },
+          "CT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Zabaykalsky Kraj",
+            "DXCC Entity Code": "15",
+            "Oblast #": "166",
+            "CQ Zone": "18",
+            "ITU Zone": "33",
+            "Comments": "referred to as Chita (Chitinskaya oblast) before 2008-03-01"
+          },
+          "HA.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Republic of Khakassia",
+            "DXCC Entity Code": "15",
+            "Oblast #": "104",
+            "CQ Zone": "18",
+            "ITU Zone": "32"
+          },
+          "KY.15.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Koryaksky Autonomous Okrug",
+            "DXCC Entity Code": "15",
+            "Oblast #": "129",
+            "CQ Zone": "19",
+            "ITU Zone": "25",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2007-01-01"
+          },
+          "TU.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Republic of Tuva",
+            "DXCC Entity Code": "15",
+            "Oblast #": "159",
+            "CQ Zone": "23",
+            "ITU Zone": "32"
+          },
+          "KT.15": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KT",
+            "Primary Administrative Subdivision": "Kamchatka",
+            "DXCC Entity Code": "15",
+            "Oblast #": "128",
+            "CQ Zone": "19",
+            "ITU Zone": "35",
+            "Comments": "Kamchatskaya oblast"
+          },
+          "IB.21": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IB",
+            "Primary Administrative Subdivision": "Balears",
+            "DXCC Entity Code": "21"
+          },
+          "MI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Minsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Minskaya voblasts\u0027"
+          },
+          "BR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brest",
+            "DXCC Entity Code": "27",
+            "Comments": "Brestskaya voblasts\u0027"
+          },
+          "HR.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Grodno",
+            "DXCC Entity Code": "27",
+            "Comments": "Hrodzenskaya voblasts\u0027"
+          },
+          "VI.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vitebsk",
+            "DXCC Entity Code": "27",
+            "Comments": "Vitsyebskaya voblasts\u0027"
+          },
+          "MA.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mogilev",
+            "DXCC Entity Code": "27",
+            "Comments": "Mahilyowskaya voblasts\u0027"
+          },
+          "HO.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Gomel",
+            "DXCC Entity Code": "27",
+            "Comments": "Homyel\u0027skaya voblasts\u0027"
+          },
+          "HM.27": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Horad Minsk",
+            "DXCC Entity Code": "27"
+          },
+          "GC.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Las Palmas",
+            "DXCC Entity Code": "29"
+          },
+          "TF.29": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TF",
+            "Primary Administrative Subdivision": "Santa Cruz de Tenerife",
+            "DXCC Entity Code": "29"
+          },
+          "CE.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceuta",
+            "DXCC Entity Code": "32"
+          },
+          "ML.32": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Melilla",
+            "DXCC Entity Code": "32"
+          },
+          "COL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COL",
+            "Primary Administrative Subdivision": "Colima",
+            "DXCC Entity Code": "50"
+          },
+          "DF.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "50",
+            "Import-only": "true",
+            "Comments": "replaced by CMX"
+          },
+          "CMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CMX",
+            "Primary Administrative Subdivision": "Ciudad de México",
+            "DXCC Entity Code": "50"
+          },
+          "EMX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMX",
+            "Primary Administrative Subdivision": "Estado de México",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "MEX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MEX",
+            "Primary Administrative Subdivision": "México",
+            "DXCC Entity Code": "50"
+          },
+          "GTO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTO",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "GUA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUA",
+            "Primary Administrative Subdivision": "Guanajuato",
+            "DXCC Entity Code": "50"
+          },
+          "HGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HGO",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "HID.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HID",
+            "Primary Administrative Subdivision": "Hidalgo",
+            "DXCC Entity Code": "50"
+          },
+          "JAL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JAL",
+            "Primary Administrative Subdivision": "Jalisco",
+            "DXCC Entity Code": "50"
+          },
+          "MIC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michoacán de Ocampo",
+            "DXCC Entity Code": "50"
+          },
+          "MOR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOR",
+            "Primary Administrative Subdivision": "Morelos",
+            "DXCC Entity Code": "50"
+          },
+          "NAY.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAY",
+            "Primary Administrative Subdivision": "Nayarit",
+            "DXCC Entity Code": "50"
+          },
+          "PUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUE",
+            "Primary Administrative Subdivision": "Puebla",
+            "DXCC Entity Code": "50"
+          },
+          "QRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QRO",
+            "Primary Administrative Subdivision": "Querétaro de Arteaga",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "QUE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Querétaro",
+            "DXCC Entity Code": "50"
+          },
+          "TLX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLX",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TLA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TLA",
+            "Primary Administrative Subdivision": "Tlaxcala",
+            "DXCC Entity Code": "50"
+          },
+          "VER.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VER",
+            "Primary Administrative Subdivision": "Veracruz de Ignacio de la Llave",
+            "DXCC Entity Code": "50"
+          },
+          "AGS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "AGU.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGU",
+            "Primary Administrative Subdivision": "Aguascalientes",
+            "DXCC Entity Code": "50"
+          },
+          "BC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "BCN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCN",
+            "Primary Administrative Subdivision": "Baja California",
+            "DXCC Entity Code": "50"
+          },
+          "BCS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BCS",
+            "Primary Administrative Subdivision": "Baja California Sur",
+            "DXCC Entity Code": "50"
+          },
+          "CHH.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHH",
+            "Primary Administrative Subdivision": "Chihuahua",
+            "DXCC Entity Code": "50"
+          },
+          "COA.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COA",
+            "Primary Administrative Subdivision": "Coahuila de Zaragoza",
+            "DXCC Entity Code": "50"
+          },
+          "DGO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DGO",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "DUR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DUR",
+            "Primary Administrative Subdivision": "Durango",
+            "DXCC Entity Code": "50"
+          },
+          "NL.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nuevo Leon",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "NLE.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NLE",
+            "Primary Administrative Subdivision": "Nuevo León",
+            "DXCC Entity Code": "50"
+          },
+          "SLP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLP",
+            "Primary Administrative Subdivision": "San Luis Potosí",
+            "DXCC Entity Code": "50"
+          },
+          "SIN.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIN",
+            "Primary Administrative Subdivision": "Sinaloa",
+            "DXCC Entity Code": "50"
+          },
+          "SON.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SON",
+            "Primary Administrative Subdivision": "Sonora",
+            "DXCC Entity Code": "50"
+          },
+          "TMS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TMS",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "TAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAM",
+            "Primary Administrative Subdivision": "Tamaulipas",
+            "DXCC Entity Code": "50"
+          },
+          "ZAC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAC",
+            "Primary Administrative Subdivision": "Zacatecas",
+            "DXCC Entity Code": "50"
+          },
+          "CAM.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Campeche",
+            "DXCC Entity Code": "50"
+          },
+          "CHS.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHS",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "CHP.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHP",
+            "Primary Administrative Subdivision": "Chiapas",
+            "DXCC Entity Code": "50"
+          },
+          "GRO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GRO",
+            "Primary Administrative Subdivision": "Guerrero",
+            "DXCC Entity Code": "50"
+          },
+          "OAX.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OAX",
+            "Primary Administrative Subdivision": "Oaxaca",
+            "DXCC Entity Code": "50"
+          },
+          "QTR.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QTR",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50",
+            "Import-only": "true"
+          },
+          "ROO.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROO",
+            "Primary Administrative Subdivision": "Quintana Roo",
+            "DXCC Entity Code": "50"
+          },
+          "TAB.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAB",
+            "Primary Administrative Subdivision": "Tabasco",
+            "DXCC Entity Code": "50"
+          },
+          "YUC.50": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUC",
+            "Primary Administrative Subdivision": "Yucatán",
+            "DXCC Entity Code": "50"
+          },
+          "SP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "City of St. Petersburg",
+            "DXCC Entity Code": "54",
+            "Oblast #": "169",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "LO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "136",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Republic of Karelia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "88",
+            "CQ Zone": "16",
+            "ITU Zone": "19"
+          },
+          "AR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "113",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "NO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Nenetsky Autonomous Okrug",
+            "DXCC Entity Code": "54",
+            "Oblast #": "114",
+            "CQ Zone": "16",
+            "ITU Zone": "20"
+          },
+          "VO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Vologda",
+            "DXCC Entity Code": "54",
+            "Oblast #": "120",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vologodskaya oblast"
+          },
+          "NV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Novgorodskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "144",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "PS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pskov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "149",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Pskovskaya oblast"
+          },
+          "MU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murmansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "143",
+            "CQ Zone": "16",
+            "ITU Zone": "19",
+            "Comments": "Murmanskaya oblast"
+          },
+          "MA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "City of Moscow",
+            "DXCC Entity Code": "54",
+            "Oblast #": "170",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Moscowskaya oblast",
+            "DXCC Entity Code": "54",
+            "Oblast #": "142",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "OR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oryel",
+            "DXCC Entity Code": "54",
+            "Oblast #": "147",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Orlovskaya oblast"
+          },
+          "LP.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LP",
+            "Primary Administrative Subdivision": "Lipetsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "137",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Lipetskaya oblast"
+          },
+          "TV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Tver\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "126",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tverskaya oblast"
+          },
+          "SM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smolensk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "155",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Smolenskaya oblast"
+          },
+          "YR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YR",
+            "Primary Administrative Subdivision": "Yaroslavl",
+            "DXCC Entity Code": "54",
+            "Oblast #": "168",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Yaroslavskaya oblast"
+          },
+          "KS.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kostroma",
+            "DXCC Entity Code": "54",
+            "Oblast #": "132",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kostromskaya oblast"
+          },
+          "TL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tula",
+            "DXCC Entity Code": "54",
+            "Oblast #": "160",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tul\u0027skaya oblast"
+          },
+          "VR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Voronezh",
+            "DXCC Entity Code": "54",
+            "Oblast #": "121",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Voronezhskaya oblast"
+          },
+          "TB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TB",
+            "Primary Administrative Subdivision": "Tambov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "157",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Tambovskaya oblast"
+          },
+          "RA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ryazan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "151",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ryazanskaya oblast"
+          },
+          "NN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NN",
+            "Primary Administrative Subdivision": "Nizhni Novgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "122",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Nizhegorodskaya oblast"
+          },
+          "IV.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Ivanovo",
+            "DXCC Entity Code": "54",
+            "Oblast #": "123",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ivanovskaya oblast"
+          },
+          "VL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vladimir",
+            "DXCC Entity Code": "54",
+            "Oblast #": "119",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Vladimirskaya oblast"
+          },
+          "KU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kursk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "135",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kurskaya oblast"
+          },
+          "KG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KG",
+            "Primary Administrative Subdivision": "Kaluga",
+            "DXCC Entity Code": "54",
+            "Oblast #": "127",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Kaluzhskaya oblast"
+          },
+          "BR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bryansk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "118",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Bryanskaya oblast"
+          },
+          "BO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Belgorod",
+            "DXCC Entity Code": "54",
+            "Oblast #": "117",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Belgorodskaya oblast"
+          },
+          "VG.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VG",
+            "Primary Administrative Subdivision": "Volgograd",
+            "DXCC Entity Code": "54",
+            "Oblast #": "156",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Volgogradskaya oblast"
+          },
+          "SA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Saratov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "152",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Saratovskaya oblast"
+          },
+          "PE.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Penza",
+            "DXCC Entity Code": "54",
+            "Oblast #": "148",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Penzenskaya oblast"
+          },
+          "SR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Samara",
+            "DXCC Entity Code": "54",
+            "Oblast #": "133",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Samarskaya oblast"
+          },
+          "UL.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UL",
+            "Primary Administrative Subdivision": "Ulyanovsk",
+            "DXCC Entity Code": "54",
+            "Oblast #": "164",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Ulyanovskaya oblast"
+          },
+          "KI.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirov",
+            "DXCC Entity Code": "54",
+            "Oblast #": "131",
+            "CQ Zone": "16",
+            "ITU Zone": "30",
+            "Comments": "Kirovskaya oblast"
+          },
+          "TA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Republic of Tataria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "94",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "MR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MR",
+            "Primary Administrative Subdivision": "Republic of Marij-El",
+            "DXCC Entity Code": "54",
+            "Oblast #": "91",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "MD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Republic of Mordovia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "92",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "UD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Republic of Udmurtia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "95",
+            "CQ Zone": "16",
+            "ITU Zone": "30"
+          },
+          "CU.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Republic of Chuvashia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "97",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KR.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krasnodar",
+            "DXCC Entity Code": "54",
+            "Oblast #": "101",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Krasnodarsky Kraj"
+          },
+          "KC.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Republic of Karachaevo-Cherkessia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "109",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "ST.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Stavropol\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "108",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Stavropolsky Kraj"
+          },
+          "KM.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KM",
+            "Primary Administrative Subdivision": "Republic of Kalmykia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "89",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "SO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Republic of Northern Ossetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "93",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "RO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rostov-on-Don",
+            "DXCC Entity Code": "54",
+            "Oblast #": "150",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Rostovskaya oblast"
+          },
+          "CN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Republic Chechnya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "IN.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Republic of Ingushetia",
+            "DXCC Entity Code": "54",
+            "Oblast #": "96",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AO.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Astrakhan\u0027",
+            "DXCC Entity Code": "54",
+            "Oblast #": "115",
+            "CQ Zone": "16",
+            "ITU Zone": "29",
+            "Comments": "Astrakhanskaya oblast"
+          },
+          "DA.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Republic of Daghestan",
+            "DXCC Entity Code": "54",
+            "Oblast #": "86",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "KB.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Republic of Kabardino-Balkaria",
+            "DXCC Entity Code": "54",
+            "Oblast #": "87",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AD.54": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AD",
+            "Primary Administrative Subdivision": "Republic of Adygeya",
+            "DXCC Entity Code": "54",
+            "Oblast #": "102",
+            "CQ Zone": "16",
+            "ITU Zone": "29"
+          },
+          "AR.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkhangelsk",
+            "DXCC Entity Code": "61",
+            "Comments": "Arkhangelskaya oblast"
+          },
+          "FJL.61": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJL",
+            "Primary Administrative Subdivision": "Franz Josef Land",
+            "DXCC Entity Code": "61",
+            "Import-only": "true"
+          },
+          "15.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Artemisa",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "09.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Camagüey",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "08.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ciego de Ávila",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "06.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Cienfuegos",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "12.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Granma",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "14.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Guantánamo",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "11.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Holguín",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "99.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "99",
+            "Primary Administrative Subdivision": "Isla de la Juventud",
+            "DXCC Entity Code": "70",
+            "Comments": "special municipality"
+          },
+          "03.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "La Habana",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "10.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Las Tunas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "04.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Matanzas",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "16.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Mayabeque",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "01.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Pinar del Río",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "07.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Sancti Spíritus",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "13.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Santiago de Cuba",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "05.70": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Villa Clara",
+            "DXCC Entity Code": "70",
+            "Comments": "province"
+          },
+          "C.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Capital federal",
+            "DXCC Entity Code": "100",
+            "Comments": "Buenos Aires City"
+          },
+          "B.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Buenos Aires Province",
+            "DXCC Entity Code": "100"
+          },
+          "S.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Santa Fe",
+            "DXCC Entity Code": "100"
+          },
+          "H.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chaco",
+            "DXCC Entity Code": "100"
+          },
+          "P.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Formosa",
+            "DXCC Entity Code": "100"
+          },
+          "X.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "100"
+          },
+          "N.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "100"
+          },
+          "E.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Entre Ríos",
+            "DXCC Entity Code": "100"
+          },
+          "T.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tucumán",
+            "DXCC Entity Code": "100"
+          },
+          "W.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Corrientes",
+            "DXCC Entity Code": "100"
+          },
+          "M.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Mendoza",
+            "DXCC Entity Code": "100"
+          },
+          "G.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Santiago del Estero",
+            "DXCC Entity Code": "100"
+          },
+          "A.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Salta",
+            "DXCC Entity Code": "100"
+          },
+          "J.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "San Juan",
+            "DXCC Entity Code": "100"
+          },
+          "D.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "San Luis",
+            "DXCC Entity Code": "100"
+          },
+          "K.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Catamarca",
+            "DXCC Entity Code": "100"
+          },
+          "F.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "100"
+          },
+          "Y.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Jujuy",
+            "DXCC Entity Code": "100"
+          },
+          "L.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "La Pampa",
+            "DXCC Entity Code": "100"
+          },
+          "R.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "100"
+          },
+          "U.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Chubut",
+            "DXCC Entity Code": "100"
+          },
+          "Z.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Santa Cruz",
+            "DXCC Entity Code": "100"
+          },
+          "V.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Tierra del Fuego",
+            "DXCC Entity Code": "100"
+          },
+          "Q.100": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Neuquén",
+            "DXCC Entity Code": "100"
+          },
+          "ES.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ES",
+            "Primary Administrative Subdivision": "Espírito Santo",
+            "DXCC Entity Code": "108"
+          },
+          "GO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Goiás",
+            "DXCC Entity Code": "108"
+          },
+          "SC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Santa Catarina",
+            "DXCC Entity Code": "108"
+          },
+          "SE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sergipe",
+            "DXCC Entity Code": "108"
+          },
+          "AL.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alagoas",
+            "DXCC Entity Code": "108"
+          },
+          "AM.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "108"
+          },
+          "TO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tocantins",
+            "DXCC Entity Code": "108"
+          },
+          "AP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Amapá",
+            "DXCC Entity Code": "108"
+          },
+          "PB.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Paraíba",
+            "DXCC Entity Code": "108"
+          },
+          "MA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maranhão",
+            "DXCC Entity Code": "108"
+          },
+          "RN.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rio Grande do Norte",
+            "DXCC Entity Code": "108"
+          },
+          "PI.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Piauí",
+            "DXCC Entity Code": "108"
+          },
+          "DF.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DF",
+            "Primary Administrative Subdivision": "Distrito Federal",
+            "DXCC Entity Code": "108"
+          },
+          "CE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Ceará",
+            "DXCC Entity Code": "108"
+          },
+          "AC.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Acre",
+            "DXCC Entity Code": "108"
+          },
+          "MS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mato Grosso do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "RR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RR",
+            "Primary Administrative Subdivision": "Roraima",
+            "DXCC Entity Code": "108"
+          },
+          "RO.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rondônia",
+            "DXCC Entity Code": "108"
+          },
+          "RJ.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rio de Janeiro",
+            "DXCC Entity Code": "108"
+          },
+          "SP.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "São Paulo",
+            "DXCC Entity Code": "108"
+          },
+          "RS.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Rio Grande do Sul",
+            "DXCC Entity Code": "108"
+          },
+          "MG.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MG",
+            "Primary Administrative Subdivision": "Minas Gerais",
+            "DXCC Entity Code": "108"
+          },
+          "PR.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Paraná",
+            "DXCC Entity Code": "108"
+          },
+          "BA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bahia",
+            "DXCC Entity Code": "108"
+          },
+          "PE.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pernambuco",
+            "DXCC Entity Code": "108"
+          },
+          "PA.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pará",
+            "DXCC Entity Code": "108"
+          },
+          "MT.108": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Mato Grosso",
+            "DXCC Entity Code": "108"
+          },
+          "HI.110": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hawaii",
+            "DXCC Entity Code": "110"
+          },
+          "II.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "II",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AN.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antofagasta",
+            "DXCC Entity Code": "112"
+          },
+          "III.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "III",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AT.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Atacama",
+            "DXCC Entity Code": "112"
+          },
+          "I.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "TA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tarapacá",
+            "DXCC Entity Code": "112"
+          },
+          "XV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XV",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AP.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Arica y Parinacota",
+            "DXCC Entity Code": "112"
+          },
+          "IV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IV",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "CO.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coquimbo",
+            "DXCC Entity Code": "112"
+          },
+          "V.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "VS.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Valparaíso",
+            "DXCC Entity Code": "112"
+          },
+          "RM.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Region Metropolitana de Santiago",
+            "DXCC Entity Code": "112"
+          },
+          "VI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Libertador General Bernardo O\u0027Higgins",
+            "DXCC Entity Code": "112"
+          },
+          "VII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VII",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "ML.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Maule",
+            "DXCC Entity Code": "112"
+          },
+          "VIII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIII",
+            "Primary Administrative Subdivision": "Bío-Bío",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "BI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biobío",
+            "DXCC Entity Code": "112"
+          },
+          "IX.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IX",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "La Araucanía",
+            "DXCC Entity Code": "112"
+          },
+          "XIV.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XIV",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LR.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Los Ríos",
+            "DXCC Entity Code": "112"
+          },
+          "X.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "LL.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Los Lagos",
+            "DXCC Entity Code": "112"
+          },
+          "XI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibáñez del Campo",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "AI.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Aisén del General Carlos Ibañez del Campo",
+            "DXCC Entity Code": "112"
+          },
+          "XII.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XII",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112",
+            "Import-only": "true"
+          },
+          "MA.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Magallanes",
+            "DXCC Entity Code": "112"
+          },
+          "NB.112": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Ñuble",
+            "DXCC Entity Code": "112"
+          },
+          "22.118": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Jan Mayen",
+            "DXCC Entity Code": "118"
+          },
+          "KA.126": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kalingrad",
+            "DXCC Entity Code": "126",
+            "Oblast #": "125",
+            "CQ Zone": "15",
+            "ITU Zone": "29",
+            "Comments": "Kaliningradskaya oblast"
+          },
+          "16.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Alto Paraguay",
+            "DXCC Entity Code": "132"
+          },
+          "19.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Boquerón",
+            "DXCC Entity Code": "132"
+          },
+          "15.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Presidente Hayes",
+            "DXCC Entity Code": "132"
+          },
+          "13.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Amambay",
+            "DXCC Entity Code": "132"
+          },
+          "01.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "1.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "1",
+            "Primary Administrative Subdivision": "Concepción",
+            "DXCC Entity Code": "132"
+          },
+          "14.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Canindeyú",
+            "DXCC Entity Code": "132"
+          },
+          "02.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "2.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2",
+            "Primary Administrative Subdivision": "San Pedro",
+            "DXCC Entity Code": "132"
+          },
+          "ASU.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ASU",
+            "Primary Administrative Subdivision": "Asunción",
+            "DXCC Entity Code": "132"
+          },
+          "11.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "132"
+          },
+          "03.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "3.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "3",
+            "Primary Administrative Subdivision": "Cordillera",
+            "DXCC Entity Code": "132"
+          },
+          "09.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "9.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "9",
+            "Primary Administrative Subdivision": "Paraguarí",
+            "DXCC Entity Code": "132"
+          },
+          "06.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Caazapl",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "6.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "6",
+            "Primary Administrative Subdivision": "Caazapá",
+            "DXCC Entity Code": "132"
+          },
+          "05.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "5.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "5",
+            "Primary Administrative Subdivision": "Caeguazú",
+            "DXCC Entity Code": "132"
+          },
+          "04.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "4.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "4",
+            "Primary Administrative Subdivision": "Guairá",
+            "DXCC Entity Code": "132"
+          },
+          "08.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Miaiones",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "8.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "8",
+            "Primary Administrative Subdivision": "Misiones",
+            "DXCC Entity Code": "132"
+          },
+          "12.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Ñeembucú",
+            "DXCC Entity Code": "132"
+          },
+          "10.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Alto Paraná",
+            "DXCC Entity Code": "132"
+          },
+          "07.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Itapua",
+            "DXCC Entity Code": "132",
+            "Import-only": "true"
+          },
+          "7.132": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "7",
+            "Primary Administrative Subdivision": "Itapúa",
+            "DXCC Entity Code": "132"
+          },
+          "A.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Seoul",
+            "DXCC Entity Code": "137",
+            "Comments": "Seoul Teugbyeolsi"
+          },
+          "N.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Inchon",
+            "DXCC Entity Code": "137",
+            "Comments": "Incheon Gwang\u0027yeogsi"
+          },
+          "D.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Kangwon-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gang \u0027weondo"
+          },
+          "C.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Kyunggi-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeonggido"
+          },
+          "E.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Choongchungbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongbugdo"
+          },
+          "F.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Choongchungnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Chungcheongnamdo"
+          },
+          "R.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Taejon",
+            "DXCC Entity Code": "137",
+            "Comments": "Daejeon Gwang\u0027yeogsi"
+          },
+          "M.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Cheju-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jejudo"
+          },
+          "G.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Chollabuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonrabugdo"
+          },
+          "H.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Chollanam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Jeonranamdo"
+          },
+          "Q.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Q",
+            "Primary Administrative Subdivision": "Kwangju",
+            "DXCC Entity Code": "137",
+            "Comments": "Gwangju Gwang\u0027yeogsi"
+          },
+          "K.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Kyungsangbuk-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangbugdo"
+          },
+          "L.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Kyungsangnam-do",
+            "DXCC Entity Code": "137",
+            "Comments": "Gyeongsangnamdo"
+          },
+          "B.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Pusan",
+            "DXCC Entity Code": "137",
+            "Comments": "Busan Gwang\u0027yeogsi"
+          },
+          "P.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Taegu",
+            "DXCC Entity Code": "137",
+            "Comments": "Daegu Gwang\u0027yeogsi"
+          },
+          "S.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Ulsan",
+            "DXCC Entity Code": "137",
+            "Comments": "Ulsan Gwanq\u0027yeogsi"
+          },
+          "T.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Sejong",
+            "DXCC Entity Code": "137"
+          },
+          "IS.137": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Special Island",
+            "DXCC Entity Code": "137"
+          },
+          "KI.138": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kure Island",
+            "DXCC Entity Code": "138"
+          },
+          "LD.142": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Lakshadweep",
+            "DXCC Entity Code": "142",
+            "Comments": "Union territory"
+          },
+          "MO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Montevideo",
+            "DXCC Entity Code": "144"
+          },
+          "CA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Canelones",
+            "DXCC Entity Code": "144"
+          },
+          "SJ.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "San José",
+            "DXCC Entity Code": "144"
+          },
+          "CO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colonia",
+            "DXCC Entity Code": "144"
+          },
+          "SO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soriano",
+            "DXCC Entity Code": "144"
+          },
+          "RN.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Río Negro",
+            "DXCC Entity Code": "144"
+          },
+          "PA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Paysandú",
+            "DXCC Entity Code": "144"
+          },
+          "SA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salto",
+            "DXCC Entity Code": "144"
+          },
+          "AR.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Artigas",
+            "DXCC Entity Code": "144"
+          },
+          "FD.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FD",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "144"
+          },
+          "FS.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FS",
+            "Primary Administrative Subdivision": "Flores",
+            "DXCC Entity Code": "144"
+          },
+          "DU.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DU",
+            "Primary Administrative Subdivision": "Durazno",
+            "DXCC Entity Code": "144"
+          },
+          "TA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tacuarembó",
+            "DXCC Entity Code": "144"
+          },
+          "RV.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RV",
+            "Primary Administrative Subdivision": "Rivera",
+            "DXCC Entity Code": "144"
+          },
+          "MA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Maldonado",
+            "DXCC Entity Code": "144"
+          },
+          "LA.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lavalleja",
+            "DXCC Entity Code": "144"
+          },
+          "RO.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rocha",
+            "DXCC Entity Code": "144"
+          },
+          "TT.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TT",
+            "Primary Administrative Subdivision": "Treinta y Tres",
+            "DXCC Entity Code": "144"
+          },
+          "CL.144": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Cerro Largo",
+            "DXCC Entity Code": "144"
+          },
+          "LH.147": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Lord Howe Is",
+            "DXCC Entity Code": "147"
+          },
+          "AM.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amazonas",
+            "DXCC Entity Code": "148"
+          },
+          "AN.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Anzoátegui",
+            "DXCC Entity Code": "148"
+          },
+          "AP.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Apure",
+            "DXCC Entity Code": "148"
+          },
+          "AR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Aragua",
+            "DXCC Entity Code": "148"
+          },
+          "BA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Barinas",
+            "DXCC Entity Code": "148"
+          },
+          "BO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bolívar",
+            "DXCC Entity Code": "148"
+          },
+          "CA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Carabobo",
+            "DXCC Entity Code": "148"
+          },
+          "CO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cojedes",
+            "DXCC Entity Code": "148"
+          },
+          "DA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DA",
+            "Primary Administrative Subdivision": "Delta Amacuro",
+            "DXCC Entity Code": "148"
+          },
+          "DC.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "Distrito Capital",
+            "DXCC Entity Code": "148"
+          },
+          "FA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FA",
+            "Primary Administrative Subdivision": "Falcón",
+            "DXCC Entity Code": "148"
+          },
+          "GU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guárico",
+            "DXCC Entity Code": "148"
+          },
+          "LA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Lara",
+            "DXCC Entity Code": "148"
+          },
+          "ME.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Mérida",
+            "DXCC Entity Code": "148"
+          },
+          "MI.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Miranda",
+            "DXCC Entity Code": "148"
+          },
+          "MO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Monagas",
+            "DXCC Entity Code": "148"
+          },
+          "NE.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nueva Esparta",
+            "DXCC Entity Code": "148"
+          },
+          "PO.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Portuguesa",
+            "DXCC Entity Code": "148"
+          },
+          "SU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sucre",
+            "DXCC Entity Code": "148"
+          },
+          "TA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Táchira",
+            "DXCC Entity Code": "148"
+          },
+          "TR.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Trujillo",
+            "DXCC Entity Code": "148"
+          },
+          "VA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vargas",
+            "DXCC Entity Code": "148"
+          },
+          "YA.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yaracuy",
+            "DXCC Entity Code": "148"
+          },
+          "ZU.148": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZU",
+            "Primary Administrative Subdivision": "Zulia",
+            "DXCC Entity Code": "148"
+          },
+          "AC.149": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Açores",
+            "DXCC Entity Code": "149"
+          },
+          "ACT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ACT",
+            "Primary Administrative Subdivision": "Australian Capital Territory",
+            "DXCC Entity Code": "150"
+          },
+          "NSW.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSW",
+            "Primary Administrative Subdivision": "New South Wales",
+            "DXCC Entity Code": "150"
+          },
+          "VIC.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VIC",
+            "Primary Administrative Subdivision": "Victoria",
+            "DXCC Entity Code": "150"
+          },
+          "QLD.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QLD",
+            "Primary Administrative Subdivision": "Queensland",
+            "DXCC Entity Code": "150"
+          },
+          "SA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "South Australia",
+            "DXCC Entity Code": "150"
+          },
+          "WA.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Western Australia",
+            "DXCC Entity Code": "150"
+          },
+          "TAS.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasmania",
+            "DXCC Entity Code": "150"
+          },
+          "NT.150": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Northern Territory",
+            "DXCC Entity Code": "150"
+          },
+          "LO.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Leningradskaya Oblast",
+            "DXCC Entity Code": "151"
+          },
+          "MV.151": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Malyj Vysotskij",
+            "DXCC Entity Code": "151",
+            "Import-only": "true"
+          },
+          "MA.153": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Macquarie Is",
+            "DXCC Entity Code": "153"
+          },
+          "NCD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCD",
+            "Primary Administrative Subdivision": "National Capital District",
+            "DXCC Entity Code": "163",
+            "Comments": "Port Moresby"
+          },
+          "CPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPM",
+            "Primary Administrative Subdivision": "Central",
+            "DXCC Entity Code": "163"
+          },
+          "CPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPK",
+            "Primary Administrative Subdivision": "Chimbu",
+            "DXCC Entity Code": "163"
+          },
+          "EHG.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EHG",
+            "Primary Administrative Subdivision": "Eastern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "EBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EBR",
+            "Primary Administrative Subdivision": "East New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "ESW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ESW",
+            "Primary Administrative Subdivision": "East Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "EPW.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EPW",
+            "Primary Administrative Subdivision": "Enga",
+            "DXCC Entity Code": "163"
+          },
+          "GPK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPK",
+            "Primary Administrative Subdivision": "Gulf",
+            "DXCC Entity Code": "163"
+          },
+          "MPM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPM",
+            "Primary Administrative Subdivision": "Madang",
+            "DXCC Entity Code": "163"
+          },
+          "MRL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MRL",
+            "Primary Administrative Subdivision": "Manus",
+            "DXCC Entity Code": "163"
+          },
+          "MBA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBA",
+            "Primary Administrative Subdivision": "Milne Bay",
+            "DXCC Entity Code": "163"
+          },
+          "MPL.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MPL",
+            "Primary Administrative Subdivision": "Morobe",
+            "DXCC Entity Code": "163"
+          },
+          "NIK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIK",
+            "Primary Administrative Subdivision": "New Ireland",
+            "DXCC Entity Code": "163"
+          },
+          "NPP.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NPP",
+            "Primary Administrative Subdivision": "Northern",
+            "DXCC Entity Code": "163"
+          },
+          "NSA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "North Solomons",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "NSB.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSB",
+            "Primary Administrative Subdivision": "Bougainville",
+            "DXCC Entity Code": "163"
+          },
+          "SAN.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAN",
+            "Primary Administrative Subdivision": "West Sepik",
+            "DXCC Entity Code": "163"
+          },
+          "SHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SHM",
+            "Primary Administrative Subdivision": "Southern Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WPD.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WPD",
+            "Primary Administrative Subdivision": "Western",
+            "DXCC Entity Code": "163"
+          },
+          "WHM.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WHM",
+            "Primary Administrative Subdivision": "Western Highlands",
+            "DXCC Entity Code": "163"
+          },
+          "WBR.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBR",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163",
+            "Import-only": "true"
+          },
+          "WBK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WBK",
+            "Primary Administrative Subdivision": "West New Britain",
+            "DXCC Entity Code": "163"
+          },
+          "HLA.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLA",
+            "Primary Administrative Subdivision": "Hela",
+            "DXCC Entity Code": "163"
+          },
+          "JWK.163": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JWK",
+            "Primary Administrative Subdivision": "Jiwaka",
+            "DXCC Entity Code": "163"
+          },
+          "AUK.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUK",
+            "Primary Administrative Subdivision": "Auckland",
+            "DXCC Entity Code": "170"
+          },
+          "BOP.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOP",
+            "Primary Administrative Subdivision": "Bay of Plenty",
+            "DXCC Entity Code": "170"
+          },
+          "NTL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NTL",
+            "Primary Administrative Subdivision": "Northland",
+            "DXCC Entity Code": "170"
+          },
+          "WKO.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WKO",
+            "Primary Administrative Subdivision": "Waikato",
+            "DXCC Entity Code": "170"
+          },
+          "GIS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GIS",
+            "Primary Administrative Subdivision": "Gisborne",
+            "DXCC Entity Code": "170"
+          },
+          "HKB.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKB",
+            "Primary Administrative Subdivision": "Hawke\u0027s Bay",
+            "DXCC Entity Code": "170"
+          },
+          "MWT.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MWT",
+            "Primary Administrative Subdivision": "Manawatū-Whanganui",
+            "DXCC Entity Code": "170"
+          },
+          "TKI.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TKI",
+            "Primary Administrative Subdivision": "Taranaki",
+            "DXCC Entity Code": "170"
+          },
+          "WGN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WGN",
+            "Primary Administrative Subdivision": "Greater Wellington",
+            "DXCC Entity Code": "170"
+          },
+          "CAN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Canterbury",
+            "DXCC Entity Code": "170"
+          },
+          "MBH.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MBH",
+            "Primary Administrative Subdivision": "Marlborough",
+            "DXCC Entity Code": "170"
+          },
+          "NSN.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSN",
+            "Primary Administrative Subdivision": "Nelson",
+            "DXCC Entity Code": "170"
+          },
+          "TAS.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAS",
+            "Primary Administrative Subdivision": "Tasman",
+            "DXCC Entity Code": "170"
+          },
+          "WTC.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WTC",
+            "Primary Administrative Subdivision": "West Coast",
+            "DXCC Entity Code": "170"
+          },
+          "OTA.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OTA",
+            "Primary Administrative Subdivision": "Otago",
+            "DXCC Entity Code": "170"
+          },
+          "STL.170": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STL",
+            "Primary Administrative Subdivision": "Southland",
+            "DXCC Entity Code": "170"
+          },
+          "MT.177": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Minami Torishima",
+            "DXCC Entity Code": "177"
+          },
+          "O.192": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Ogasawara",
+            "DXCC Entity Code": "192"
+          },
+          "WC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WC",
+            "Primary Administrative Subdivision": "Wien",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vienna (Wien)"
+          },
+          "HA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Hallein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "JO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JO",
+            "Primary Administrative Subdivision": "St. Johann",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Salzburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "SL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Salzburg-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "TA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tamsweg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "ZE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zell Am See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Salzburg"
+          },
+          "AM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AM",
+            "Primary Administrative Subdivision": "Amstetten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Bruck/Leitha",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "BN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Baden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gmünd",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "GF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GF",
+            "Primary Administrative Subdivision": "Gänserndorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Hollabrunn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "HO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HO",
+            "Primary Administrative Subdivision": "Horn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Korneuburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Krems-Region",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "KS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Krems",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "LF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LF",
+            "Primary Administrative Subdivision": "Lilienfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Mödling",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ME.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Melk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "MI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Mistelbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "NK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NK",
+            "Primary Administrative Subdivision": "Neunkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "St. Pölten",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "PL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "St. Pölten-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Scheibbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "SW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SW",
+            "Primary Administrative Subdivision": "Schwechat",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "TU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TU",
+            "Primary Administrative Subdivision": "Tulln",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "Wr.Neustadt-Bezirk",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WN",
+            "Primary Administrative Subdivision": "Wr.Neustadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WT",
+            "Primary Administrative Subdivision": "Waidhofen/Thaya",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WU",
+            "Primary Administrative Subdivision": "Wien-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "WY.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Waidhofen/Ybbs",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "ZT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZT",
+            "Primary Administrative Subdivision": "Zwettl",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Lower Austria (Niederösterreich)"
+          },
+          "EC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EC",
+            "Primary Administrative Subdivision": "Eisenstadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "EU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EU",
+            "Primary Administrative Subdivision": "Eisenstadt-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "GS.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Güssing",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "JE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JE",
+            "Primary Administrative Subdivision": "Jennersdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "MA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Mattersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "ND.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "Neusiedl/See",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OP",
+            "Primary Administrative Subdivision": "Oberpullendorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "OW.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Oberwart",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Burgenland"
+          },
+          "BR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braunau/Inn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "EF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EF",
+            "Primary Administrative Subdivision": "Eferding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "FR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freistadt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GM",
+            "Primary Administrative Subdivision": "Gmunden",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "GR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grieskirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "KI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirchdorf",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Linz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "LL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LL",
+            "Primary Administrative Subdivision": "Linz-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "PE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Perg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Ried/Innkreis",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "RO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rohrbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SD.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Schärding",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Steyr-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "SR.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Steyr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "UU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UU",
+            "Primary Administrative Subdivision": "Urfahr",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "VB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vöcklabruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WE",
+            "Primary Administrative Subdivision": "Wels",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "WL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WL",
+            "Primary Administrative Subdivision": "Wels-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Upper Austria (Oberösterreich)"
+          },
+          "BA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bad Aussee",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "BM.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck/Mur",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "BM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BM",
+            "Primary Administrative Subdivision": "Bruck-Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "DL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Deutschlandsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "FB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FB",
+            "Primary Administrative Subdivision": "Feldbach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "FF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FF",
+            "Primary Administrative Subdivision": "Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "GB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GB",
+            "Primary Administrative Subdivision": "Gröbming",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GC",
+            "Primary Administrative Subdivision": "Graz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "GU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Graz-Umgebung",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "HB.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hartberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "HF.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HF",
+            "Primary Administrative Subdivision": "Hartberg-Fürstenfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "JU.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Judenburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "KF.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KF",
+            "Primary Administrative Subdivision": "Knittelfeld",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2012/01/01"
+          },
+          "LB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Leibnitz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Leoben",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Liezen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "LN.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Leoben-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MT.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Murtal",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2012/01/01"
+          },
+          "MU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "MZ.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mürzzuschlag",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "RA.206.Deleted.0": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Radkersburg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Deleted": "true",
+            "Comments": "for contacts made before 2013/01/01"
+          },
+          "SO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Südoststeiermark",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)",
+            "Comments": "for contacts made on or after 2013/01/01"
+          },
+          "VO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Voitsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "WZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WZ",
+            "Primary Administrative Subdivision": "Weiz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Styria (Steiermark)"
+          },
+          "IC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IC",
+            "Primary Administrative Subdivision": "Innsbruck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Innsbruck-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "IM.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imst",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KB.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KB",
+            "Primary Administrative Subdivision": "Kitzbühel",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "KU.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KU",
+            "Primary Administrative Subdivision": "Kufstein",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LA.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Landeck",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "LZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LZ",
+            "Primary Administrative Subdivision": "Lienz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "RE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reutte",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "SZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwaz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Tyrol (Tirol)"
+          },
+          "FE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Feldkirchen",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "HE.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hermagor",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KC",
+            "Primary Administrative Subdivision": "Klagenfurt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "KL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Klagenfurt-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SP.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "Spittal/Drau",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "SV.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "St.Veit/Glan",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VI.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Villach",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VK",
+            "Primary Administrative Subdivision": "Völkermarkt",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "VL.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Villach-Land",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "WO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WO",
+            "Primary Administrative Subdivision": "Wolfsberg",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Carinthia (Kärnten)"
+          },
+          "BC.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bregenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "BZ.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bludenz",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "DO.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dornbirn",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "FK.206": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FK",
+            "Primary Administrative Subdivision": "Feldkirch",
+            "DXCC Entity Code": "206",
+            "Contained Within": "Vorarlberg"
+          },
+          "AN.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Antwerpen",
+            "DXCC Entity Code": "209"
+          },
+          "BR.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brussels",
+            "DXCC Entity Code": "209"
+          },
+          "BW.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Brabant Wallon",
+            "DXCC Entity Code": "209"
+          },
+          "HT.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HT",
+            "Primary Administrative Subdivision": "Hainaut",
+            "DXCC Entity Code": "209"
+          },
+          "LB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "209"
+          },
+          "LG.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LG",
+            "Primary Administrative Subdivision": "Liêge",
+            "DXCC Entity Code": "209"
+          },
+          "NM.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Namur",
+            "DXCC Entity Code": "209"
+          },
+          "LU.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luxembourg",
+            "DXCC Entity Code": "209"
+          },
+          "OV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Oost-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "VB.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Vlaams Brabant",
+            "DXCC Entity Code": "209"
+          },
+          "WV.209": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West-Vlaanderen",
+            "DXCC Entity Code": "209"
+          },
+          "BU.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgas",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "SL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sliven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas"
+          },
+          "YA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YA",
+            "Primary Administrative Subdivision": "Yambol",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Burgas",
+            "Comments": "Jambol"
+          },
+          "SO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sofija Grad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "City of Sofia"
+          },
+          "HA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Haskovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "KA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Kărdžali",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "SZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Stara Zagora",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Hashkovo"
+          },
+          "PA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pazardžik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "PD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Plovdiv",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "SM.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Smoljan",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Plovdiv"
+          },
+          "BL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Blagoevgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "KD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KD",
+            "Primary Administrative Subdivision": "Kjustendil",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "PK.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PK",
+            "Primary Administrative Subdivision": "Pernik",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia"
+          },
+          "SF.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SF",
+            "Primary Administrative Subdivision": "Sofija",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Sofia",
+            "Comments": "Sofia"
+          },
+          "GA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Gabrovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "LV.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "Loveč",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč",
+            "Comments": "Lovech"
+          },
+          "PL.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PL",
+            "Primary Administrative Subdivision": "Pleven",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "VT.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Veliko Tărnovo",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Loveč"
+          },
+          "MN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VD.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Vidin",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "VR.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vraca",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Montanta"
+          },
+          "RZ.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RZ",
+            "Primary Administrative Subdivision": "Razgrad",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "RS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RS",
+            "Primary Administrative Subdivision": "Ruse",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "SS.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Silistra",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "TA.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tărgovište",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Ruse"
+          },
+          "DO.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Dobrič",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "SN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Šumen",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "VN.212": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Varna",
+            "DXCC Entity Code": "212",
+            "Contained Within": "Varna"
+          },
+          "2A.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2A",
+            "Primary Administrative Subdivision": "Corse-du-Sud",
+            "DXCC Entity Code": "214"
+          },
+          "2B.214": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "2B",
+            "Primary Administrative Subdivision": "Haute-Corse",
+            "DXCC Entity Code": "214"
+          },
+          "015.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "015",
+            "Primary Administrative Subdivision": "Koebenhavns amt",
+            "DXCC Entity Code": "221"
+          },
+          "020.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "020",
+            "Primary Administrative Subdivision": "Frederiksborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "025.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "025",
+            "Primary Administrative Subdivision": "Roskilde amt",
+            "DXCC Entity Code": "221"
+          },
+          "030.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "030",
+            "Primary Administrative Subdivision": "Vestsjaellands amt",
+            "DXCC Entity Code": "221"
+          },
+          "035.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "035",
+            "Primary Administrative Subdivision": "Storstrøm amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Storstroems"
+          },
+          "040.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "040",
+            "Primary Administrative Subdivision": "Bornholms amt",
+            "DXCC Entity Code": "221"
+          },
+          "042.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "042",
+            "Primary Administrative Subdivision": "Fyns amt",
+            "DXCC Entity Code": "221"
+          },
+          "050.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "050",
+            "Primary Administrative Subdivision": "Sínderjylland amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Sydjyllands"
+          },
+          "055.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "055",
+            "Primary Administrative Subdivision": "Ribe amt",
+            "DXCC Entity Code": "221"
+          },
+          "060.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "060",
+            "Primary Administrative Subdivision": "Vejle amt",
+            "DXCC Entity Code": "221"
+          },
+          "065.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "065",
+            "Primary Administrative Subdivision": "Ringkøbing amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Ringkoebing"
+          },
+          "070.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "070",
+            "Primary Administrative Subdivision": "Århus amt",
+            "DXCC Entity Code": "221",
+            "Comments": "Aarhus"
+          },
+          "076.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "076",
+            "Primary Administrative Subdivision": "Viborg amt",
+            "DXCC Entity Code": "221"
+          },
+          "080.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "080",
+            "Primary Administrative Subdivision": "Nordjyllands amt",
+            "DXCC Entity Code": "221"
+          },
+          "101.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "101",
+            "Primary Administrative Subdivision": "Copenhagen City",
+            "DXCC Entity Code": "221"
+          },
+          "147.221": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Frederiksberg",
+            "DXCC Entity Code": "221"
+          },
+          "100.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "100",
+            "Primary Administrative Subdivision": "Somero",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "102.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "102",
+            "Primary Administrative Subdivision": "Alastaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "103.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "103",
+            "Primary Administrative Subdivision": "Askainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "104.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "104",
+            "Primary Administrative Subdivision": "Aura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "105.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "105",
+            "Primary Administrative Subdivision": "Dragsfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "106.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "106",
+            "Primary Administrative Subdivision": "Eura",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "107.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "107",
+            "Primary Administrative Subdivision": "Eurajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "108.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "108",
+            "Primary Administrative Subdivision": "Halikko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "109.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "109",
+            "Primary Administrative Subdivision": "Harjavalta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "110.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "110",
+            "Primary Administrative Subdivision": "Honkajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "111.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "111",
+            "Primary Administrative Subdivision": "Houtskari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "112.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "112",
+            "Primary Administrative Subdivision": "Huittinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "115.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "115",
+            "Primary Administrative Subdivision": "Iniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "116.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "116",
+            "Primary Administrative Subdivision": "Jämijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "117.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "117",
+            "Primary Administrative Subdivision": "Kaarina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "119.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "119",
+            "Primary Administrative Subdivision": "Kankaanpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "120.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "120",
+            "Primary Administrative Subdivision": "Karinainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "122.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "122",
+            "Primary Administrative Subdivision": "Karvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "123.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "123",
+            "Primary Administrative Subdivision": "Äetsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "124.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "124",
+            "Primary Administrative Subdivision": "Kemiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "126.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "126",
+            "Primary Administrative Subdivision": "Kiikala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "128.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "128",
+            "Primary Administrative Subdivision": "Kiikoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "129.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "129",
+            "Primary Administrative Subdivision": "Kisko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "130.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "130",
+            "Primary Administrative Subdivision": "Kiukainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "131.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "131",
+            "Primary Administrative Subdivision": "Kodisjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "132.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "132",
+            "Primary Administrative Subdivision": "Kokemäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "133.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "133",
+            "Primary Administrative Subdivision": "Korppoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "134.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "134",
+            "Primary Administrative Subdivision": "Koski tl",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "135.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "135",
+            "Primary Administrative Subdivision": "Kullaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "136.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "136",
+            "Primary Administrative Subdivision": "Kustavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "137.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "137",
+            "Primary Administrative Subdivision": "Kuusjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "138.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "138",
+            "Primary Administrative Subdivision": "Köyliö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "139.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "139",
+            "Primary Administrative Subdivision": "Laitila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "140.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "140",
+            "Primary Administrative Subdivision": "Lappi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "141.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "141",
+            "Primary Administrative Subdivision": "Lavia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "142.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "142",
+            "Primary Administrative Subdivision": "Lemu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "143.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "143",
+            "Primary Administrative Subdivision": "Lieto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "144.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "144",
+            "Primary Administrative Subdivision": "Loimaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "145.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "145",
+            "Primary Administrative Subdivision": "Loimaan kunta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "147.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "147",
+            "Primary Administrative Subdivision": "Luvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "148.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "148",
+            "Primary Administrative Subdivision": "Marttila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "149.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "149",
+            "Primary Administrative Subdivision": "Masku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "150.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "150",
+            "Primary Administrative Subdivision": "Mellilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "151.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "151",
+            "Primary Administrative Subdivision": "Merikarvia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "152.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "152",
+            "Primary Administrative Subdivision": "Merimasku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "154.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "154",
+            "Primary Administrative Subdivision": "Mietoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "156.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "156",
+            "Primary Administrative Subdivision": "Muurla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "157.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "157",
+            "Primary Administrative Subdivision": "Mynämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "158.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "158",
+            "Primary Administrative Subdivision": "Naantali",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "159.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "159",
+            "Primary Administrative Subdivision": "Nakkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "160.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "160",
+            "Primary Administrative Subdivision": "Nauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "161.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "161",
+            "Primary Administrative Subdivision": "Noormarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "162.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "162",
+            "Primary Administrative Subdivision": "Nousiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "163.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "163",
+            "Primary Administrative Subdivision": "Oripää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "164.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "164",
+            "Primary Administrative Subdivision": "Paimio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "165.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "165",
+            "Primary Administrative Subdivision": "Parainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "167.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "167",
+            "Primary Administrative Subdivision": "Perniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "168.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "168",
+            "Primary Administrative Subdivision": "Pertteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "169.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "169",
+            "Primary Administrative Subdivision": "Piikkiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "170.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "170",
+            "Primary Administrative Subdivision": "Pomarkku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "171.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "171",
+            "Primary Administrative Subdivision": "Pori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "172.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "172",
+            "Primary Administrative Subdivision": "Punkalaidun",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "173.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "173",
+            "Primary Administrative Subdivision": "Pyhäranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "174.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "174",
+            "Primary Administrative Subdivision": "Pöytyä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "175.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "175",
+            "Primary Administrative Subdivision": "Raisio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "176.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "176",
+            "Primary Administrative Subdivision": "Rauma",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "178.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "178",
+            "Primary Administrative Subdivision": "Rusko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "179.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "179",
+            "Primary Administrative Subdivision": "Rymättylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "180.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "180",
+            "Primary Administrative Subdivision": "Salo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "181.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "181",
+            "Primary Administrative Subdivision": "Sauvo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "182.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "182",
+            "Primary Administrative Subdivision": "Siikainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "183.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "183",
+            "Primary Administrative Subdivision": "Suodenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "184.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "184",
+            "Primary Administrative Subdivision": "Suomusjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "185.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "185",
+            "Primary Administrative Subdivision": "Säkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "186.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "186",
+            "Primary Administrative Subdivision": "Särkisalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "187.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "187",
+            "Primary Administrative Subdivision": "Taivassalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "188.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "188",
+            "Primary Administrative Subdivision": "Tarvasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "189.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "189",
+            "Primary Administrative Subdivision": "Turku",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "190.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "190",
+            "Primary Administrative Subdivision": "Ulvila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "191.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "191",
+            "Primary Administrative Subdivision": "Uusikaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "192.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "192",
+            "Primary Administrative Subdivision": "Vahto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "193.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "193",
+            "Primary Administrative Subdivision": "Vammala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "194.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "194",
+            "Primary Administrative Subdivision": "Vampula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "195.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "195",
+            "Primary Administrative Subdivision": "Vehmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "196.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "196",
+            "Primary Administrative Subdivision": "Velkua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "198.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "198",
+            "Primary Administrative Subdivision": "Västanfjärd",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "199.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "199",
+            "Primary Administrative Subdivision": "Yläne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Turku-Pori (Turun ja Porin lääni)"
+          },
+          "201.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "201",
+            "Primary Administrative Subdivision": "Artjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "202.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "202",
+            "Primary Administrative Subdivision": "Askola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "204.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "204",
+            "Primary Administrative Subdivision": "Espoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "205.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "205",
+            "Primary Administrative Subdivision": "Hanko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "206.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "206",
+            "Primary Administrative Subdivision": "Helsinki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "207.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "207",
+            "Primary Administrative Subdivision": "Hyvinkää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "208.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "208",
+            "Primary Administrative Subdivision": "Inkoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "209.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "209",
+            "Primary Administrative Subdivision": "Järvenpää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "210.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "210",
+            "Primary Administrative Subdivision": "Karjaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "211.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "211",
+            "Primary Administrative Subdivision": "Karjalohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "212.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "212",
+            "Primary Administrative Subdivision": "Karkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "213.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "213",
+            "Primary Administrative Subdivision": "Kauniainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "214.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "214",
+            "Primary Administrative Subdivision": "Kerava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "215.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "215",
+            "Primary Administrative Subdivision": "Kirkkonummi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "216.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "216",
+            "Primary Administrative Subdivision": "Lapinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "217.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "217",
+            "Primary Administrative Subdivision": "Liljendal",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "218.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "218",
+            "Primary Administrative Subdivision": "Lohjan kaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "220.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "220",
+            "Primary Administrative Subdivision": "Loviisa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "221.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "221",
+            "Primary Administrative Subdivision": "Myrskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "222.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "222",
+            "Primary Administrative Subdivision": "Mäntsälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "223.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "223",
+            "Primary Administrative Subdivision": "Nummi-Pusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "224.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "224",
+            "Primary Administrative Subdivision": "Nurmijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "225.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "225",
+            "Primary Administrative Subdivision": "Orimattila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "226.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "226",
+            "Primary Administrative Subdivision": "Pernaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "227.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "227",
+            "Primary Administrative Subdivision": "Pohja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "228.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "228",
+            "Primary Administrative Subdivision": "Pornainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "229.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "229",
+            "Primary Administrative Subdivision": "Porvoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "231.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "231",
+            "Primary Administrative Subdivision": "Pukkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "233.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "233",
+            "Primary Administrative Subdivision": "Ruotsinpyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "234.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "234",
+            "Primary Administrative Subdivision": "Sammatti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "235.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "235",
+            "Primary Administrative Subdivision": "Sipoo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "236.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "236",
+            "Primary Administrative Subdivision": "Siuntio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "238.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "238",
+            "Primary Administrative Subdivision": "Tammisaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "241.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "241",
+            "Primary Administrative Subdivision": "Tuusula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "242.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "242",
+            "Primary Administrative Subdivision": "Vantaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "243.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "243",
+            "Primary Administrative Subdivision": "Vihti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Uudenmaa (Uudenmaan lääni)"
+          },
+          "301.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "301",
+            "Primary Administrative Subdivision": "Asikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "303.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "303",
+            "Primary Administrative Subdivision": "Forssa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "304.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "304",
+            "Primary Administrative Subdivision": "Hattula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "305.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "305",
+            "Primary Administrative Subdivision": "Hauho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "306.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "306",
+            "Primary Administrative Subdivision": "Hausjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "307.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "307",
+            "Primary Administrative Subdivision": "Hollola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "308.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "308",
+            "Primary Administrative Subdivision": "Humppila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "309.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "309",
+            "Primary Administrative Subdivision": "Hämeenlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "310.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "310",
+            "Primary Administrative Subdivision": "Janakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "311.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "311",
+            "Primary Administrative Subdivision": "Jokioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "312.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "312",
+            "Primary Administrative Subdivision": "Juupajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "313.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "313",
+            "Primary Administrative Subdivision": "Kalvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "314.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "314",
+            "Primary Administrative Subdivision": "Kangasala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "315.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "315",
+            "Primary Administrative Subdivision": "Hämeenkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "316.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "316",
+            "Primary Administrative Subdivision": "Kuhmalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "318.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "318",
+            "Primary Administrative Subdivision": "Kuru",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "319.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "319",
+            "Primary Administrative Subdivision": "Kylmäkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "320.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "320",
+            "Primary Administrative Subdivision": "Kärkölä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "321.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "321",
+            "Primary Administrative Subdivision": "Lahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "322.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "322",
+            "Primary Administrative Subdivision": "Lammi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "323.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "323",
+            "Primary Administrative Subdivision": "Lempäälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "324.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "324",
+            "Primary Administrative Subdivision": "Loppi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "325.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "325",
+            "Primary Administrative Subdivision": "Luopioinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "326.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "326",
+            "Primary Administrative Subdivision": "Längelmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "327.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "327",
+            "Primary Administrative Subdivision": "Mänttä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "328.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "328",
+            "Primary Administrative Subdivision": "Nastola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "329.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "329",
+            "Primary Administrative Subdivision": "Nokia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "330.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "330",
+            "Primary Administrative Subdivision": "Orivesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "331.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "331",
+            "Primary Administrative Subdivision": "Padasjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "332.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "332",
+            "Primary Administrative Subdivision": "Pirkkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "333.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "333",
+            "Primary Administrative Subdivision": "Pälkäne",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "334.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "334",
+            "Primary Administrative Subdivision": "Renko",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "335.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "335",
+            "Primary Administrative Subdivision": "Riihimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "336.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "336",
+            "Primary Administrative Subdivision": "Ruovesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "337.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "337",
+            "Primary Administrative Subdivision": "Sahalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "340.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "340",
+            "Primary Administrative Subdivision": "Tammela",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "341.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "341",
+            "Primary Administrative Subdivision": "Tampere",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "342.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "342",
+            "Primary Administrative Subdivision": "Toijala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "344.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "344",
+            "Primary Administrative Subdivision": "Tuulos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "345.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "345",
+            "Primary Administrative Subdivision": "Urjala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "346.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "346",
+            "Primary Administrative Subdivision": "Valkeakoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "347.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "347",
+            "Primary Administrative Subdivision": "Vesilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "348.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "348",
+            "Primary Administrative Subdivision": "Viiala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "349.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "349",
+            "Primary Administrative Subdivision": "Vilppula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "350.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "350",
+            "Primary Administrative Subdivision": "Virrat",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "351.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "351",
+            "Primary Administrative Subdivision": "Ylöjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "352.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "352",
+            "Primary Administrative Subdivision": "Ypäjä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "353.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "353",
+            "Primary Administrative Subdivision": "Hämeenkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "354.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "354",
+            "Primary Administrative Subdivision": "Ikaalinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "355.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "355",
+            "Primary Administrative Subdivision": "Kihniö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "356.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "356",
+            "Primary Administrative Subdivision": "Mouhijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "357.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "357",
+            "Primary Administrative Subdivision": "Parkano",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "358.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "358",
+            "Primary Administrative Subdivision": "Viljakkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Haeme (Hämeen lääni)"
+          },
+          "402.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "402",
+            "Primary Administrative Subdivision": "Enonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "403.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "403",
+            "Primary Administrative Subdivision": "Hartola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "404.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "404",
+            "Primary Administrative Subdivision": "Haukivuori",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "405.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "405",
+            "Primary Administrative Subdivision": "Heinola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "407.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "407",
+            "Primary Administrative Subdivision": "Heinävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "408.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "408",
+            "Primary Administrative Subdivision": "Hirvensalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "409.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "409",
+            "Primary Administrative Subdivision": "Joroinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "410.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "410",
+            "Primary Administrative Subdivision": "Juva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "411.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "411",
+            "Primary Administrative Subdivision": "Jäppilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "412.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "412",
+            "Primary Administrative Subdivision": "Kangaslampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "413.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "413",
+            "Primary Administrative Subdivision": "Kangasniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "414.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "414",
+            "Primary Administrative Subdivision": "Kerimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "415.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "415",
+            "Primary Administrative Subdivision": "Mikkeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "417.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "417",
+            "Primary Administrative Subdivision": "Mäntyharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "418.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "418",
+            "Primary Administrative Subdivision": "Pertunmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "419.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "419",
+            "Primary Administrative Subdivision": "Pieksämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "420.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "420",
+            "Primary Administrative Subdivision": "Pieksänmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "421.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "421",
+            "Primary Administrative Subdivision": "Punkaharju",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "422.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "422",
+            "Primary Administrative Subdivision": "Puumala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "423.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "423",
+            "Primary Administrative Subdivision": "Rantasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "424.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "424",
+            "Primary Administrative Subdivision": "Ristiina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "425.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "425",
+            "Primary Administrative Subdivision": "Savonlinna",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "426.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "426",
+            "Primary Administrative Subdivision": "Savonranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "427.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "427",
+            "Primary Administrative Subdivision": "Sulkava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "428.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "428",
+            "Primary Administrative Subdivision": "Sysmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Mikkeli (Mikkelin lääni)"
+          },
+          "502.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "502",
+            "Primary Administrative Subdivision": "Elimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "503.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "503",
+            "Primary Administrative Subdivision": "Hamina",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "504.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "504",
+            "Primary Administrative Subdivision": "Iitti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "505.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "505",
+            "Primary Administrative Subdivision": "Imatra",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "506.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "506",
+            "Primary Administrative Subdivision": "Jaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "507.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "507",
+            "Primary Administrative Subdivision": "Joutseno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "509.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "509",
+            "Primary Administrative Subdivision": "Kotka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "510.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "510",
+            "Primary Administrative Subdivision": "Kouvola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "511.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "511",
+            "Primary Administrative Subdivision": "Kuusankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "513.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "513",
+            "Primary Administrative Subdivision": "Lappeenranta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "514.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "514",
+            "Primary Administrative Subdivision": "Lemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "515.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "515",
+            "Primary Administrative Subdivision": "Luumäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "516.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "516",
+            "Primary Administrative Subdivision": "Miehikkälä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "518.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "518",
+            "Primary Administrative Subdivision": "Parikkala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "519.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "519",
+            "Primary Administrative Subdivision": "Pyhtää",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "520.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "520",
+            "Primary Administrative Subdivision": "Rautjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "521.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "521",
+            "Primary Administrative Subdivision": "Ruokolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "522.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "522",
+            "Primary Administrative Subdivision": "Saari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "523.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "523",
+            "Primary Administrative Subdivision": "Savitaipale",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "525.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "525",
+            "Primary Administrative Subdivision": "Suomenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "526.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "526",
+            "Primary Administrative Subdivision": "Taipalsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "527.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "527",
+            "Primary Administrative Subdivision": "Uukuniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "528.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "528",
+            "Primary Administrative Subdivision": "Valkeala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "530.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "530",
+            "Primary Administrative Subdivision": "Virolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "531.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "531",
+            "Primary Administrative Subdivision": "Ylämaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "532.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "532",
+            "Primary Administrative Subdivision": "Anjalankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kymi (Kymen lääni)"
+          },
+          "601.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "601",
+            "Primary Administrative Subdivision": "Alahärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "602.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "602",
+            "Primary Administrative Subdivision": "Alajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "603.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "603",
+            "Primary Administrative Subdivision": "Alavus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "604.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "604",
+            "Primary Administrative Subdivision": "Evijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "605.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "605",
+            "Primary Administrative Subdivision": "Halsua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "606.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "606",
+            "Primary Administrative Subdivision": "Hankasalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "607.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "607",
+            "Primary Administrative Subdivision": "Himanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "608.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "608",
+            "Primary Administrative Subdivision": "Ilmajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "609.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "609",
+            "Primary Administrative Subdivision": "Isojoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "610.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "610",
+            "Primary Administrative Subdivision": "Isokyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "611.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "611",
+            "Primary Administrative Subdivision": "Jalasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "612.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "612",
+            "Primary Administrative Subdivision": "Joutsa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "613.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "613",
+            "Primary Administrative Subdivision": "Jurva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "614.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "614",
+            "Primary Administrative Subdivision": "Jyväskylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "615.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "615",
+            "Primary Administrative Subdivision": "Jyväskylän mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "616.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "616",
+            "Primary Administrative Subdivision": "Jämsä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "617.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "617",
+            "Primary Administrative Subdivision": "Jämsänkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "619.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "619",
+            "Primary Administrative Subdivision": "Kannonkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "620.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "620",
+            "Primary Administrative Subdivision": "Kannus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "621.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "621",
+            "Primary Administrative Subdivision": "Karijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "622.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "622",
+            "Primary Administrative Subdivision": "Karstula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "623.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "623",
+            "Primary Administrative Subdivision": "Kaskinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "624.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "624",
+            "Primary Administrative Subdivision": "Kauhajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "625.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "625",
+            "Primary Administrative Subdivision": "Kauhava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "626.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "626",
+            "Primary Administrative Subdivision": "Kaustinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "627.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "627",
+            "Primary Administrative Subdivision": "Keuruu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "628.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "628",
+            "Primary Administrative Subdivision": "Kinnula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "629.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "629",
+            "Primary Administrative Subdivision": "Kivijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "630.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "630",
+            "Primary Administrative Subdivision": "Kokkola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "632.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "632",
+            "Primary Administrative Subdivision": "Konnevesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "633.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "633",
+            "Primary Administrative Subdivision": "Korpilahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "634.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "634",
+            "Primary Administrative Subdivision": "Korsnäs",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "635.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "635",
+            "Primary Administrative Subdivision": "Kortesjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "636.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "636",
+            "Primary Administrative Subdivision": "Kristiinankaupunki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "637.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "637",
+            "Primary Administrative Subdivision": "Kruunupyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "638.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "638",
+            "Primary Administrative Subdivision": "Kuhmoinen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "639.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "639",
+            "Primary Administrative Subdivision": "Kuortane",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "640.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "640",
+            "Primary Administrative Subdivision": "Kurikka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "641.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "641",
+            "Primary Administrative Subdivision": "Kyyjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "642.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "642",
+            "Primary Administrative Subdivision": "Kälviä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "643.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "643",
+            "Primary Administrative Subdivision": "Laihia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "644.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "644",
+            "Primary Administrative Subdivision": "Lappajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "645.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "645",
+            "Primary Administrative Subdivision": "Lapua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "646.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "646",
+            "Primary Administrative Subdivision": "Laukaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "647.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "647",
+            "Primary Administrative Subdivision": "Lehtimäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "648.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "648",
+            "Primary Administrative Subdivision": "Leivonmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "649.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "649",
+            "Primary Administrative Subdivision": "Lestijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "650.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "650",
+            "Primary Administrative Subdivision": "Lohtaja",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "651.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "651",
+            "Primary Administrative Subdivision": "Luhanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "652.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "652",
+            "Primary Administrative Subdivision": "Luoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "653.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "653",
+            "Primary Administrative Subdivision": "Maalahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "654.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "654",
+            "Primary Administrative Subdivision": "Maksamaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "655.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "655",
+            "Primary Administrative Subdivision": "Multia",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "656.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "656",
+            "Primary Administrative Subdivision": "Mustasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "657.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "657",
+            "Primary Administrative Subdivision": "Muurame",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "658.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "658",
+            "Primary Administrative Subdivision": "Nurmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "659.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "659",
+            "Primary Administrative Subdivision": "Närpiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "660.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "660",
+            "Primary Administrative Subdivision": "Oravainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "661.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "661",
+            "Primary Administrative Subdivision": "Perho",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "662.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "662",
+            "Primary Administrative Subdivision": "Peräseinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "663.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "663",
+            "Primary Administrative Subdivision": "Petäjävesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "664.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "664",
+            "Primary Administrative Subdivision": "Pietarsaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "665.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "665",
+            "Primary Administrative Subdivision": "Pedersöre",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "666.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "666",
+            "Primary Administrative Subdivision": "Pihtipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "668.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "668",
+            "Primary Administrative Subdivision": "Pylkönmäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "669.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "669",
+            "Primary Administrative Subdivision": "Saarijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "670.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "670",
+            "Primary Administrative Subdivision": "Seinäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "671.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "671",
+            "Primary Administrative Subdivision": "Soini",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "672.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "672",
+            "Primary Administrative Subdivision": "Sumiainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "673.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "673",
+            "Primary Administrative Subdivision": "Suolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "675.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "675",
+            "Primary Administrative Subdivision": "Teuva",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "676.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "676",
+            "Primary Administrative Subdivision": "Toholampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "677.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "677",
+            "Primary Administrative Subdivision": "Toivakka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "678.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "678",
+            "Primary Administrative Subdivision": "Töysä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "679.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "679",
+            "Primary Administrative Subdivision": "Ullava",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "680.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "680",
+            "Primary Administrative Subdivision": "Uurainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "681.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "681",
+            "Primary Administrative Subdivision": "Uusikaarlepyy",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "682.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "682",
+            "Primary Administrative Subdivision": "Vaasa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "683.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "683",
+            "Primary Administrative Subdivision": "Veteli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "684.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "684",
+            "Primary Administrative Subdivision": "Viitasaari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "685.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "685",
+            "Primary Administrative Subdivision": "Vimpeli",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "686.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "686",
+            "Primary Administrative Subdivision": "Vähäkyrö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "687.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "687",
+            "Primary Administrative Subdivision": "Vöyri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "688.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "688",
+            "Primary Administrative Subdivision": "Ylihärmä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "689.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "689",
+            "Primary Administrative Subdivision": "Ylistaro",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "690.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "690",
+            "Primary Administrative Subdivision": "Ähtäri",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "692.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "692",
+            "Primary Administrative Subdivision": "Äänekoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Keski-Suomi (Keski-Suomen lääni), Vaasa (Vaasan lääni)"
+          },
+          "701.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "701",
+            "Primary Administrative Subdivision": "Eno",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "702.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "702",
+            "Primary Administrative Subdivision": "Iisalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "703.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "703",
+            "Primary Administrative Subdivision": "Ilomantsi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "704.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "704",
+            "Primary Administrative Subdivision": "Joensuu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "705.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "705",
+            "Primary Administrative Subdivision": "Juankoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "706.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "706",
+            "Primary Administrative Subdivision": "Juuka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "707.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "707",
+            "Primary Administrative Subdivision": "Kaavi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "708.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "708",
+            "Primary Administrative Subdivision": "Karttula",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "709.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "709",
+            "Primary Administrative Subdivision": "Keitele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "710.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "710",
+            "Primary Administrative Subdivision": "Kesälahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "711.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "711",
+            "Primary Administrative Subdivision": "Kiihtelysvaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "712.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "712",
+            "Primary Administrative Subdivision": "Kitee",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "713.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "713",
+            "Primary Administrative Subdivision": "Kiuruvesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "714.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "714",
+            "Primary Administrative Subdivision": "Kontiolahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "715.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "715",
+            "Primary Administrative Subdivision": "Kuopio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "716.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "716",
+            "Primary Administrative Subdivision": "Lapinlahti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "717.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "717",
+            "Primary Administrative Subdivision": "Leppävirta",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "718.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "718",
+            "Primary Administrative Subdivision": "Lieksa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "719.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "719",
+            "Primary Administrative Subdivision": "Liperi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "720.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "720",
+            "Primary Administrative Subdivision": "Maaninka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "721.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "721",
+            "Primary Administrative Subdivision": "Nilsiä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "722.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "722",
+            "Primary Administrative Subdivision": "Nurmes",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "723.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "723",
+            "Primary Administrative Subdivision": "Outokumpu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "724.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "724",
+            "Primary Administrative Subdivision": "Pielavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "725.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "725",
+            "Primary Administrative Subdivision": "Polvijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "726.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "726",
+            "Primary Administrative Subdivision": "Pyhäselkä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "727.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "727",
+            "Primary Administrative Subdivision": "Rautalampi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "728.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "728",
+            "Primary Administrative Subdivision": "Rautavaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "729.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "729",
+            "Primary Administrative Subdivision": "Rääkkylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "730.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "730",
+            "Primary Administrative Subdivision": "Siilinjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "731.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "731",
+            "Primary Administrative Subdivision": "Sonkajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "732.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "732",
+            "Primary Administrative Subdivision": "Suonenjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "733.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "733",
+            "Primary Administrative Subdivision": "Tervo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "734.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "734",
+            "Primary Administrative Subdivision": "Tohmajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "735.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "735",
+            "Primary Administrative Subdivision": "Tuupovaara",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "736.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "736",
+            "Primary Administrative Subdivision": "Tuusniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "737.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "737",
+            "Primary Administrative Subdivision": "Valtimo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "738.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "738",
+            "Primary Administrative Subdivision": "Varkaus",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "739.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "739",
+            "Primary Administrative Subdivision": "Varpaisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "740.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "740",
+            "Primary Administrative Subdivision": "Vehmersalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "741.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "741",
+            "Primary Administrative Subdivision": "Vesanto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "742.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "742",
+            "Primary Administrative Subdivision": "Vieremä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "743.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "743",
+            "Primary Administrative Subdivision": "Värtsilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Kuopio (Kuopion lääni), Pohjois-Karjala (Pohjois-Karjalan lääni)"
+          },
+          "801.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "801",
+            "Primary Administrative Subdivision": "Alavieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "802.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "802",
+            "Primary Administrative Subdivision": "Haapajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "803.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "803",
+            "Primary Administrative Subdivision": "Haapavesi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "804.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "804",
+            "Primary Administrative Subdivision": "Hailuoto",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "805.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "805",
+            "Primary Administrative Subdivision": "Haukipudas",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "806.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "806",
+            "Primary Administrative Subdivision": "Hyrynsalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "807.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "807",
+            "Primary Administrative Subdivision": "Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "808.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "808",
+            "Primary Administrative Subdivision": "Kajaani",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "810.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "810",
+            "Primary Administrative Subdivision": "Kalajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "811.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "811",
+            "Primary Administrative Subdivision": "Kempele",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "812.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "812",
+            "Primary Administrative Subdivision": "Kestilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "813.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "813",
+            "Primary Administrative Subdivision": "Kiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "814.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "814",
+            "Primary Administrative Subdivision": "Kuhmo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "815.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "815",
+            "Primary Administrative Subdivision": "Kuivaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "816.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "816",
+            "Primary Administrative Subdivision": "Kuusamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "817.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "817",
+            "Primary Administrative Subdivision": "Kärsämäki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "818.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "818",
+            "Primary Administrative Subdivision": "Liminka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "819.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "819",
+            "Primary Administrative Subdivision": "Lumijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "820.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "820",
+            "Primary Administrative Subdivision": "Merijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "821.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "821",
+            "Primary Administrative Subdivision": "Muhos",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "822.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "822",
+            "Primary Administrative Subdivision": "Nivala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "823.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "823",
+            "Primary Administrative Subdivision": "Oulainen",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "824.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "824",
+            "Primary Administrative Subdivision": "Oulu",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "825.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "825",
+            "Primary Administrative Subdivision": "Oulunsalo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "826.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "826",
+            "Primary Administrative Subdivision": "Paltamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "827.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "827",
+            "Primary Administrative Subdivision": "Pattijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "828.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "828",
+            "Primary Administrative Subdivision": "Piippola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "829.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "829",
+            "Primary Administrative Subdivision": "Pudasjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "830.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "830",
+            "Primary Administrative Subdivision": "Pulkkila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "831.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "831",
+            "Primary Administrative Subdivision": "Puolanka",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "832.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "832",
+            "Primary Administrative Subdivision": "Pyhäjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "833.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "833",
+            "Primary Administrative Subdivision": "Pyhäjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "834.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "834",
+            "Primary Administrative Subdivision": "Pyhäntä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "835.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "835",
+            "Primary Administrative Subdivision": "Raahe",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "836.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "836",
+            "Primary Administrative Subdivision": "Rantsila",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "837.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "837",
+            "Primary Administrative Subdivision": "Reisjärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "838.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "838",
+            "Primary Administrative Subdivision": "Ristijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "839.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "839",
+            "Primary Administrative Subdivision": "Ruukki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "840.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "840",
+            "Primary Administrative Subdivision": "Sievi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "841.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "841",
+            "Primary Administrative Subdivision": "Siikajoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "842.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "842",
+            "Primary Administrative Subdivision": "Sotkamo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "843.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "843",
+            "Primary Administrative Subdivision": "Suomussalmi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "844.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "844",
+            "Primary Administrative Subdivision": "Taivalkoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "846.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "846",
+            "Primary Administrative Subdivision": "Tyrnävä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "847.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "847",
+            "Primary Administrative Subdivision": "Utajärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "848.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "848",
+            "Primary Administrative Subdivision": "Vaala",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "849.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "849",
+            "Primary Administrative Subdivision": "Vihanti",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "850.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "850",
+            "Primary Administrative Subdivision": "Vuolijoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "851.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "851",
+            "Primary Administrative Subdivision": "Yli-Ii",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "852.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "852",
+            "Primary Administrative Subdivision": "Ylikiiminki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "853.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "853",
+            "Primary Administrative Subdivision": "Ylivieska",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Oulu (Oulun lääni)"
+          },
+          "901.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "901",
+            "Primary Administrative Subdivision": "Enontekiö",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "902.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "902",
+            "Primary Administrative Subdivision": "Inari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "903.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "903",
+            "Primary Administrative Subdivision": "Kemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "904.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "904",
+            "Primary Administrative Subdivision": "Keminmaa",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "905.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "905",
+            "Primary Administrative Subdivision": "Kemijärvi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "907.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "907",
+            "Primary Administrative Subdivision": "Kittilä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "908.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "908",
+            "Primary Administrative Subdivision": "Kolari",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "909.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "909",
+            "Primary Administrative Subdivision": "Muonio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "910.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "910",
+            "Primary Administrative Subdivision": "Pelkosenniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "911.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "911",
+            "Primary Administrative Subdivision": "Pello",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "912.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "912",
+            "Primary Administrative Subdivision": "Posio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "913.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "913",
+            "Primary Administrative Subdivision": "Ranua",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "914.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "914",
+            "Primary Administrative Subdivision": "Rovaniemi",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "915.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "915",
+            "Primary Administrative Subdivision": "Rovaniemen mlk",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "916.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "916",
+            "Primary Administrative Subdivision": "Salla",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "917.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "917",
+            "Primary Administrative Subdivision": "Savukoski",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "918.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "918",
+            "Primary Administrative Subdivision": "Simo",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "919.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "919",
+            "Primary Administrative Subdivision": "Sodankylä",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "920.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "920",
+            "Primary Administrative Subdivision": "Tervola",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "921.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "921",
+            "Primary Administrative Subdivision": "Tornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "922.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "922",
+            "Primary Administrative Subdivision": "Utsjoki",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "923.224": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "923",
+            "Primary Administrative Subdivision": "Ylitornio",
+            "DXCC Entity Code": "224",
+            "Contained Within": "Lappi (Lapin lääni)"
+          },
+          "CA.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cagliari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "CI.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CI",
+            "Primary Administrative Subdivision": "Carbonia-Iglesias",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true",
+            "Comments": "replaced by SU"
+          },
+          "SU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sud Sardegna",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "MD.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Medio Campidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)",
+            "Import-only": "true"
+          },
+          "NU.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NU",
+            "Primary Administrative Subdivision": "Nuoro",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OG.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OG",
+            "Primary Administrative Subdivision": "Ogliastra",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OR.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oristano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "OT.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olbia-Tempio",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "SS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Sassari",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "VS.225": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "MedioCampidano",
+            "DXCC Entity Code": "225",
+            "Contained Within": "Sardinia (Sardegna)"
+          },
+          "01.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Ain",
+            "DXCC Entity Code": "227"
+          },
+          "02.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aisne",
+            "DXCC Entity Code": "227"
+          },
+          "03.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Allier",
+            "DXCC Entity Code": "227"
+          },
+          "04.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Alpes-de-Haute-Provence",
+            "DXCC Entity Code": "227"
+          },
+          "05.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Hautes-Alpes",
+            "DXCC Entity Code": "227"
+          },
+          "06.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Alpes-Maritimes",
+            "DXCC Entity Code": "227"
+          },
+          "07.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Ardèche",
+            "DXCC Entity Code": "227"
+          },
+          "08.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Ardennes",
+            "DXCC Entity Code": "227"
+          },
+          "09.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ariège",
+            "DXCC Entity Code": "227"
+          },
+          "10.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Aube",
+            "DXCC Entity Code": "227"
+          },
+          "11.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Aude",
+            "DXCC Entity Code": "227"
+          },
+          "12.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Aveyron",
+            "DXCC Entity Code": "227"
+          },
+          "13.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Bouches-du-Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "14.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Calvados",
+            "DXCC Entity Code": "227"
+          },
+          "15.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Cantal",
+            "DXCC Entity Code": "227"
+          },
+          "16.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Charente",
+            "DXCC Entity Code": "227"
+          },
+          "17.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Charente-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "18.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Cher",
+            "DXCC Entity Code": "227"
+          },
+          "19.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Corrèze",
+            "DXCC Entity Code": "227"
+          },
+          "21.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Côte-d\u0027Or",
+            "DXCC Entity Code": "227"
+          },
+          "22.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Côtes-d\u0027Armor",
+            "DXCC Entity Code": "227"
+          },
+          "23.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Creuse",
+            "DXCC Entity Code": "227"
+          },
+          "24.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Dordogne",
+            "DXCC Entity Code": "227"
+          },
+          "25.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Doubs",
+            "DXCC Entity Code": "227"
+          },
+          "26.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Drôme",
+            "DXCC Entity Code": "227"
+          },
+          "27.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Eure",
+            "DXCC Entity Code": "227"
+          },
+          "28.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Eure-et-Loir",
+            "DXCC Entity Code": "227"
+          },
+          "29.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Finistère",
+            "DXCC Entity Code": "227"
+          },
+          "30.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Gard",
+            "DXCC Entity Code": "227"
+          },
+          "31.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Haute-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "32.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Gers",
+            "DXCC Entity Code": "227"
+          },
+          "33.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Gironde",
+            "DXCC Entity Code": "227"
+          },
+          "34.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Hérault",
+            "DXCC Entity Code": "227"
+          },
+          "35.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Ille-et-Vilaine",
+            "DXCC Entity Code": "227"
+          },
+          "36.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Indre",
+            "DXCC Entity Code": "227"
+          },
+          "37.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Indre-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "38.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Isère",
+            "DXCC Entity Code": "227"
+          },
+          "39.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "227"
+          },
+          "40.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Landes",
+            "DXCC Entity Code": "227"
+          },
+          "41.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Loir-et-Cher",
+            "DXCC Entity Code": "227"
+          },
+          "42.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Loire",
+            "DXCC Entity Code": "227"
+          },
+          "43.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Haute-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "44.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Loire-Atlantique",
+            "DXCC Entity Code": "227"
+          },
+          "45.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Loiret",
+            "DXCC Entity Code": "227"
+          },
+          "46.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Lot",
+            "DXCC Entity Code": "227"
+          },
+          "47.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Lot-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "48.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "48",
+            "Primary Administrative Subdivision": "Lozère",
+            "DXCC Entity Code": "227"
+          },
+          "49.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "49",
+            "Primary Administrative Subdivision": "Maine-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "50.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Manche",
+            "DXCC Entity Code": "227"
+          },
+          "51.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "51",
+            "Primary Administrative Subdivision": "Marne",
+            "DXCC Entity Code": "227"
+          },
+          "52.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "52",
+            "Primary Administrative Subdivision": "Haute-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "53.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "53",
+            "Primary Administrative Subdivision": "Mayenne",
+            "DXCC Entity Code": "227"
+          },
+          "54.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Meurthe-et-Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "55.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "55",
+            "Primary Administrative Subdivision": "Meuse",
+            "DXCC Entity Code": "227"
+          },
+          "56.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "56",
+            "Primary Administrative Subdivision": "Morbihan",
+            "DXCC Entity Code": "227"
+          },
+          "57.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "57",
+            "Primary Administrative Subdivision": "Moselle",
+            "DXCC Entity Code": "227"
+          },
+          "58.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "58",
+            "Primary Administrative Subdivision": "Nièvre",
+            "DXCC Entity Code": "227"
+          },
+          "59.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "59",
+            "Primary Administrative Subdivision": "Nord",
+            "DXCC Entity Code": "227"
+          },
+          "60.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "60",
+            "Primary Administrative Subdivision": "Oise",
+            "DXCC Entity Code": "227"
+          },
+          "61.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "61",
+            "Primary Administrative Subdivision": "Orne",
+            "DXCC Entity Code": "227"
+          },
+          "62.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "62",
+            "Primary Administrative Subdivision": "Pas-de-Calais",
+            "DXCC Entity Code": "227"
+          },
+          "63.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "63",
+            "Primary Administrative Subdivision": "Puy-de-Dôme",
+            "DXCC Entity Code": "227"
+          },
+          "64.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "64",
+            "Primary Administrative Subdivision": "Pyrénées-Atlantiques",
+            "DXCC Entity Code": "227"
+          },
+          "65.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "65",
+            "Primary Administrative Subdivision": "Hautes-Pyrénées",
+            "DXCC Entity Code": "227"
+          },
+          "66.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "66",
+            "Primary Administrative Subdivision": "Pyrénées-Orientales",
+            "DXCC Entity Code": "227"
+          },
+          "67.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "67",
+            "Primary Administrative Subdivision": "Bas-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "68.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "68",
+            "Primary Administrative Subdivision": "Haut-Rhin",
+            "DXCC Entity Code": "227"
+          },
+          "69.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "69",
+            "Primary Administrative Subdivision": "Rhône",
+            "DXCC Entity Code": "227"
+          },
+          "70.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "70",
+            "Primary Administrative Subdivision": "Haute-Saône",
+            "DXCC Entity Code": "227"
+          },
+          "71.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "71",
+            "Primary Administrative Subdivision": "Saône-et-Loire",
+            "DXCC Entity Code": "227"
+          },
+          "72.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "72",
+            "Primary Administrative Subdivision": "Sarthe",
+            "DXCC Entity Code": "227"
+          },
+          "73.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "73",
+            "Primary Administrative Subdivision": "Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "74.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "74",
+            "Primary Administrative Subdivision": "Haute-Savoie",
+            "DXCC Entity Code": "227"
+          },
+          "75.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "75",
+            "Primary Administrative Subdivision": "Paris",
+            "DXCC Entity Code": "227"
+          },
+          "76.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "76",
+            "Primary Administrative Subdivision": "Seine-Maritime",
+            "DXCC Entity Code": "227"
+          },
+          "77.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "77",
+            "Primary Administrative Subdivision": "Seine-et-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "78.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "78",
+            "Primary Administrative Subdivision": "Yvelines",
+            "DXCC Entity Code": "227"
+          },
+          "79.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "79",
+            "Primary Administrative Subdivision": "Deux-Sèvres",
+            "DXCC Entity Code": "227"
+          },
+          "80.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "80",
+            "Primary Administrative Subdivision": "Somme",
+            "DXCC Entity Code": "227"
+          },
+          "81.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "81",
+            "Primary Administrative Subdivision": "Tarn",
+            "DXCC Entity Code": "227"
+          },
+          "82.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "82",
+            "Primary Administrative Subdivision": "Tarn-et-Garonne",
+            "DXCC Entity Code": "227"
+          },
+          "83.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "83",
+            "Primary Administrative Subdivision": "Var",
+            "DXCC Entity Code": "227"
+          },
+          "84.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "84",
+            "Primary Administrative Subdivision": "Vaucluse",
+            "DXCC Entity Code": "227"
+          },
+          "85.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "85",
+            "Primary Administrative Subdivision": "Vendée",
+            "DXCC Entity Code": "227"
+          },
+          "86.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "86",
+            "Primary Administrative Subdivision": "Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "87.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "87",
+            "Primary Administrative Subdivision": "Haute-Vienne",
+            "DXCC Entity Code": "227"
+          },
+          "88.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "88",
+            "Primary Administrative Subdivision": "Vosges",
+            "DXCC Entity Code": "227"
+          },
+          "89.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "89",
+            "Primary Administrative Subdivision": "Yonne",
+            "DXCC Entity Code": "227"
+          },
+          "90.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "90",
+            "Primary Administrative Subdivision": "Territoire de Belfort",
+            "DXCC Entity Code": "227"
+          },
+          "91.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "91",
+            "Primary Administrative Subdivision": "Essonne",
+            "DXCC Entity Code": "227"
+          },
+          "92.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "92",
+            "Primary Administrative Subdivision": "Hauts-de-Seine",
+            "DXCC Entity Code": "227"
+          },
+          "93.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "93",
+            "Primary Administrative Subdivision": "Seine-Saint-Denis",
+            "DXCC Entity Code": "227"
+          },
+          "94.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "94",
+            "Primary Administrative Subdivision": "Val-de-Marne",
+            "DXCC Entity Code": "227"
+          },
+          "95.227": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "95",
+            "Primary Administrative Subdivision": "Val-d\u0027Oise",
+            "DXCC Entity Code": "227"
+          },
+          "BB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BB",
+            "Primary Administrative Subdivision": "Brandenburg",
+            "DXCC Entity Code": "230"
+          },
+          "BE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Berlin",
+            "DXCC Entity Code": "230"
+          },
+          "BW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BW",
+            "Primary Administrative Subdivision": "Baden-Württemberg",
+            "DXCC Entity Code": "230"
+          },
+          "BY.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BY",
+            "Primary Administrative Subdivision": "Bayern",
+            "DXCC Entity Code": "230"
+          },
+          "HB.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Bremen",
+            "DXCC Entity Code": "230"
+          },
+          "HE.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hessen",
+            "DXCC Entity Code": "230"
+          },
+          "HH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HH",
+            "Primary Administrative Subdivision": "Hamburg",
+            "DXCC Entity Code": "230"
+          },
+          "MV.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MV",
+            "Primary Administrative Subdivision": "Mecklenburg-Vorpommern",
+            "DXCC Entity Code": "230"
+          },
+          "NI.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Niedersachsen",
+            "DXCC Entity Code": "230"
+          },
+          "NW.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nordrhein-Westfalen",
+            "DXCC Entity Code": "230"
+          },
+          "RP.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RP",
+            "Primary Administrative Subdivision": "Rheinland-Pfalz",
+            "DXCC Entity Code": "230"
+          },
+          "SL.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Saarland",
+            "DXCC Entity Code": "230"
+          },
+          "SH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schleswig-Holstein",
+            "DXCC Entity Code": "230"
+          },
+          "SN.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Sachsen",
+            "DXCC Entity Code": "230"
+          },
+          "ST.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Sachsen-Anhalt",
+            "DXCC Entity Code": "230"
+          },
+          "TH.230": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TH",
+            "Primary Administrative Subdivision": "Thüringen",
+            "DXCC Entity Code": "230"
+          },
+          "GY.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GY",
+            "Primary Administrative Subdivision": "Gyõr",
+            "DXCC Entity Code": "239",
+            "Comments": "Gyõr-Moson-Sopron"
+          },
+          "VA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Vas",
+            "DXCC Entity Code": "239"
+          },
+          "ZA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zala",
+            "DXCC Entity Code": "239"
+          },
+          "KO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Komárom",
+            "DXCC Entity Code": "239",
+            "Comments": "Komárom-Esztergom"
+          },
+          "VE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Veszprém",
+            "DXCC Entity Code": "239"
+          },
+          "BA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Baranya",
+            "DXCC Entity Code": "239"
+          },
+          "SO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Somogy",
+            "DXCC Entity Code": "239"
+          },
+          "TO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Tolna",
+            "DXCC Entity Code": "239"
+          },
+          "FE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Fejér",
+            "DXCC Entity Code": "239"
+          },
+          "BP.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BP",
+            "Primary Administrative Subdivision": "Budapest",
+            "DXCC Entity Code": "239"
+          },
+          "HE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Heves",
+            "DXCC Entity Code": "239"
+          },
+          "NG.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NG",
+            "Primary Administrative Subdivision": "Nógrád",
+            "DXCC Entity Code": "239"
+          },
+          "PE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pest",
+            "DXCC Entity Code": "239"
+          },
+          "SZ.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Szolnok",
+            "DXCC Entity Code": "239",
+            "Comments": "Jász-Nagykun-Szolnok"
+          },
+          "BE.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Békés",
+            "DXCC Entity Code": "239"
+          },
+          "BN.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bács-Kiskun",
+            "DXCC Entity Code": "239"
+          },
+          "CS.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Csongrád",
+            "DXCC Entity Code": "239"
+          },
+          "BO.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Borsod",
+            "DXCC Entity Code": "239",
+            "Comments": "Borsod-Abaúj-Zemplén"
+          },
+          "HB.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hajdú-Bihar",
+            "DXCC Entity Code": "239"
+          },
+          "SA.239": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Szabolcs",
+            "DXCC Entity Code": "239",
+            "Comments": "Szabolcs-Szatmár-Bereg"
+          },
+          "CW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CW",
+            "Primary Administrative Subdivision": "Carlow",
+            "DXCC Entity Code": "245",
+            "Comments": "Ceatharlach"
+          },
+          "CN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cavan",
+            "DXCC Entity Code": "245",
+            "Comments": "An Cabhán"
+          },
+          "CE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Clare",
+            "DXCC Entity Code": "245",
+            "Comments": "An Clár"
+          },
+          "C.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Import-only": "true",
+            "Comments": "Corcaigh"
+          },
+          "CO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Cork",
+            "DXCC Entity Code": "245",
+            "Comments": "Corcaigh"
+          },
+          "DL.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Donegal",
+            "DXCC Entity Code": "245",
+            "Comments": "Dún na nGall"
+          },
+          "D.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dublin",
+            "DXCC Entity Code": "245",
+            "Comments": "Baile Áth Cliath"
+          },
+          "G.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Galway",
+            "DXCC Entity Code": "245",
+            "Comments": "Gaillimh"
+          },
+          "KY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kerry",
+            "DXCC Entity Code": "245",
+            "Comments": "Ciarraí"
+          },
+          "KE.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KE",
+            "Primary Administrative Subdivision": "Kildare",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Dara"
+          },
+          "KK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KK",
+            "Primary Administrative Subdivision": "Kilkenny",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Chainnigh"
+          },
+          "LS.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LS",
+            "Primary Administrative Subdivision": "Laois",
+            "DXCC Entity Code": "245",
+            "Comments": "Laois"
+          },
+          "LM.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LM",
+            "Primary Administrative Subdivision": "Leitrim",
+            "DXCC Entity Code": "245",
+            "Comments": "Liatroim"
+          },
+          "LK.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LK",
+            "Primary Administrative Subdivision": "Limerick",
+            "DXCC Entity Code": "245",
+            "Comments": "Luimneach"
+          },
+          "LD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LD",
+            "Primary Administrative Subdivision": "Longford",
+            "DXCC Entity Code": "245",
+            "Comments": "An Longfort"
+          },
+          "LH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LH",
+            "Primary Administrative Subdivision": "Louth",
+            "DXCC Entity Code": "245",
+            "Comments": "Lú"
+          },
+          "MO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Mayo",
+            "DXCC Entity Code": "245",
+            "Comments": "Maigh Eo"
+          },
+          "MH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Meath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Mhí"
+          },
+          "MN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Monaghan",
+            "DXCC Entity Code": "245",
+            "Comments": "Muineachán"
+          },
+          "OY.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OY",
+            "Primary Administrative Subdivision": "Offaly",
+            "DXCC Entity Code": "245",
+            "Comments": "Uíbh Fhailí"
+          },
+          "RN.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Roscommon",
+            "DXCC Entity Code": "245",
+            "Comments": "Ros Comáin"
+          },
+          "SO.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sligo",
+            "DXCC Entity Code": "245",
+            "Comments": "Sligeach"
+          },
+          "TA.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Tipperary",
+            "DXCC Entity Code": "245",
+            "Comments": "Tiobraid Árann"
+          },
+          "WD.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WD",
+            "Primary Administrative Subdivision": "Waterford",
+            "DXCC Entity Code": "245",
+            "Comments": "Port Láirge"
+          },
+          "WH.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WH",
+            "Primary Administrative Subdivision": "Westmeath",
+            "DXCC Entity Code": "245",
+            "Comments": "An Iarmhí"
+          },
+          "WX.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WX",
+            "Primary Administrative Subdivision": "Wexford",
+            "DXCC Entity Code": "245",
+            "Comments": "Loch Garman"
+          },
+          "WW.245": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WW",
+            "Primary Administrative Subdivision": "Wicklow",
+            "DXCC Entity Code": "245",
+            "Comments": "Cill Mhantáin"
+          },
+          "GE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "IM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IM",
+            "Primary Administrative Subdivision": "Imperia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SP",
+            "Primary Administrative Subdivision": "La Spezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "SV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Savona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Liguria"
+          },
+          "AL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alessandria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AT",
+            "Primary Administrative Subdivision": "Asti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "BI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Biella",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "CN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Cuneo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "NO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NO",
+            "Primary Administrative Subdivision": "Novara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "TO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Torino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VB",
+            "Primary Administrative Subdivision": "Verbano Cusio Ossola",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "VC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Vercelli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Piedmont (Piemonte)"
+          },
+          "AO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AO",
+            "Primary Administrative Subdivision": "Aosta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Aosta Valley (Valle D\u0027Aosta)"
+          },
+          "BG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bergamo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Brescia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Como",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "CR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Cremona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LC",
+            "Primary Administrative Subdivision": "Lecco",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "LO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "Lodi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MB",
+            "Primary Administrative Subdivision": "Monza e Brianza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Mantova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "MI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Milano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "PV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PV",
+            "Primary Administrative Subdivision": "Pavia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "SO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Sondrio",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "VA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Varese",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Lombardy (Lombardia)"
+          },
+          "BL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Belluno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "PD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PD",
+            "Primary Administrative Subdivision": "Padova",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "RO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RO",
+            "Primary Administrative Subdivision": "Rovigo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "TV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TV",
+            "Primary Administrative Subdivision": "Treviso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VE",
+            "Primary Administrative Subdivision": "Venezia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Verona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "VI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vicenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Veneto"
+          },
+          "BZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Bolzano",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "TN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Trento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Trentino-South Tyrol (Trentino-Alto Adige)"
+          },
+          "GO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GO",
+            "Primary Administrative Subdivision": "Gorizia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "PN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PN",
+            "Primary Administrative Subdivision": "Pordenone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "TS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TS",
+            "Primary Administrative Subdivision": "Trieste",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "UD.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UD",
+            "Primary Administrative Subdivision": "Udine",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Friuli-Venezia Giulia"
+          },
+          "BO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BO",
+            "Primary Administrative Subdivision": "Bologna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FE",
+            "Primary Administrative Subdivision": "Ferrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "FO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FO",
+            "Primary Administrative Subdivision": "Forlì",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna",
+            "Import-only": "true"
+          },
+          "FC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FC",
+            "Primary Administrative Subdivision": "Forlì-Cesena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "MO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Modena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PR",
+            "Primary Administrative Subdivision": "Parma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "PC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PC",
+            "Primary Administrative Subdivision": "Piacenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RA",
+            "Primary Administrative Subdivision": "Ravenna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RE",
+            "Primary Administrative Subdivision": "Reggio Emilia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "RN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RN",
+            "Primary Administrative Subdivision": "Rimini",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Emilia Romagna"
+          },
+          "AR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arezzo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "FI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FI",
+            "Primary Administrative Subdivision": "Firenze",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "GR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Grosseto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Livorno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "LU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lucca",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "MS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Massa Carrara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Pistoia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PI",
+            "Primary Administrative Subdivision": "Pisa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "PO.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Prato",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "SI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SI",
+            "Primary Administrative Subdivision": "Siena",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Tuscany (Toscana)"
+          },
+          "CH.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AQ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AQ",
+            "Primary Administrative Subdivision": "L\u0027Aquila",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "PE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PE",
+            "Primary Administrative Subdivision": "Pescara",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "TE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teramo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Abruzzo"
+          },
+          "AN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AN",
+            "Primary Administrative Subdivision": "Ancona",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "AP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Ascoli Piceno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "FM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FM",
+            "Primary Administrative Subdivision": "Fermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MC",
+            "Primary Administrative Subdivision": "Macerata",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "PS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PS",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche",
+            "Import-only": "true"
+          },
+          "PU.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PU",
+            "Primary Administrative Subdivision": "Pesaro e Urbino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Marche"
+          },
+          "MT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Matera",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "PZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PZ",
+            "Primary Administrative Subdivision": "Potenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Basilicata"
+          },
+          "BA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Bari",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Barletta-Andria-Trani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "BR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brindisi",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "FG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FG",
+            "Primary Administrative Subdivision": "Foggia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "LE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "Lecce",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "TA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TA",
+            "Primary Administrative Subdivision": "Taranto",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Puglia"
+          },
+          "CZ.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CZ",
+            "Primary Administrative Subdivision": "Catanzaro",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "CS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Cosenza",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "KR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Crotone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "RC.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RC",
+            "Primary Administrative Subdivision": "Reggio Calabria",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "VV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VV",
+            "Primary Administrative Subdivision": "Vibo Valentia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Calabria"
+          },
+          "AV.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Avellino",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "BN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Benevento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "CE.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CE",
+            "Primary Administrative Subdivision": "Caserta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "NA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Napoli",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "SA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salerno",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Campania"
+          },
+          "IS.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Isernia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "CB.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Campobasso",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Molise"
+          },
+          "FR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Frosinone",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "LT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LT",
+            "Primary Administrative Subdivision": "Latina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RI.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rieti",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "RM.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RM",
+            "Primary Administrative Subdivision": "Roma",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "VT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Viterbo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Latium (Lazio)"
+          },
+          "PG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Perugia",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "TR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Terni",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Umbria"
+          },
+          "AG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Agrigento",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CL.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Caltanissetta",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "CT.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Catania",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "EN.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EN",
+            "Primary Administrative Subdivision": "Enna",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "ME.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Messina",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "PA.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Palermo",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "RG.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RG",
+            "Primary Administrative Subdivision": "Ragusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "SR.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Siracusa",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "TP.248": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TP",
+            "Primary Administrative Subdivision": "Trapani",
+            "DXCC Entity Code": "248",
+            "Contained Within": "Sicliy (Sicilia)"
+          },
+          "21.259": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Svalbard",
+            "DXCC Entity Code": "259"
+          },
+          "42.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Agder",
+            "DXCC Entity Code": "266"
+          },
+          "34.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Innlandet",
+            "DXCC Entity Code": "266"
+          },
+          "15.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Møre og Romsdal",
+            "DXCC Entity Code": "266"
+          },
+          "18.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Nordland",
+            "DXCC Entity Code": "266"
+          },
+          "03.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Oslo",
+            "DXCC Entity Code": "266"
+          },
+          "11.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Rogaland",
+            "DXCC Entity Code": "266"
+          },
+          "54.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "54",
+            "Primary Administrative Subdivision": "Troms og Finnmark",
+            "DXCC Entity Code": "266"
+          },
+          "50.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "50",
+            "Primary Administrative Subdivision": "Trøndelag",
+            "DXCC Entity Code": "266"
+          },
+          "38.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Vestfold og Telemark",
+            "DXCC Entity Code": "266"
+          },
+          "46.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Vestland",
+            "DXCC Entity Code": "266"
+          },
+          "30.266": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Viken",
+            "DXCC Entity Code": "266"
+          },
+          "MD.256": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Madeira",
+            "DXCC Entity Code": "256"
+          },
+          "DR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DR",
+            "Primary Administrative Subdivision": "Drenthe",
+            "DXCC Entity Code": "263"
+          },
+          "FR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Fryslân",
+            "DXCC Entity Code": "263"
+          },
+          "GR.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Groningen",
+            "DXCC Entity Code": "263"
+          },
+          "NB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NB",
+            "Primary Administrative Subdivision": "Noord-Brabant",
+            "DXCC Entity Code": "263"
+          },
+          "OV.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OV",
+            "Primary Administrative Subdivision": "Overijssel",
+            "DXCC Entity Code": "263"
+          },
+          "ZH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuid-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "FL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Flevoland",
+            "DXCC Entity Code": "263"
+          },
+          "GD.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "GE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Gelderland",
+            "DXCC Entity Code": "263"
+          },
+          "LB.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LB",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "LI.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LI",
+            "Primary Administrative Subdivision": "Limburg",
+            "DXCC Entity Code": "263"
+          },
+          "NH.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "Noord-Holland",
+            "DXCC Entity Code": "263"
+          },
+          "UT.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utrecht",
+            "DXCC Entity Code": "263"
+          },
+          "ZL.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZL",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263",
+            "Import-only": "true"
+          },
+          "ZE.263": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZE",
+            "Primary Administrative Subdivision": "Zeeland",
+            "DXCC Entity Code": "263"
+          },
+          "Z.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zachodnio-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "F.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "P.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Kujawsko-Pomorskie",
+            "DXCC Entity Code": "269"
+          },
+          "B.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Lubuskie",
+            "DXCC Entity Code": "269"
+          },
+          "W.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Wielkopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "J.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Warminsko-Mazurskie",
+            "DXCC Entity Code": "269"
+          },
+          "O.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Podlaskie",
+            "DXCC Entity Code": "269"
+          },
+          "R.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "R",
+            "Primary Administrative Subdivision": "Mazowieckie",
+            "DXCC Entity Code": "269"
+          },
+          "D.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Dolnoslaskie",
+            "DXCC Entity Code": "269"
+          },
+          "U.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Opolskie",
+            "DXCC Entity Code": "269"
+          },
+          "C.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Lodzkie",
+            "DXCC Entity Code": "269"
+          },
+          "S.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Swietokrzyskie",
+            "DXCC Entity Code": "269"
+          },
+          "K.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Podkarpackie",
+            "DXCC Entity Code": "269"
+          },
+          "L.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lubelskie",
+            "DXCC Entity Code": "269"
+          },
+          "G.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Slaskie",
+            "DXCC Entity Code": "269"
+          },
+          "M.269": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Malopolskie",
+            "DXCC Entity Code": "269"
+          },
+          "AV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Aveiro",
+            "DXCC Entity Code": "272"
+          },
+          "BJ.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beja",
+            "DXCC Entity Code": "272"
+          },
+          "BR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Braga",
+            "DXCC Entity Code": "272"
+          },
+          "BG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BG",
+            "Primary Administrative Subdivision": "Bragança",
+            "DXCC Entity Code": "272"
+          },
+          "CB.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CB",
+            "Primary Administrative Subdivision": "Castelo Branco",
+            "DXCC Entity Code": "272"
+          },
+          "CO.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Coimbra",
+            "DXCC Entity Code": "272"
+          },
+          "EV.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EV",
+            "Primary Administrative Subdivision": "Evora",
+            "DXCC Entity Code": "272"
+          },
+          "FR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Faro",
+            "DXCC Entity Code": "272"
+          },
+          "GD.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guarda",
+            "DXCC Entity Code": "272"
+          },
+          "LR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LR",
+            "Primary Administrative Subdivision": "Leiria",
+            "DXCC Entity Code": "272"
+          },
+          "LX.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LX",
+            "Primary Administrative Subdivision": "Lisboa",
+            "DXCC Entity Code": "272"
+          },
+          "PG.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PG",
+            "Primary Administrative Subdivision": "Portalegre",
+            "DXCC Entity Code": "272"
+          },
+          "PT.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PT",
+            "Primary Administrative Subdivision": "Porto",
+            "DXCC Entity Code": "272"
+          },
+          "SR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SR",
+            "Primary Administrative Subdivision": "Santarem",
+            "DXCC Entity Code": "272"
+          },
+          "ST.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ST",
+            "Primary Administrative Subdivision": "Setubal",
+            "DXCC Entity Code": "272"
+          },
+          "VC.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VC",
+            "Primary Administrative Subdivision": "Viana do Castelo",
+            "DXCC Entity Code": "272"
+          },
+          "VR.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VR",
+            "Primary Administrative Subdivision": "Vila Real",
+            "DXCC Entity Code": "272"
+          },
+          "VS.272": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Viseu",
+            "DXCC Entity Code": "272"
+          },
+          "AR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arad",
+            "DXCC Entity Code": "275"
+          },
+          "CS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Caraș-Severin",
+            "DXCC Entity Code": "275"
+          },
+          "HD.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HD",
+            "Primary Administrative Subdivision": "Hunedoara",
+            "DXCC Entity Code": "275"
+          },
+          "TM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TM",
+            "Primary Administrative Subdivision": "Timiș",
+            "DXCC Entity Code": "275"
+          },
+          "BU.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Bucureşti",
+            "DXCC Entity Code": "275",
+            "Import-only": "true",
+            "Comments": "Bucure\u0027ti"
+          },
+          "B.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "București",
+            "DXCC Entity Code": "275"
+          },
+          "IF.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ilfov",
+            "DXCC Entity Code": "275"
+          },
+          "BR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Brăila",
+            "DXCC Entity Code": "275"
+          },
+          "CT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Constanța",
+            "DXCC Entity Code": "275"
+          },
+          "GL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Galați",
+            "DXCC Entity Code": "275"
+          },
+          "TL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TL",
+            "Primary Administrative Subdivision": "Tulcea",
+            "DXCC Entity Code": "275"
+          },
+          "VN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VN",
+            "Primary Administrative Subdivision": "Vrancea",
+            "DXCC Entity Code": "275"
+          },
+          "AB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Alba",
+            "DXCC Entity Code": "275"
+          },
+          "BH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BH",
+            "Primary Administrative Subdivision": "Bihor",
+            "DXCC Entity Code": "275"
+          },
+          "BN.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BN",
+            "Primary Administrative Subdivision": "Bistrița-Năsăud",
+            "DXCC Entity Code": "275"
+          },
+          "CJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJ",
+            "Primary Administrative Subdivision": "Cluj",
+            "DXCC Entity Code": "275"
+          },
+          "MM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MM",
+            "Primary Administrative Subdivision": "Maramureș",
+            "DXCC Entity Code": "275"
+          },
+          "SJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SJ",
+            "Primary Administrative Subdivision": "Sălaj",
+            "DXCC Entity Code": "275"
+          },
+          "SM.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SM",
+            "Primary Administrative Subdivision": "Satu Mare",
+            "DXCC Entity Code": "275"
+          },
+          "BV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BV",
+            "Primary Administrative Subdivision": "Brașov",
+            "DXCC Entity Code": "275"
+          },
+          "CV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CV",
+            "Primary Administrative Subdivision": "Covasna",
+            "DXCC Entity Code": "275"
+          },
+          "HR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Harghita",
+            "DXCC Entity Code": "275"
+          },
+          "MS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mureș",
+            "DXCC Entity Code": "275"
+          },
+          "SB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SB",
+            "Primary Administrative Subdivision": "Sibiu",
+            "DXCC Entity Code": "275"
+          },
+          "AG.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Argeș",
+            "DXCC Entity Code": "275"
+          },
+          "DJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DJ",
+            "Primary Administrative Subdivision": "Dolj",
+            "DXCC Entity Code": "275"
+          },
+          "GJ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gorj",
+            "DXCC Entity Code": "275"
+          },
+          "MH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mehedinți",
+            "DXCC Entity Code": "275"
+          },
+          "OT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OT",
+            "Primary Administrative Subdivision": "Olt",
+            "DXCC Entity Code": "275"
+          },
+          "VL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VL",
+            "Primary Administrative Subdivision": "Vâlcea",
+            "DXCC Entity Code": "275"
+          },
+          "BC.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BC",
+            "Primary Administrative Subdivision": "Bacău",
+            "DXCC Entity Code": "275"
+          },
+          "BT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BT",
+            "Primary Administrative Subdivision": "Botoșani",
+            "DXCC Entity Code": "275"
+          },
+          "IS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IS",
+            "Primary Administrative Subdivision": "Iași",
+            "DXCC Entity Code": "275"
+          },
+          "NT.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NT",
+            "Primary Administrative Subdivision": "Neamț",
+            "DXCC Entity Code": "275"
+          },
+          "SV.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SV",
+            "Primary Administrative Subdivision": "Suceava",
+            "DXCC Entity Code": "275"
+          },
+          "VS.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Vaslui",
+            "DXCC Entity Code": "275"
+          },
+          "BZ.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BZ",
+            "Primary Administrative Subdivision": "Buzău",
+            "DXCC Entity Code": "275"
+          },
+          "CL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CL",
+            "Primary Administrative Subdivision": "Călărași",
+            "DXCC Entity Code": "275"
+          },
+          "DB.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DB",
+            "Primary Administrative Subdivision": "Dâmbovița",
+            "DXCC Entity Code": "275"
+          },
+          "GR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Giurgiu",
+            "DXCC Entity Code": "275"
+          },
+          "IL.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Ialomița",
+            "DXCC Entity Code": "275"
+          },
+          "PH.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PH",
+            "Primary Administrative Subdivision": "Prahova",
+            "DXCC Entity Code": "275"
+          },
+          "TR.275": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Teleorman",
+            "DXCC Entity Code": "275"
+          },
+          "AV.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AV",
+            "Primary Administrative Subdivision": "Ávila",
+            "DXCC Entity Code": "281"
+          },
+          "BU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BU",
+            "Primary Administrative Subdivision": "Burgos",
+            "DXCC Entity Code": "281"
+          },
+          "C.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "A Coruña",
+            "DXCC Entity Code": "281"
+          },
+          "LE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LE",
+            "Primary Administrative Subdivision": "León",
+            "DXCC Entity Code": "281"
+          },
+          "LO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LO",
+            "Primary Administrative Subdivision": "La Rioja",
+            "DXCC Entity Code": "281"
+          },
+          "LU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Lugo",
+            "DXCC Entity Code": "281"
+          },
+          "O.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Asturias",
+            "DXCC Entity Code": "281"
+          },
+          "OU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OU",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281",
+            "Import-only": "true"
+          },
+          "OR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Ourense",
+            "DXCC Entity Code": "281"
+          },
+          "P.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "P",
+            "Primary Administrative Subdivision": "Palencia",
+            "DXCC Entity Code": "281"
+          },
+          "PO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Pontevedra",
+            "DXCC Entity Code": "281"
+          },
+          "S.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Cantabria",
+            "DXCC Entity Code": "281"
+          },
+          "SA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SA",
+            "Primary Administrative Subdivision": "Salamanca",
+            "DXCC Entity Code": "281"
+          },
+          "SG.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "Segovia",
+            "DXCC Entity Code": "281"
+          },
+          "SO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Soria",
+            "DXCC Entity Code": "281"
+          },
+          "VA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Valladolid",
+            "DXCC Entity Code": "281"
+          },
+          "ZA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zamora",
+            "DXCC Entity Code": "281"
+          },
+          "BI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BI",
+            "Primary Administrative Subdivision": "Bizkaia",
+            "DXCC Entity Code": "281"
+          },
+          "HU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HU",
+            "Primary Administrative Subdivision": "Huesca",
+            "DXCC Entity Code": "281"
+          },
+          "NA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NA",
+            "Primary Administrative Subdivision": "Navarra",
+            "DXCC Entity Code": "281"
+          },
+          "SS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SS",
+            "Primary Administrative Subdivision": "Gipuzkoa",
+            "DXCC Entity Code": "281"
+          },
+          "TE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Teruel",
+            "DXCC Entity Code": "281"
+          },
+          "VI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Álava",
+            "DXCC Entity Code": "281"
+          },
+          "Z.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Zaragoza",
+            "DXCC Entity Code": "281"
+          },
+          "B.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "B",
+            "Primary Administrative Subdivision": "Barcelona",
+            "DXCC Entity Code": "281"
+          },
+          "GI.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GI",
+            "Primary Administrative Subdivision": "Girona",
+            "DXCC Entity Code": "281"
+          },
+          "L.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "L",
+            "Primary Administrative Subdivision": "Lleida",
+            "DXCC Entity Code": "281"
+          },
+          "T.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Tarragona",
+            "DXCC Entity Code": "281"
+          },
+          "BA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BA",
+            "Primary Administrative Subdivision": "Badajoz",
+            "DXCC Entity Code": "281"
+          },
+          "CC.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CC",
+            "Primary Administrative Subdivision": "Cáceres",
+            "DXCC Entity Code": "281"
+          },
+          "CR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Ciudad Real",
+            "DXCC Entity Code": "281"
+          },
+          "CU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CU",
+            "Primary Administrative Subdivision": "Cuenca",
+            "DXCC Entity Code": "281"
+          },
+          "GU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GU",
+            "Primary Administrative Subdivision": "Guadalajara",
+            "DXCC Entity Code": "281"
+          },
+          "M.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Madrid",
+            "DXCC Entity Code": "281"
+          },
+          "TO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TO",
+            "Primary Administrative Subdivision": "Toledo",
+            "DXCC Entity Code": "281"
+          },
+          "A.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "A",
+            "Primary Administrative Subdivision": "Alicante",
+            "DXCC Entity Code": "281"
+          },
+          "AB.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Albacete",
+            "DXCC Entity Code": "281"
+          },
+          "CS.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CS",
+            "Primary Administrative Subdivision": "Castellón",
+            "DXCC Entity Code": "281"
+          },
+          "MU.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MU",
+            "Primary Administrative Subdivision": "Murcia",
+            "DXCC Entity Code": "281"
+          },
+          "V.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "V",
+            "Primary Administrative Subdivision": "València",
+            "DXCC Entity Code": "281"
+          },
+          "AL.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Almeria",
+            "DXCC Entity Code": "281"
+          },
+          "CA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "Cádiz",
+            "DXCC Entity Code": "281"
+          },
+          "CO.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Córdoba",
+            "DXCC Entity Code": "281"
+          },
+          "GR.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Granada",
+            "DXCC Entity Code": "281"
+          },
+          "H.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Huelva",
+            "DXCC Entity Code": "281"
+          },
+          "J.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "J",
+            "Primary Administrative Subdivision": "Jaén",
+            "DXCC Entity Code": "281"
+          },
+          "MA.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Málaga",
+            "DXCC Entity Code": "281"
+          },
+          "SE.281": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SE",
+            "Primary Administrative Subdivision": "Sevilla",
+            "DXCC Entity Code": "281"
+          },
+          "AB.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AB",
+            "Primary Administrative Subdivision": "Stockholms län",
+            "DXCC Entity Code": "284"
+          },
+          "I.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "I",
+            "Primary Administrative Subdivision": "Gotlands län",
+            "DXCC Entity Code": "284"
+          },
+          "BD.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BD",
+            "Primary Administrative Subdivision": "Norrbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "AC.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AC",
+            "Primary Administrative Subdivision": "Västerbottens län",
+            "DXCC Entity Code": "284"
+          },
+          "X.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "X",
+            "Primary Administrative Subdivision": "Gävleborgs län",
+            "DXCC Entity Code": "284"
+          },
+          "Z.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Z",
+            "Primary Administrative Subdivision": "Jämtlands län",
+            "DXCC Entity Code": "284"
+          },
+          "Y.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "Y",
+            "Primary Administrative Subdivision": "Västernorrlands län",
+            "DXCC Entity Code": "284"
+          },
+          "W.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "W",
+            "Primary Administrative Subdivision": "Dalarnas län",
+            "DXCC Entity Code": "284"
+          },
+          "S.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "S",
+            "Primary Administrative Subdivision": "Värmlands län",
+            "DXCC Entity Code": "284"
+          },
+          "O.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "O",
+            "Primary Administrative Subdivision": "Västra Götalands län",
+            "DXCC Entity Code": "284"
+          },
+          "T.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "T",
+            "Primary Administrative Subdivision": "Örebro län",
+            "DXCC Entity Code": "284"
+          },
+          "E.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "E",
+            "Primary Administrative Subdivision": "Östergötlands län",
+            "DXCC Entity Code": "284"
+          },
+          "D.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "D",
+            "Primary Administrative Subdivision": "Södermanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "C.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "C",
+            "Primary Administrative Subdivision": "Uppsala län",
+            "DXCC Entity Code": "284"
+          },
+          "U.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "U",
+            "Primary Administrative Subdivision": "Västmanlands län",
+            "DXCC Entity Code": "284"
+          },
+          "N.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "N",
+            "Primary Administrative Subdivision": "Hallands län",
+            "DXCC Entity Code": "284"
+          },
+          "K.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "K",
+            "Primary Administrative Subdivision": "Blekinge län",
+            "DXCC Entity Code": "284"
+          },
+          "F.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "F",
+            "Primary Administrative Subdivision": "Jönköpings län",
+            "DXCC Entity Code": "284"
+          },
+          "H.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "H",
+            "Primary Administrative Subdivision": "Kalmar län",
+            "DXCC Entity Code": "284"
+          },
+          "G.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "G",
+            "Primary Administrative Subdivision": "Kronobergs län",
+            "DXCC Entity Code": "284"
+          },
+          "M.284": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "M",
+            "Primary Administrative Subdivision": "Skåne län",
+            "DXCC Entity Code": "284"
+          },
+          "AG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AG",
+            "Primary Administrative Subdivision": "Aargau",
+            "DXCC Entity Code": "287"
+          },
+          "AR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Appenzell Ausserrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "AI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AI",
+            "Primary Administrative Subdivision": "Appenzell Innerrhoden",
+            "DXCC Entity Code": "287"
+          },
+          "BL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BL",
+            "Primary Administrative Subdivision": "Basel Landschaft",
+            "DXCC Entity Code": "287"
+          },
+          "BS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BS",
+            "Primary Administrative Subdivision": "Basel Stadt",
+            "DXCC Entity Code": "287"
+          },
+          "BE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BE",
+            "Primary Administrative Subdivision": "Bern",
+            "DXCC Entity Code": "287"
+          },
+          "FR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FR",
+            "Primary Administrative Subdivision": "Freiburg / Fribourg",
+            "DXCC Entity Code": "287"
+          },
+          "GE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GE",
+            "Primary Administrative Subdivision": "Genf / Genève",
+            "DXCC Entity Code": "287"
+          },
+          "GL.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GL",
+            "Primary Administrative Subdivision": "Glarus",
+            "DXCC Entity Code": "287"
+          },
+          "GR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GR",
+            "Primary Administrative Subdivision": "Graubuenden / Grisons",
+            "DXCC Entity Code": "287"
+          },
+          "JU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JU",
+            "Primary Administrative Subdivision": "Jura",
+            "DXCC Entity Code": "287"
+          },
+          "LU.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luzern",
+            "DXCC Entity Code": "287"
+          },
+          "NE.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Neuenburg / Neuchâtel",
+            "DXCC Entity Code": "287"
+          },
+          "NW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NW",
+            "Primary Administrative Subdivision": "Nidwalden",
+            "DXCC Entity Code": "287"
+          },
+          "OW.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OW",
+            "Primary Administrative Subdivision": "Obwalden",
+            "DXCC Entity Code": "287"
+          },
+          "SH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Schaffhausen",
+            "DXCC Entity Code": "287"
+          },
+          "SZ.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SZ",
+            "Primary Administrative Subdivision": "Schwyz",
+            "DXCC Entity Code": "287"
+          },
+          "SO.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SO",
+            "Primary Administrative Subdivision": "Solothurn",
+            "DXCC Entity Code": "287"
+          },
+          "SG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SG",
+            "Primary Administrative Subdivision": "St. Gallen",
+            "DXCC Entity Code": "287"
+          },
+          "TI.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TI",
+            "Primary Administrative Subdivision": "Tessin / Ticino",
+            "DXCC Entity Code": "287"
+          },
+          "TG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Thurgau",
+            "DXCC Entity Code": "287"
+          },
+          "UR.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UR",
+            "Primary Administrative Subdivision": "Uri",
+            "DXCC Entity Code": "287"
+          },
+          "VD.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VD",
+            "Primary Administrative Subdivision": "Waadt / Vaud",
+            "DXCC Entity Code": "287"
+          },
+          "VS.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VS",
+            "Primary Administrative Subdivision": "Wallis / Valais",
+            "DXCC Entity Code": "287"
+          },
+          "ZH.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zuerich",
+            "DXCC Entity Code": "287"
+          },
+          "ZG.287": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZG",
+            "Primary Administrative Subdivision": "Zug",
+            "DXCC Entity Code": "287"
+          },
+          "SU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SU",
+            "Primary Administrative Subdivision": "Sums\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "TE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TE",
+            "Primary Administrative Subdivision": "Ternopil\u0027s\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Cherkas\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZA",
+            "Primary Administrative Subdivision": "Zakarpats\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dnipropetrovs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "OD.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odes\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HE.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Khersons\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "PO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PO",
+            "Primary Administrative Subdivision": "Poltavs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "DO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DO",
+            "Primary Administrative Subdivision": "Donets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "RI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rivnens\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HA.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Kharkivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LU.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LU",
+            "Primary Administrative Subdivision": "Luhans\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VI",
+            "Primary Administrative Subdivision": "Vinnyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "VO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VO",
+            "Primary Administrative Subdivision": "Volyos\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZP.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZP",
+            "Primary Administrative Subdivision": "Zaporiz\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CR",
+            "Primary Administrative Subdivision": "Chernihivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "IF.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IF",
+            "Primary Administrative Subdivision": "Ivano-Frankivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "HM.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HM",
+            "Primary Administrative Subdivision": "Khmel\u0027nyts\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KV",
+            "Primary Administrative Subdivision": "Kyïv",
+            "DXCC Entity Code": "288"
+          },
+          "KO.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KO",
+            "Primary Administrative Subdivision": "Kyivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KI",
+            "Primary Administrative Subdivision": "Kirovohrads\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "LV.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LV",
+            "Primary Administrative Subdivision": "L\u0027vivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "ZH.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZH",
+            "Primary Administrative Subdivision": "Zhytomyrs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CN.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CN",
+            "Primary Administrative Subdivision": "Chernivets\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "NI.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NI",
+            "Primary Administrative Subdivision": "Mykolaivs\u0027ka Oblast\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "KR.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KR",
+            "Primary Administrative Subdivision": "Respublika Krym",
+            "DXCC Entity Code": "288"
+          },
+          "SL.288": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SL",
+            "Primary Administrative Subdivision": "Sevastopol\u0027",
+            "DXCC Entity Code": "288"
+          },
+          "CT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CT",
+            "Primary Administrative Subdivision": "Connecticut",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "ME.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ME",
+            "Primary Administrative Subdivision": "Maine",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MA",
+            "Primary Administrative Subdivision": "Massachusetts",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NH",
+            "Primary Administrative Subdivision": "New Hampshire",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "RI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RI",
+            "Primary Administrative Subdivision": "Rhode Island",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "VT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VT",
+            "Primary Administrative Subdivision": "Vermont",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NJ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NJ",
+            "Primary Administrative Subdivision": "New Jersey",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "NY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NY",
+            "Primary Administrative Subdivision": "New York",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DE",
+            "Primary Administrative Subdivision": "Delaware",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "DC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DC",
+            "Primary Administrative Subdivision": "District of Columbia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "MD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MD",
+            "Primary Administrative Subdivision": "Maryland",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "PA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PA",
+            "Primary Administrative Subdivision": "Pennsylvania",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AL",
+            "Primary Administrative Subdivision": "Alabama",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "FL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FL",
+            "Primary Administrative Subdivision": "Florida",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "GA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Georgia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "KY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KY",
+            "Primary Administrative Subdivision": "Kentucky",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "NC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NC",
+            "Primary Administrative Subdivision": "North Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "SC.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "South Carolina",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "TN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tennessee",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "VA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VA",
+            "Primary Administrative Subdivision": "Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "AR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arkansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "LA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Louisiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MS",
+            "Primary Administrative Subdivision": "Mississippi",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NM.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "New Mexico",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "OK.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OK",
+            "Primary Administrative Subdivision": "Oklahoma",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "TX.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TX",
+            "Primary Administrative Subdivision": "Texas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "CA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CA",
+            "Primary Administrative Subdivision": "California",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "AZ.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AZ",
+            "Primary Administrative Subdivision": "Arizona",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "ID.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ID",
+            "Primary Administrative Subdivision": "Idaho",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "MT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MT",
+            "Primary Administrative Subdivision": "Montana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "06/07"
+          },
+          "NV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NV",
+            "Primary Administrative Subdivision": "Nevada",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "OR.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OR",
+            "Primary Administrative Subdivision": "Oregon",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "UT.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UT",
+            "Primary Administrative Subdivision": "Utah",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06/07"
+          },
+          "WA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WA",
+            "Primary Administrative Subdivision": "Washington",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "03",
+            "ITU Zone": "06"
+          },
+          "WY.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WY",
+            "Primary Administrative Subdivision": "Wyoming",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MI",
+            "Primary Administrative Subdivision": "Michigan",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "OH.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OH",
+            "Primary Administrative Subdivision": "Ohio",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WV.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WV",
+            "Primary Administrative Subdivision": "West Virginia",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "05",
+            "ITU Zone": "08"
+          },
+          "IL.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IL",
+            "Primary Administrative Subdivision": "Illinois",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "IN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IN",
+            "Primary Administrative Subdivision": "Indiana",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "08"
+          },
+          "WI.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WI",
+            "Primary Administrative Subdivision": "Wisconsin",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "CO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CO",
+            "Primary Administrative Subdivision": "Colorado",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "IA.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IA",
+            "Primary Administrative Subdivision": "Iowa",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "KS.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KS",
+            "Primary Administrative Subdivision": "Kansas",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "MN.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Minnesota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "MO.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MO",
+            "Primary Administrative Subdivision": "Missouri",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07/08"
+          },
+          "NE.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NE",
+            "Primary Administrative Subdivision": "Nebraska",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "ND.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ND",
+            "Primary Administrative Subdivision": "North Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "SD.291": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "South Dakota",
+            "DXCC Entity Code": "291",
+            "CQ Zone": "04",
+            "ITU Zone": "07"
+          },
+          "AH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AH",
+            "Primary Administrative Subdivision": "Anhui",
+            "DXCC Entity Code": "318"
+          },
+          "BJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BJ",
+            "Primary Administrative Subdivision": "Beijing",
+            "DXCC Entity Code": "318"
+          },
+          "CQ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CQ",
+            "Primary Administrative Subdivision": "Chongqing",
+            "DXCC Entity Code": "318"
+          },
+          "FJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJ",
+            "Primary Administrative Subdivision": "Fujian",
+            "DXCC Entity Code": "318"
+          },
+          "GD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GD",
+            "Primary Administrative Subdivision": "Guangdong",
+            "DXCC Entity Code": "318"
+          },
+          "GS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GS",
+            "Primary Administrative Subdivision": "Gansu",
+            "DXCC Entity Code": "318"
+          },
+          "GX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GX",
+            "Primary Administrative Subdivision": "Guangxi Zhuangzu",
+            "DXCC Entity Code": "318"
+          },
+          "GZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZ",
+            "Primary Administrative Subdivision": "Guizhou",
+            "DXCC Entity Code": "318"
+          },
+          "HA.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HA",
+            "Primary Administrative Subdivision": "Henan",
+            "DXCC Entity Code": "318"
+          },
+          "HB.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HB",
+            "Primary Administrative Subdivision": "Hubei",
+            "DXCC Entity Code": "318"
+          },
+          "HE.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HE",
+            "Primary Administrative Subdivision": "Hebei",
+            "DXCC Entity Code": "318"
+          },
+          "HI.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HI",
+            "Primary Administrative Subdivision": "Hainan",
+            "DXCC Entity Code": "318"
+          },
+          "HL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HL",
+            "Primary Administrative Subdivision": "Heilongjiang",
+            "DXCC Entity Code": "318"
+          },
+          "HN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HN",
+            "Primary Administrative Subdivision": "Hunan",
+            "DXCC Entity Code": "318"
+          },
+          "JL.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JL",
+            "Primary Administrative Subdivision": "Jilin",
+            "DXCC Entity Code": "318"
+          },
+          "JS.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JS",
+            "Primary Administrative Subdivision": "Jiangsu",
+            "DXCC Entity Code": "318"
+          },
+          "JX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JX",
+            "Primary Administrative Subdivision": "Jiangxi",
+            "DXCC Entity Code": "318"
+          },
+          "LN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LN",
+            "Primary Administrative Subdivision": "Liaoning",
+            "DXCC Entity Code": "318"
+          },
+          "NM.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NM",
+            "Primary Administrative Subdivision": "Nei Mongol",
+            "DXCC Entity Code": "318"
+          },
+          "NX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NX",
+            "Primary Administrative Subdivision": "Ningxia Huizu",
+            "DXCC Entity Code": "318"
+          },
+          "QH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QH",
+            "Primary Administrative Subdivision": "Qinghai",
+            "DXCC Entity Code": "318"
+          },
+          "SC.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SC",
+            "Primary Administrative Subdivision": "Sichuan",
+            "DXCC Entity Code": "318"
+          },
+          "SD.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SD",
+            "Primary Administrative Subdivision": "Shandong",
+            "DXCC Entity Code": "318"
+          },
+          "SH.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SH",
+            "Primary Administrative Subdivision": "Shanghai",
+            "DXCC Entity Code": "318"
+          },
+          "SN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SN",
+            "Primary Administrative Subdivision": "Shaanxi",
+            "DXCC Entity Code": "318"
+          },
+          "SX.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SX",
+            "Primary Administrative Subdivision": "Shanxi",
+            "DXCC Entity Code": "318"
+          },
+          "TJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TJ",
+            "Primary Administrative Subdivision": "Tianjin",
+            "DXCC Entity Code": "318"
+          },
+          "XJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XJ",
+            "Primary Administrative Subdivision": "Xinjiang Uygur",
+            "DXCC Entity Code": "318"
+          },
+          "XZ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "XZ",
+            "Primary Administrative Subdivision": "Xizang",
+            "DXCC Entity Code": "318"
+          },
+          "YN.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YN",
+            "Primary Administrative Subdivision": "Yunnan",
+            "DXCC Entity Code": "318"
+          },
+          "ZJ.318": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZJ",
+            "Primary Administrative Subdivision": "Zhejiang",
+            "DXCC Entity Code": "318"
+          },
+          "AP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AP",
+            "Primary Administrative Subdivision": "Andhra Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AR",
+            "Primary Administrative Subdivision": "Arunāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "AS.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AS",
+            "Primary Administrative Subdivision": "Assam",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "BR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BR",
+            "Primary Administrative Subdivision": "Bihār",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "CH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CH",
+            "Primary Administrative Subdivision": "Chandīgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "CG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CG",
+            "Primary Administrative Subdivision": "Chhattīsgarh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "DD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DD",
+            "Primary Administrative Subdivision": "Damān and Diu",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DL",
+            "Primary Administrative Subdivision": "Delhi",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "DN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DN",
+            "Primary Administrative Subdivision": "Dādra and Nagar Haveli",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "GA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GA",
+            "Primary Administrative Subdivision": "Goa",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "GJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJ",
+            "Primary Administrative Subdivision": "Gujarāt",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HR",
+            "Primary Administrative Subdivision": "Haryāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "HP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HP",
+            "Primary Administrative Subdivision": "Himāchal Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "JK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JK",
+            "Primary Administrative Subdivision": "Jammu and Kashmīr",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "JH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "JH",
+            "Primary Administrative Subdivision": "Jhārkhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KA",
+            "Primary Administrative Subdivision": "Karnātaka",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "KL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KL",
+            "Primary Administrative Subdivision": "Kerala",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "LA.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LA",
+            "Primary Administrative Subdivision": "Ladākh",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "MP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MP",
+            "Primary Administrative Subdivision": "Madhya Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MH.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MH",
+            "Primary Administrative Subdivision": "Mahārāshtra",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MN",
+            "Primary Administrative Subdivision": "Manipur",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "ML.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ML",
+            "Primary Administrative Subdivision": "Meghālaya",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "MZ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MZ",
+            "Primary Administrative Subdivision": "Mizoram",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "NL.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NL",
+            "Primary Administrative Subdivision": "Nāgāland",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "OD.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "OD",
+            "Primary Administrative Subdivision": "Odisha",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "PY.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PY",
+            "Primary Administrative Subdivision": "Puducherry",
+            "DXCC Entity Code": "324",
+            "Comments": "Union territory"
+          },
+          "PB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PB",
+            "Primary Administrative Subdivision": "Punjab",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "RJ.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RJ",
+            "Primary Administrative Subdivision": "Rājasthān",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "SK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SK",
+            "Primary Administrative Subdivision": "Sikkim",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TN.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TN",
+            "Primary Administrative Subdivision": "Tamil Nādu",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TG.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TG",
+            "Primary Administrative Subdivision": "Telangāna",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "TR.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TR",
+            "Primary Administrative Subdivision": "Tripura",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UP.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UP",
+            "Primary Administrative Subdivision": "Uttar Pradesh",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "UK.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "UK",
+            "Primary Administrative Subdivision": "Uttarākhand",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "WB.324": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WB",
+            "Primary Administrative Subdivision": "West Bengal",
+            "DXCC Entity Code": "324",
+            "Comments": "state"
+          },
+          "12.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Chiba",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "16.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Gunma",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "14.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Ibaraki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "11.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Kanagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "13.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Saitama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "15.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Tochigi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "10.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Tokyo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "17.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Yamanashi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kanto"
+          },
+          "20.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Aichi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "19.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Gifu",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "21.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Mie",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "18.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Shizuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tokai"
+          },
+          "27.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "27",
+            "Primary Administrative Subdivision": "Hyogo",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "22.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "22",
+            "Primary Administrative Subdivision": "Kyoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "24.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "24",
+            "Primary Administrative Subdivision": "Nara",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "25.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "25",
+            "Primary Administrative Subdivision": "Osaka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "23.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "23",
+            "Primary Administrative Subdivision": "Shiga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "26.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "26",
+            "Primary Administrative Subdivision": "Wakayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kansai"
+          },
+          "35.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "35",
+            "Primary Administrative Subdivision": "Hiroshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "31.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "31",
+            "Primary Administrative Subdivision": "Okayama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "32.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "32",
+            "Primary Administrative Subdivision": "Shimane",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "34.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "34",
+            "Primary Administrative Subdivision": "Tottori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "33.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "33",
+            "Primary Administrative Subdivision": "Yamaguchi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Chugoku"
+          },
+          "38.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "38",
+            "Primary Administrative Subdivision": "Ehime",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "36.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "36",
+            "Primary Administrative Subdivision": "Kagawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "39.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "39",
+            "Primary Administrative Subdivision": "Kochi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "37.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "37",
+            "Primary Administrative Subdivision": "Tokushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shikoku"
+          },
+          "40.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "40",
+            "Primary Administrative Subdivision": "Fukuoka",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "46.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "46",
+            "Primary Administrative Subdivision": "Kagoshima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "43.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "43",
+            "Primary Administrative Subdivision": "Kumamoto",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "45.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "45",
+            "Primary Administrative Subdivision": "Miyazaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "42.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "42",
+            "Primary Administrative Subdivision": "Nagasaki",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "44.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "44",
+            "Primary Administrative Subdivision": "Oita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "47.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "47",
+            "Primary Administrative Subdivision": "Okinawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "41.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "41",
+            "Primary Administrative Subdivision": "Saga",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Kyushu"
+          },
+          "04.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Akita",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "02.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Aomori",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "07.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Fukushima",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "03.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Iwate",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "06.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Miyagi",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "05.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Yamagata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Tohoku"
+          },
+          "01.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Hokkaido",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokkaido"
+          },
+          "29.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "29",
+            "Primary Administrative Subdivision": "Fukui",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "30.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "30",
+            "Primary Administrative Subdivision": "Ishikawa",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "28.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "28",
+            "Primary Administrative Subdivision": "Toyama",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Hokuriku"
+          },
+          "09.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Nagano",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "08.339": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Niigata",
+            "DXCC Entity Code": "339",
+            "Contained Within": "Shin\u0027estu"
+          },
+          "AUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AUR",
+            "Primary Administrative Subdivision": "Aurora",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "BTG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTG",
+            "Primary Administrative Subdivision": "Batangas",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "CAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAV",
+            "Primary Administrative Subdivision": "Cavite",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "LAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAG",
+            "Primary Administrative Subdivision": "Laguna",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MAD.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAD",
+            "Primary Administrative Subdivision": "Marinduque",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDC",
+            "Primary Administrative Subdivision": "Mindoro Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "MDR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MDR",
+            "Primary Administrative Subdivision": "Mindoro Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "PLW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PLW",
+            "Primary Administrative Subdivision": "Palawan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "QUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUE",
+            "Primary Administrative Subdivision": "Quezon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "RIZ.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RIZ",
+            "Primary Administrative Subdivision": "Rizal",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ROM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROM",
+            "Primary Administrative Subdivision": "Romblon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Southern Tagalog"
+          },
+          "ILN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILN",
+            "Primary Administrative Subdivision": "Ilocos Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "ILS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILS",
+            "Primary Administrative Subdivision": "Ilocos Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "LUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUN",
+            "Primary Administrative Subdivision": "La Union",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "PAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAN",
+            "Primary Administrative Subdivision": "Pangasinan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Ilocos"
+          },
+          "BTN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BTN",
+            "Primary Administrative Subdivision": "Batanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "CAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAG",
+            "Primary Administrative Subdivision": "Cagayan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ISA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ISA",
+            "Primary Administrative Subdivision": "Isabela",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "NUV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUV",
+            "Primary Administrative Subdivision": "Nueva Vizcaya",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "QUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "QUI",
+            "Primary Administrative Subdivision": "Quirino",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cagayan Valley"
+          },
+          "ABR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ABR",
+            "Primary Administrative Subdivision": "Abra",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "APA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Apayao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BEN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BEN",
+            "Primary Administrative Subdivision": "Benguet",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "IFU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "IFU",
+            "Primary Administrative Subdivision": "Ifugao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "KAL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KAL",
+            "Primary Administrative Subdivision": "Kalinga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "MOU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MOU",
+            "Primary Administrative Subdivision": "Mountain Province",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Cordillera Administrative Region"
+          },
+          "BAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Bataan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "BUL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUL",
+            "Primary Administrative Subdivision": "Bulacan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "NUE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NUE",
+            "Primary Administrative Subdivision": "Nueva Ecija",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "PAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAM",
+            "Primary Administrative Subdivision": "Pampanga",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "TAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAR",
+            "Primary Administrative Subdivision": "Tarlac",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ZMB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMB",
+            "Primary Administrative Subdivision": "Zambales",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Luzon"
+          },
+          "ALB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ALB",
+            "Primary Administrative Subdivision": "Albay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAN",
+            "Primary Administrative Subdivision": "Camarines Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAS",
+            "Primary Administrative Subdivision": "Camarines Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "CAT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAT",
+            "Primary Administrative Subdivision": "Catanduanes",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "MAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAS",
+            "Primary Administrative Subdivision": "Masbate",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "SOR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOR",
+            "Primary Administrative Subdivision": "Sorsogon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Bicol"
+          },
+          "BIL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BIL",
+            "Primary Administrative Subdivision": "Biliran",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "EAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EAS",
+            "Primary Administrative Subdivision": "Eastern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "LEY.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEY",
+            "Primary Administrative Subdivision": "Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "NSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NSA",
+            "Primary Administrative Subdivision": "Northern Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "SLE.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLE",
+            "Primary Administrative Subdivision": "Southern Leyte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "WSA.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "WSA",
+            "Primary Administrative Subdivision": "Western Samar",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Eastern Visayas"
+          },
+          "AKL.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AKL",
+            "Primary Administrative Subdivision": "Aklan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ANT.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ANT",
+            "Primary Administrative Subdivision": "Antique",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "CAP.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAP",
+            "Primary Administrative Subdivision": "Capiz",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "GUI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUI",
+            "Primary Administrative Subdivision": "Guimaras",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "ILI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILI",
+            "Primary Administrative Subdivision": "Iloilo",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "NEC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NEC",
+            "Primary Administrative Subdivision": "Negros Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Western Visayas"
+          },
+          "BOH.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BOH",
+            "Primary Administrative Subdivision": "Bohol",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "CEB.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CEB",
+            "Primary Administrative Subdivision": "Cebu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "NER.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NER",
+            "Primary Administrative Subdivision": "Negros Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "SIG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SIG",
+            "Primary Administrative Subdivision": "Siquijor",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Central Visayas"
+          },
+          "ZAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAN",
+            "Primary Administrative Subdivision": "Zamboanga del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAS",
+            "Primary Administrative Subdivision": "Zamboanga del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "ZSI.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZSI",
+            "Primary Administrative Subdivision": "Zamboanga Sibugay",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Zamboanga Peninsular (Western Mindanao)"
+          },
+          "NCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NCO",
+            "Primary Administrative Subdivision": "Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUK",
+            "Primary Administrative Subdivision": "Sultan Kudarat",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SAR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAR",
+            "Primary Administrative Subdivision": "Sarangani",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "SCO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SCO",
+            "Primary Administrative Subdivision": "South Cotabato",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Soccsksargen (Central Mindanao)"
+          },
+          "BAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAS",
+            "Primary Administrative Subdivision": "Basilan",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAS",
+            "Primary Administrative Subdivision": "Lanao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "MAG.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAG",
+            "Primary Administrative Subdivision": "Maguindanao",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "SLU.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Sulu",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "TAW.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAW",
+            "Primary Administrative Subdivision": "Tawi-Tawi",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Autonomous Region in Muslim Mindanao"
+          },
+          "LAN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LAN",
+            "Primary Administrative Subdivision": "Lanao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "BUK.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BUK",
+            "Primary Administrative Subdivision": "Bukidnon",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "CAM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAM",
+            "Primary Administrative Subdivision": "Camiguin",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSC.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSC",
+            "Primary Administrative Subdivision": "Misamis Occidental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "MSR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MSR",
+            "Primary Administrative Subdivision": "Misamis Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Northern Mindanao"
+          },
+          "COM.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "COM",
+            "Primary Administrative Subdivision": "Davao de Oro",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAV.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAV",
+            "Primary Administrative Subdivision": "Davao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAS",
+            "Primary Administrative Subdivision": "Davao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "DAO.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DAO",
+            "Primary Administrative Subdivision": "Davao Oriental",
+            "DXCC Entity Code": "375",
+            "Contained Within": "Davao (Southern Mindanao)"
+          },
+          "AGN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGN",
+            "Primary Administrative Subdivision": "Agusan del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "AGS.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "AGS",
+            "Primary Administrative Subdivision": "Agusan del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUN.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUN",
+            "Primary Administrative Subdivision": "Surigao del Norte",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "SUR.375": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SUR",
+            "Primary Administrative Subdivision": "Surigao del Sur",
+            "DXCC Entity Code": "375",
+            "Contained Within": "CARAGA"
+          },
+          "CHA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CHA",
+            "Primary Administrative Subdivision": "Changhua",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "CYI.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYI",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "CYQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CYQ",
+            "Primary Administrative Subdivision": "Chiayi",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HSZ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSZ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "HSQ.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSQ",
+            "Primary Administrative Subdivision": "Hsinchu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "HUA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUA",
+            "Primary Administrative Subdivision": "Hualien",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "KHH.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KHH",
+            "Primary Administrative Subdivision": "Kaohsiung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "KEE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEE",
+            "Primary Administrative Subdivision": "Keelung",
+            "DXCC Entity Code": "386",
+            "Comments": "city"
+          },
+          "KIN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KIN",
+            "Primary Administrative Subdivision": "Kinmen",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "LIE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LIE",
+            "Primary Administrative Subdivision": "Lienchiang",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "MIA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIA",
+            "Primary Administrative Subdivision": "Miaoli",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NAN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAN",
+            "Primary Administrative Subdivision": "Nantou",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "NWT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NWT",
+            "Primary Administrative Subdivision": "New Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "PEN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEN",
+            "Primary Administrative Subdivision": "Penghu",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "PIF.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIF",
+            "Primary Administrative Subdivision": "Pingtung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TXG.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TXG",
+            "Primary Administrative Subdivision": "Taichung",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TNN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNN",
+            "Primary Administrative Subdivision": "Tainan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TPE.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TPE",
+            "Primary Administrative Subdivision": "Taipei",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "TTT.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTT",
+            "Primary Administrative Subdivision": "Taitung",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "TAO.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TAO",
+            "Primary Administrative Subdivision": "Taoyuan",
+            "DXCC Entity Code": "386",
+            "Comments": "special municipality"
+          },
+          "ILA.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Yilan",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "YUN.386": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "YUN",
+            "Primary Administrative Subdivision": "Yunlin",
+            "DXCC Entity Code": "386",
+            "Comments": "county"
+          },
+          "01.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "01",
+            "Primary Administrative Subdivision": "Zagrebačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "02.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "02",
+            "Primary Administrative Subdivision": "Krapinsko-Zagorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "03.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "03",
+            "Primary Administrative Subdivision": "Sisačko-Moslavačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "04.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "04",
+            "Primary Administrative Subdivision": "Karlovačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "05.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "05",
+            "Primary Administrative Subdivision": "Varaždinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "06.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "06",
+            "Primary Administrative Subdivision": "Koprivničko-Križevačka županija",
+            "DXCC Entity Code": "497"
+          },
+          "07.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "07",
+            "Primary Administrative Subdivision": "Bjelovarsko-Bilogorska županija",
+            "DXCC Entity Code": "497"
+          },
+          "08.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "08",
+            "Primary Administrative Subdivision": "Primorsko-Goranska županija",
+            "DXCC Entity Code": "497"
+          },
+          "09.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "09",
+            "Primary Administrative Subdivision": "Ličko-Senjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "10.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "10",
+            "Primary Administrative Subdivision": "Virovitičko-Podravska županija",
+            "DXCC Entity Code": "497"
+          },
+          "11.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "11",
+            "Primary Administrative Subdivision": "Požeško-Slavonska županija",
+            "DXCC Entity Code": "497"
+          },
+          "12.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "12",
+            "Primary Administrative Subdivision": "Brodsko-Posavska županija",
+            "DXCC Entity Code": "497"
+          },
+          "13.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "13",
+            "Primary Administrative Subdivision": "Zadarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "14.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "14",
+            "Primary Administrative Subdivision": "Osječko-Baranjska županija",
+            "DXCC Entity Code": "497"
+          },
+          "15.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "15",
+            "Primary Administrative Subdivision": "Šibensko-Kninska županija",
+            "DXCC Entity Code": "497"
+          },
+          "16.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "16",
+            "Primary Administrative Subdivision": "Vukovarsko-Srijemska županija",
+            "DXCC Entity Code": "497"
+          },
+          "17.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "17",
+            "Primary Administrative Subdivision": "Splitsko-Dalmatinska županija",
+            "DXCC Entity Code": "497"
+          },
+          "18.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "18",
+            "Primary Administrative Subdivision": "Istarska županija",
+            "DXCC Entity Code": "497"
+          },
+          "19.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "19",
+            "Primary Administrative Subdivision": "Dubrovačko-Neretvanska županija",
+            "DXCC Entity Code": "497"
+          },
+          "20.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "20",
+            "Primary Administrative Subdivision": "Međimurska županija",
+            "DXCC Entity Code": "497"
+          },
+          "21.497": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "21",
+            "Primary Administrative Subdivision": "Grad Zagreb",
+            "DXCC Entity Code": "497"
+          },
+          "APA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APA",
+            "Primary Administrative Subdivision": "Praha 1",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APB",
+            "Primary Administrative Subdivision": "Praha 2",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APC.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APC",
+            "Primary Administrative Subdivision": "Praha 3",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APD",
+            "Primary Administrative Subdivision": "Praha 4",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APE",
+            "Primary Administrative Subdivision": "Praha 5",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APF.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APF",
+            "Primary Administrative Subdivision": "Praha 6",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APG.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APG",
+            "Primary Administrative Subdivision": "Praha 7",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APH",
+            "Primary Administrative Subdivision": "Praha 8",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "API.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "API",
+            "Primary Administrative Subdivision": "Praha 9",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "APJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "APJ",
+            "Primary Administrative Subdivision": "Praha 10",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Prague (Praha)"
+          },
+          "BBN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBN",
+            "Primary Administrative Subdivision": "Benesov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BBE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBE",
+            "Primary Administrative Subdivision": "Beroun",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKD.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKD",
+            "Primary Administrative Subdivision": "Kladno",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKO",
+            "Primary Administrative Subdivision": "Kolin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BKH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BKH",
+            "Primary Administrative Subdivision": "Kutna Hora",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BME.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BME",
+            "Primary Administrative Subdivision": "Melnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BMB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BMB",
+            "Primary Administrative Subdivision": "Mlada Boleslav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BNY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BNY",
+            "Primary Administrative Subdivision": "Nymburk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPZ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPZ",
+            "Primary Administrative Subdivision": "Praha zapad",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPV",
+            "Primary Administrative Subdivision": "Praha vychod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BPB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BPB",
+            "Primary Administrative Subdivision": "Pribram",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "BRA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRA",
+            "Primary Administrative Subdivision": "Rakovnik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Central Bohemia (Středoceský kraj)"
+          },
+          "CBU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CBU",
+            "Primary Administrative Subdivision": "Ceske Budejovice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CCK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CCK",
+            "Primary Administrative Subdivision": "Cesky Krumlov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CJH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CJH",
+            "Primary Administrative Subdivision": "Jindrichuv Hradec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPE",
+            "Primary Administrative Subdivision": "Pelhrimov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPI",
+            "Primary Administrative Subdivision": "Pisek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CPR",
+            "Primary Administrative Subdivision": "Prachatice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CST.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CST",
+            "Primary Administrative Subdivision": "Strakonice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "CTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CTA",
+            "Primary Administrative Subdivision": "Tabor",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Bohemia (Jihočeský kraj)"
+          },
+          "DDO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DDO",
+            "Primary Administrative Subdivision": "Domazlice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DCH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DCH",
+            "Primary Administrative Subdivision": "Cheb",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKV",
+            "Primary Administrative Subdivision": "Karlovy Vary",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DKL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKL",
+            "Primary Administrative Subdivision": "Klatovy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPM",
+            "Primary Administrative Subdivision": "Plzen mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPJ",
+            "Primary Administrative Subdivision": "Plzen jih",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DPS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DPS",
+            "Primary Administrative Subdivision": "Plzen sever",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DRO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DRO",
+            "Primary Administrative Subdivision": "Rokycany",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DSO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DSO",
+            "Primary Administrative Subdivision": "Sokolov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "DTA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DTA",
+            "Primary Administrative Subdivision": "Tachov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Western Bohemia (Západocesky kraj)"
+          },
+          "ECL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECL",
+            "Primary Administrative Subdivision": "Ceska Lipa",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EDE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EDE",
+            "Primary Administrative Subdivision": "Decin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ECH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ECH",
+            "Primary Administrative Subdivision": "Chomutov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EJA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EJA",
+            "Primary Administrative Subdivision": "Jablonec n. Nisou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELI",
+            "Primary Administrative Subdivision": "Liberec",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELT.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELT",
+            "Primary Administrative Subdivision": "Litomerice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ELO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ELO",
+            "Primary Administrative Subdivision": "Louny",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EMO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EMO",
+            "Primary Administrative Subdivision": "Most",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "ETE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ETE",
+            "Primary Administrative Subdivision": "Teplice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "EUL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "EUL",
+            "Primary Administrative Subdivision": "Usti nad Labem",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Bohemia (Severoceaky kraj)"
+          },
+          "FHB.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHB",
+            "Primary Administrative Subdivision": "Havlickuv Brod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FHK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FHK",
+            "Primary Administrative Subdivision": "Hradec Kralove",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FCR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FCR",
+            "Primary Administrative Subdivision": "Chrudim",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FJI",
+            "Primary Administrative Subdivision": "Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FNA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FNA",
+            "Primary Administrative Subdivision": "Nachod",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FPA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FPA",
+            "Primary Administrative Subdivision": "Pardubice",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FRK.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FRK",
+            "Primary Administrative Subdivision": "Rychn n. Kneznou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSE",
+            "Primary Administrative Subdivision": "Semily",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FSV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FSV",
+            "Primary Administrative Subdivision": "Svitavy",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FTR",
+            "Primary Administrative Subdivision": "Trutnov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "FUO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "FUO",
+            "Primary Administrative Subdivision": "Usti nad Orlici",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Eastern Bohemia (Vychodocesky kraj)"
+          },
+          "GBL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBL",
+            "Primary Administrative Subdivision": "Blansko",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBM",
+            "Primary Administrative Subdivision": "Brno mesto",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBV.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBV",
+            "Primary Administrative Subdivision": "Brno venkov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GBR",
+            "Primary Administrative Subdivision": "Breclav",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GHO.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GHO",
+            "Primary Administrative Subdivision": "Hodonin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GJI.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GJI",
+            "Primary Administrative Subdivision": "Jihlava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GKR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GKR",
+            "Primary Administrative Subdivision": "Kromeriz",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GPR",
+            "Primary Administrative Subdivision": "Prostejov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GTR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GTR",
+            "Primary Administrative Subdivision": "Trebic",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GUH.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GUH",
+            "Primary Administrative Subdivision": "Uherske Hradiste",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GVY.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GVY",
+            "Primary Administrative Subdivision": "Vyskov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZL",
+            "Primary Administrative Subdivision": "Zlin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZN.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZN",
+            "Primary Administrative Subdivision": "Znojmo",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "GZS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GZS",
+            "Primary Administrative Subdivision": "Zdar nad Sazavou",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Southern Moravia (Jihomoravský kraj)"
+          },
+          "HBR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HBR",
+            "Primary Administrative Subdivision": "Bruntal",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HFM.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HFM",
+            "Primary Administrative Subdivision": "Frydek-Mistek",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HJE.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HJE",
+            "Primary Administrative Subdivision": "Jesenik",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HKA.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HKA",
+            "Primary Administrative Subdivision": "Karvina",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HNJ.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HNJ",
+            "Primary Administrative Subdivision": "Novy Jicin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOL.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOL",
+            "Primary Administrative Subdivision": "Olomouc",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOP.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOP",
+            "Primary Administrative Subdivision": "Opava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HOS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HOS",
+            "Primary Administrative Subdivision": "Ostrava",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HPR.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HPR",
+            "Primary Administrative Subdivision": "Prerov",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HSU.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HSU",
+            "Primary Administrative Subdivision": "Sumperk",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "HVS.503": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HVS",
+            "Primary Administrative Subdivision": "Vsetin",
+            "DXCC Entity Code": "503",
+            "Contained Within": "Northern Moravia (Soveromoravsky kraj)"
+          },
+          "BAA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAA",
+            "Primary Administrative Subdivision": "Bratislava 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAB",
+            "Primary Administrative Subdivision": "Bratislava 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAC",
+            "Primary Administrative Subdivision": "Bratislava 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAD",
+            "Primary Administrative Subdivision": "Bratislava 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "BAE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAE",
+            "Primary Administrative Subdivision": "Bratislava 5",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "MAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAL",
+            "Primary Administrative Subdivision": "Malacky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "PEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PEZ",
+            "Primary Administrative Subdivision": "Pezinok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "SEN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEN",
+            "Primary Administrative Subdivision": "Senec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Bratislava (Bratislavský kraj)"
+          },
+          "DST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DST",
+            "Primary Administrative Subdivision": "Dunajska Streda",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "GAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GAL",
+            "Primary Administrative Subdivision": "Galanta",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "HLO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HLO",
+            "Primary Administrative Subdivision": "Hlohovec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "PIE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PIE",
+            "Primary Administrative Subdivision": "Piestany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SEA",
+            "Primary Administrative Subdivision": "Senica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "SKA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SKA",
+            "Primary Administrative Subdivision": "Skalica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "TRN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRN",
+            "Primary Administrative Subdivision": "Trnava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trnava (Trnavský kraj)"
+          },
+          "BAN.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAN",
+            "Primary Administrative Subdivision": "Banovce n. Bebr.",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "ILA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ILA",
+            "Primary Administrative Subdivision": "Ilava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "MYJ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MYJ",
+            "Primary Administrative Subdivision": "Myjava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "NMV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NMV",
+            "Primary Administrative Subdivision": "Nove Mesto n. Vah",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PAR",
+            "Primary Administrative Subdivision": "Partizanske",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PBY",
+            "Primary Administrative Subdivision": "Povazska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PRI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRI",
+            "Primary Administrative Subdivision": "Prievidza",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "PUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PUC",
+            "Primary Administrative Subdivision": "Puchov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "TNC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TNC",
+            "Primary Administrative Subdivision": "Trencin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Trencin (Trenčiansky kraj)"
+          },
+          "KOM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KOM",
+            "Primary Administrative Subdivision": "Komarno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "LVC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LVC",
+            "Primary Administrative Subdivision": "Levice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NIT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NIT",
+            "Primary Administrative Subdivision": "Nitra",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "NZA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NZA",
+            "Primary Administrative Subdivision": "Nove Zamky",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "SAL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAL",
+            "Primary Administrative Subdivision": "Sala",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "TOP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TOP",
+            "Primary Administrative Subdivision": "Topolcany",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "ZMO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZMO",
+            "Primary Administrative Subdivision": "Zlate Moravce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Nitra (Nitrianaky kraj)"
+          },
+          "BYT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BYT",
+            "Primary Administrative Subdivision": "Bytca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "CAD.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "CAD",
+            "Primary Administrative Subdivision": "Cadca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "DKU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DKU",
+            "Primary Administrative Subdivision": "Dolny Kubin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "KNM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KNM",
+            "Primary Administrative Subdivision": "Kysucke N. Mesto",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "LMI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LMI",
+            "Primary Administrative Subdivision": "Liptovsky Mikulas",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "MAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MAR",
+            "Primary Administrative Subdivision": "Martin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "NAM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "NAM",
+            "Primary Administrative Subdivision": "Namestovo",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "RUZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RUZ",
+            "Primary Administrative Subdivision": "Ruzomberok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TTE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TTE",
+            "Primary Administrative Subdivision": "Turcianske Teplice",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "TVR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TVR",
+            "Primary Administrative Subdivision": "Tvrdosin",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "ZIL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIL",
+            "Primary Administrative Subdivision": "Zilina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Zilina (Žilinský kraj)"
+          },
+          "BBY.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BBY",
+            "Primary Administrative Subdivision": "Banska Bystrica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BST.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BST",
+            "Primary Administrative Subdivision": "Banska Stiavnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "BRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BRE",
+            "Primary Administrative Subdivision": "Brezno",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "DET.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "DET",
+            "Primary Administrative Subdivision": "Detva",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "KRU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KRU",
+            "Primary Administrative Subdivision": "Krupina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "LUC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LUC",
+            "Primary Administrative Subdivision": "Lucenec",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "POL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POL",
+            "Primary Administrative Subdivision": "Poltar",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "REV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "REV",
+            "Primary Administrative Subdivision": "Revuca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "RSO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "RSO",
+            "Primary Administrative Subdivision": "Rimavska Sobota",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "VKR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VKR",
+            "Primary Administrative Subdivision": "Velky Krtis",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZAR",
+            "Primary Administrative Subdivision": "Zarnovica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZIH.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZIH",
+            "Primary Administrative Subdivision": "Ziar nad Hronom",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "ZVO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ZVO",
+            "Primary Administrative Subdivision": "Zvolen",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Banska Bystrica (Banskobystrický kraj)"
+          },
+          "GEL.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "GEL",
+            "Primary Administrative Subdivision": "Gelnica",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEA.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEA",
+            "Primary Administrative Subdivision": "Kosice 1",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEB",
+            "Primary Administrative Subdivision": "Kosice 2",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEC",
+            "Primary Administrative Subdivision": "Kosice 3",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KED",
+            "Primary Administrative Subdivision": "Kosice 4",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "KEO.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEO",
+            "Primary Administrative Subdivision": "Kosice-okolie",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "MIC.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MIC",
+            "Primary Administrative Subdivision": "Michalovce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "ROZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "ROZ",
+            "Primary Administrative Subdivision": "Roznava",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SOB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SOB",
+            "Primary Administrative Subdivision": "Sobrance",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "SNV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNV",
+            "Primary Administrative Subdivision": "Spisska Nova Ves",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "TRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "TRE",
+            "Primary Administrative Subdivision": "Trebisov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Kosice (Košický kraj)"
+          },
+          "BAR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "BAR",
+            "Primary Administrative Subdivision": "Bardejov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "HUM.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "HUM",
+            "Primary Administrative Subdivision": "Humenne",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "KEZ.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "KEZ",
+            "Primary Administrative Subdivision": "Kezmarok",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "LEV.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "LEV",
+            "Primary Administrative Subdivision": "Levoca",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "MED.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "MED",
+            "Primary Administrative Subdivision": "Medzilaborce",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "POP.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "POP",
+            "Primary Administrative Subdivision": "Poprad",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "PRE.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "PRE",
+            "Primary Administrative Subdivision": "Presov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SAB.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SAB",
+            "Primary Administrative Subdivision": "Sabinov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SNI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SNI",
+            "Primary Administrative Subdivision": "Snina",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SLU.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SLU",
+            "Primary Administrative Subdivision": "Stara Lubovna",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "STR.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "STR",
+            "Primary Administrative Subdivision": "Stropkov",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "SVI.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "SVI",
+            "Primary Administrative Subdivision": "Svidnik",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          },
+          "VRT.504": {
+            "Enumeration Name": "Primary_Administrative_Subdivision",
+            "Code": "VRT",
+            "Primary Administrative Subdivision": "Vranov nad Toplou",
+            "DXCC Entity Code": "504",
+            "Contained Within": "Presov (Prešovský kraj)"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_propagation_mode.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_propagation_mode.json
@@ -1,0 +1,123 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:49Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Propagation_Mode": {
+        "Header": [
+          "Enumeration Name",
+          "Enumeration",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AS",
+            "Description": "Aircraft Scatter"
+          },
+          "AUE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUE",
+            "Description": "Aurora-E"
+          },
+          "AUR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "AUR",
+            "Description": "Aurora"
+          },
+          "BS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "BS",
+            "Description": "Back scatter"
+          },
+          "ECH": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ECH",
+            "Description": "EchoLink"
+          },
+          "EME": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "EME",
+            "Description": "Earth-Moon-Earth"
+          },
+          "ES": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ES",
+            "Description": "Sporadic E"
+          },
+          "F2": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "F2",
+            "Description": "F2 Reflection"
+          },
+          "FAI": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "FAI",
+            "Description": "Field Aligned Irregularities"
+          },
+          "GWAVE": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "GWAVE",
+            "Description": "Ground Wave"
+          },
+          "INTERNET": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "INTERNET",
+            "Description": "Internet-assisted"
+          },
+          "ION": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "ION",
+            "Description": "Ionoscatter"
+          },
+          "IRL": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "IRL",
+            "Description": "IRLP"
+          },
+          "LOS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "LOS",
+            "Description": "Line of Sight (includes transmission through obstacles such as walls)"
+          },
+          "MS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "MS",
+            "Description": "Meteor scatter"
+          },
+          "RPT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RPT",
+            "Description": "Terrestrial or atmospheric repeater or transponder"
+          },
+          "RS": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "RS",
+            "Description": "Rain scatter"
+          },
+          "SAT": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "SAT",
+            "Description": "Satellite"
+          },
+          "TEP": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TEP",
+            "Description": "Trans-equatorial"
+          },
+          "TR": {
+            "Enumeration Name": "Propagation_Mode",
+            "Enumeration": "TR",
+            "Description": "Tropospheric ducting"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qsl_medium.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qsl_medium.json
@@ -1,0 +1,38 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:49Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSL_Medium": {
+        "Header": [
+          "Enumeration Name",
+          "Medium",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "CARD": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "CARD",
+            "Description": "QSO confirmation via paper QSL card"
+          },
+          "EQSL": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "EQSL",
+            "Description": "QSO confirmation via eQSL.cc"
+          },
+          "LOTW": {
+            "Enumeration Name": "QSL_Medium",
+            "Medium": "LOTW",
+            "Description": "QSO confirmation via ARRL Logbook of the World"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qsl_rcvd.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qsl_rcvd.json
@@ -1,0 +1,54 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:49Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSL_Rcvd": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "Y",
+            "Meaning": "yes (confirmed)",
+            "Description": "an incoming QSL card has been received the QSO has been confirmed by the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "an incoming QSL card has not been received the QSO has not been confirmed by the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the logging station has requested a QSL card the logging station has requested the QSO be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          },
+          "V": {
+            "Enumeration Name": "QSL_Rcvd",
+            "Status": "V",
+            "Meaning": "verified",
+            "Description": "DXCC award credit granted for the QSL card - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:card,DXCC_BAND:card,DXCC_MODE:card DXCC credit granted for the LoTW confirmation - instead use \u003CCREDIT_GRANTED:39\u003EDXCC:lotw,DXCC_BAND:lotw,DXCC_MODE:lotw",
+            "Import-only": "true"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qsl_sent.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qsl_sent.json
@@ -1,0 +1,53 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:50Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSL_Sent": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Meaning",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Y",
+            "Meaning": "yes",
+            "Description": "an outgoing QSL card has been sent the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "N",
+            "Meaning": "no",
+            "Description": "do not send an outgoing QSL card do not upload the QSO to the online service"
+          },
+          "R": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "R",
+            "Meaning": "requested",
+            "Description": "the contacted station has requested a QSL card the contacted station has requested the QSO be uploaded to the online service"
+          },
+          "Q": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "Q",
+            "Meaning": "queued",
+            "Description": "an outgoing QSL card has been selected to be sent a QSO has been selected to be uploaded to the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSL_Sent",
+            "Status": "I",
+            "Meaning": "ignore or invalid"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qsl_via.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qsl_via.json
@@ -1,0 +1,44 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:50Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSL_Via": {
+        "Header": [
+          "Enumeration Name",
+          "Via",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "B": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "B",
+            "Description": "bureau"
+          },
+          "D": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "D",
+            "Description": "direct"
+          },
+          "E": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "E",
+            "Description": "electronic"
+          },
+          "M": {
+            "Enumeration Name": "QSL_Via",
+            "Via": "M",
+            "Description": "manager",
+            "Import-only": "true"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qso_complete.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qso_complete.json
@@ -1,0 +1,43 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:50Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSO_Complete": {
+        "Header": [
+          "Enumeration Name",
+          "Abbreviation",
+          "Meaning",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "Y",
+            "Meaning": "yes"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "N",
+            "Meaning": "no"
+          },
+          "NIL": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "NIL",
+            "Meaning": "not heard"
+          },
+          "?": {
+            "Enumeration Name": "QSO_Complete",
+            "Abbreviation": "?",
+            "Meaning": "uncertain"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qso_download_status.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qso_download_status.json
@@ -1,0 +1,38 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:51Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSO_Download_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "Y",
+            "Description": "the QSO has been downloaded from the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "N",
+            "Description": "the QSO has not been downloaded from the online service"
+          },
+          "I": {
+            "Enumeration Name": "QSO_Download_Status",
+            "Status": "I",
+            "Description": "ignore or invalid"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_qso_upload_status.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_qso_upload_status.json
@@ -1,0 +1,38 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:51Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "QSO_Upload_Status": {
+        "Header": [
+          "Enumeration Name",
+          "Status",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "Y": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "Y",
+            "Description": "the QSO has been uploaded to, and accepted by, the online service"
+          },
+          "N": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "N",
+            "Description": "do not upload the QSO to the online service"
+          },
+          "M": {
+            "Enumeration Name": "QSO_Upload_Status",
+            "Status": "M",
+            "Description": "the QSO has been modified since being uploaded to the online service"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_region.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_region.json
@@ -1,0 +1,109 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:51Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Region": {
+        "Header": [
+          "Enumeration Name",
+          "Region Entity Code",
+          "DXCC Entity Code",
+          "Region",
+          "Prefix",
+          "Applicability",
+          "Start Date",
+          "End Date",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NONE": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "NONE",
+            "Region": "Not within a WAE or CQ region that is within a DXCC entity"
+          },
+          "IV.206": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "IV",
+            "DXCC Entity Code": "206",
+            "Region": "ITU Vienna",
+            "Prefix": "4U1V",
+            "Applicability": "CQ, WAE"
+          },
+          "AI.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "AI",
+            "DXCC Entity Code": "248",
+            "Region": "African Italy",
+            "Prefix": "IG9",
+            "Applicability": "CQ"
+          },
+          "SY.248": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SY",
+            "DXCC Entity Code": "248",
+            "Region": "Sicily",
+            "Prefix": "IT9",
+            "Applicability": "CQ, WAE"
+          },
+          "BI.259": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "BI",
+            "DXCC Entity Code": "259",
+            "Region": "Bear Island",
+            "Prefix": "JW/B",
+            "Applicability": "CQ, WAE"
+          },
+          "SI.279": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "SI",
+            "DXCC Entity Code": "279",
+            "Region": "Shetland Islands",
+            "Prefix": "GM/S",
+            "Applicability": "CQ, WAE"
+          },
+          "KO.296": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "296",
+            "Region": "Kosovo",
+            "Prefix": "YU8",
+            "Applicability": "CQ, WAE",
+            "End Date": "2012-09-11T00:00:00Z"
+          },
+          "KO.0": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "0",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2012-09-12T00:00:00Z",
+            "End Date": "2018-01-20T00:00:00Z"
+          },
+          "KO.522": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "KO",
+            "DXCC Entity Code": "522",
+            "Region": "Kosovo",
+            "Prefix": "Z6",
+            "Applicability": "CQ, WAE",
+            "Start Date": "2018-01-21T00:00:00Z"
+          },
+          "ET.390": {
+            "Enumeration Name": "Region",
+            "Region Entity Code": "ET",
+            "DXCC Entity Code": "390",
+            "Region": "European Turkey",
+            "Prefix": "TA1",
+            "Applicability": "CQ"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_secondary_administrative_subdivision.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_secondary_administrative_subdivision.json
@@ -1,0 +1,457 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:52Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Secondary_Administrative_Subdivision": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "Secondary Administrative Subdivision",
+          "DXCC Entity Code",
+          "Alaska Judicial District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "AK,Aleutians East": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians East",
+            "Secondary Administrative Subdivision": "Aleutians East",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Aleutians Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians Islands",
+            "Secondary Administrative Subdivision": "Aleutians Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Aleutians West": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Aleutians West",
+            "Secondary Administrative Subdivision": "Aleutians West",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Anchorage": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Anchorage",
+            "Secondary Administrative Subdivision": "Anchorage",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Angoon",
+            "Secondary Administrative Subdivision": "Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Barrow": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Barrow",
+            "Secondary Administrative Subdivision": "Barrow",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Bethel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bethel",
+            "Secondary Administrative Subdivision": "Bethel",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Bristol Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Bristol Bay",
+            "Secondary Administrative Subdivision": "Bristol Bay",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Cordova-McCarthy": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Cordova-McCarthy",
+            "Secondary Administrative Subdivision": "Cordova-McCarthy",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Denali": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Denali",
+            "Secondary Administrative Subdivision": "Denali",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Dillingham": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Dillingham",
+            "Secondary Administrative Subdivision": "Dillingham",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks",
+            "Secondary Administrative Subdivision": "Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Fairbanks North Star": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fairbanks North Star",
+            "Secondary Administrative Subdivision": "Fairbanks North Star",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,First Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,First Judicial District",
+            "Secondary Administrative Subdivision": "First Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Fourth Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Fourth Judicial District",
+            "Secondary Administrative Subdivision": "Fourth Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Haines": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Haines",
+            "Secondary Administrative Subdivision": "Haines",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Juneau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Juneau",
+            "Secondary Administrative Subdivision": "Juneau",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kenai Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai Peninsula",
+            "Secondary Administrative Subdivision": "Kenai Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kenai-Cook Inlet": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kenai-Cook Inlet",
+            "Secondary Administrative Subdivision": "Kenai-Cook Inlet",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan",
+            "Secondary Administrative Subdivision": "Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Ketchikan Gateway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Ketchikan Gateway",
+            "Secondary Administrative Subdivision": "Ketchikan Gateway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Kobuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kobuk",
+            "Secondary Administrative Subdivision": "Kobuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kodiak Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kodiak Island",
+            "Secondary Administrative Subdivision": "Kodiak Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Kuskokwim": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kuskokwim",
+            "Secondary Administrative Subdivision": "Kuskokwim",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Kusilvak": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Kusilvak",
+            "Secondary Administrative Subdivision": "Kusilvak",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Lake and Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lake and Peninsula",
+            "Secondary Administrative Subdivision": "Lake and Peninsula",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Lynn Canal-Icy Straits": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Lynn Canal-Icy Straits",
+            "Secondary Administrative Subdivision": "Lynn Canal-Icy Straits",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Matanuska-Susitna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Matanuska-Susitna",
+            "Secondary Administrative Subdivision": "Matanuska-Susitna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Nome": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Nome",
+            "Secondary Administrative Subdivision": "Nome",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,North Slope": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,North Slope",
+            "Secondary Administrative Subdivision": "North Slope",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Northwest Arctic": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Northwest Arctic",
+            "Secondary Administrative Subdivision": "Northwest Arctic",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District"
+          },
+          "AK,Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Palmer-Wasilla-Talkeetna": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Palmer-Wasilla-Talkeetna",
+            "Secondary Administrative Subdivision": "Palmer-Wasilla-Talkeetna",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Petersburg",
+            "Secondary Administrative Subdivision": "Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Pribilof Islands": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Pribilof Islands",
+            "Secondary Administrative Subdivision": "Pribilof Islands",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Prince of Wales": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales",
+            "Secondary Administrative Subdivision": "Prince of Wales",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Prince of Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Hyder",
+            "Secondary Administrative Subdivision": "Prince of Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Prince of Wales-Outer Ketchikan": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Prince of Wales-Outer Ketchikan",
+            "Secondary Administrative Subdivision": "Prince of Wales-Outer Ketchikan",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Saint Matthew Island": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Saint Matthew Island",
+            "Secondary Administrative Subdivision": "Saint Matthew Island",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Second Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Second Judicial District",
+            "Secondary Administrative Subdivision": "Second Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Seward": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Seward",
+            "Secondary Administrative Subdivision": "Seward",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Sitka": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Sitka",
+            "Secondary Administrative Subdivision": "Sitka",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Hoonah-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Hoonah-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Hoonah-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway",
+            "Secondary Administrative Subdivision": "Skagway",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Skagway-Yakuta": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakuta",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Skagway-Yakutat-Angoon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Skagway-Yakutat-Angoon",
+            "Secondary Administrative Subdivision": "Skagway-Yakutat-Angoon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Southeast Fairbanks": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Southeast Fairbanks",
+            "Secondary Administrative Subdivision": "Southeast Fairbanks",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          },
+          "AK,Third Judicial District": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Third Judicial District",
+            "Secondary Administrative Subdivision": "Third Judicial District",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Upper Yukon": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Upper Yukon",
+            "Secondary Administrative Subdivision": "Upper Yukon",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Chitina-Whittier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Chitina-Whittier",
+            "Secondary Administrative Subdivision": "Valdez-Chitina-Whittier",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Valdez-Cordova": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Valdez-Cordova",
+            "Secondary Administrative Subdivision": "Valdez-Cordova",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Third Judicial District"
+          },
+          "AK,Wade Hampton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wade Hampton",
+            "Secondary Administrative Subdivision": "Wade Hampton",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Second Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Wales-Hyder": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wales-Hyder",
+            "Secondary Administrative Subdivision": "Wales-Hyder",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell",
+            "Secondary Administrative Subdivision": "Wrangell",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Wrangell-Petersburg": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Wrangell-Petersburg",
+            "Secondary Administrative Subdivision": "Wrangell-Petersburg",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District",
+            "Deleted": "true"
+          },
+          "AK,Yakutat": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yakutat",
+            "Secondary Administrative Subdivision": "Yakutat",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska First Judicial District"
+          },
+          "AK,Yukon-Koyukuk": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision",
+            "Code": "AK,Yukon-Koyukuk",
+            "Secondary Administrative Subdivision": "Yukon-Koyukuk",
+            "DXCC Entity Code": "6",
+            "Alaska Judicial District": "Alaska Fourth Judicial District"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_secondary_administrative_subdivision_alt.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_secondary_administrative_subdivision_alt.json
@@ -1,0 +1,537 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:52Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Secondary_Administrative_Subdivision_Alt": {
+        "Header": [
+          "Enumeration Name",
+          "Code",
+          "DXCC Entity Code",
+          "Region",
+          "District",
+          "Deleted",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "NZ_Regions:Northland/Far North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Far North",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Far North"
+          },
+          "NZ_Regions:Northland/Whangarei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Whangarei",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Whangarei"
+          },
+          "NZ_Regions:Northland/Kaipara": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Northland/Kaipara",
+            "DXCC Entity Code": "170",
+            "Region": "Northland",
+            "District": "Kaipara"
+          },
+          "NZ_Regions:Auckland/Rodney": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Rodney",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Rodney"
+          },
+          "NZ_Regions:Auckland/North Shore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/North Shore",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "North Shore"
+          },
+          "NZ_Regions:Auckland/Waitakere": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Waitakere",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Waitakere"
+          },
+          "NZ_Regions:Auckland/Auckland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Auckland",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Auckland"
+          },
+          "NZ_Regions:Auckland/Manukau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Manukau",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Manukau"
+          },
+          "NZ_Regions:Auckland/Papakura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Papakura",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Papakura"
+          },
+          "NZ_Regions:Auckland/Franklin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Auckland/Franklin",
+            "DXCC Entity Code": "170",
+            "Region": "Auckland",
+            "District": "Franklin"
+          },
+          "NZ_Regions:Waikato/Thames-Coromandel": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Thames-Coromandel",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Thames-Coromandel"
+          },
+          "NZ_Regions:Waikato/Hauraki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hauraki",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hauraki"
+          },
+          "NZ_Regions:Waikato/Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waikato"
+          },
+          "NZ_Regions:Waikato/Matamata Piako": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Matamata Piako",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Matamata Piako"
+          },
+          "NZ_Regions:Waikato/Hamilton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Hamilton",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Hamilton"
+          },
+          "NZ_Regions:Waikato/Waipa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waipa",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waipa"
+          },
+          "NZ_Regions:Waikato/Otorohanga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Otorohanga",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Otorohanga"
+          },
+          "NZ_Regions:Waikato/South Waikato": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/South Waikato",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "South Waikato"
+          },
+          "NZ_Regions:Waikato/Waitomo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Waitomo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Waitomo"
+          },
+          "NZ_Regions:Waikato/Taupo": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Waikato/Taupo",
+            "DXCC Entity Code": "170",
+            "Region": "Waikato",
+            "District": "Taupo"
+          },
+          "NZ_Regions:Bay of Plenty/Western Bay of Plenty": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Western Bay of Plenty",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Western Bay of Plenty"
+          },
+          "NZ_Regions:Bay of Plenty/Tauranga": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Tauranga",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Tauranga"
+          },
+          "NZ_Regions:Bay of Plenty/Rotorua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Rotorua",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Rotorua"
+          },
+          "NZ_Regions:Bay of Plenty/Kawerau": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Kawerau",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Kawerau"
+          },
+          "NZ_Regions:Bay of Plenty/Whakatane": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Whakatane",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Whakatane"
+          },
+          "NZ_Regions:Bay of Plenty/Opotiki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Bay of Plenty/Opotiki",
+            "DXCC Entity Code": "170",
+            "Region": "Bay of Plenty",
+            "District": "Opotiki"
+          },
+          "NZ_Regions:Gisborne/Gisborne": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Gisborne/Gisborne",
+            "DXCC Entity Code": "170",
+            "Region": "Gisborne",
+            "District": "Gisborne"
+          },
+          "NZ_Regions:Hawkes Bay/Wairoa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Wairoa",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Wairoa"
+          },
+          "NZ_Regions:Hawkes Bay/Hastings": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Hastings",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Hastings"
+          },
+          "NZ_Regions:Hawkes Bay/Napier": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Napier",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Napier"
+          },
+          "NZ_Regions:Hawkes Bay/Central Hawkes Bay": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Hawkes Bay/Central Hawkes Bay",
+            "DXCC Entity Code": "170",
+            "Region": "Hawkes Bay",
+            "District": "Central Hawkes Bay"
+          },
+          "NZ_Regions:Taranaki/New Plymouth": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/New Plymouth",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "New Plymouth"
+          },
+          "NZ_Regions:Taranaki/Stratford": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/Stratford",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "Stratford"
+          },
+          "NZ_Regions:Taranaki/South Taranaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Taranaki/South Taranaki",
+            "DXCC Entity Code": "170",
+            "Region": "Taranaki",
+            "District": "South Taranaki"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Ruapehu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Ruapehu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Ruapehu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Wanganui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Wanganui",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Wanganui"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Rangitikei": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Rangitikei",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Rangitikei"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Manawatu": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Manawatu",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Manawatu"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Palmerston North": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Palmerston North",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Palmerston North"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Horowhenua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Horowhenua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Horowhenua"
+          },
+          "NZ_Regions:Wanganui-Manawatu/Tararua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wanganui-Manawatu/Tararua",
+            "DXCC Entity Code": "170",
+            "Region": "Wanganui-Manawatu",
+            "District": "Tararua"
+          },
+          "NZ_Regions:Wellington/Masterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Masterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Masterton"
+          },
+          "NZ_Regions:Wellington/Carterton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Carterton",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Carterton"
+          },
+          "NZ_Regions:Wellington/South Wairarapa": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/South Wairarapa",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "South Wairarapa"
+          },
+          "NZ_Regions:Wellington/Kapiti Coast": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Kapiti Coast",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Kapiti Coast"
+          },
+          "NZ_Regions:Wellington/Porirua": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Porirua",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Porirua"
+          },
+          "NZ_Regions:Wellington/Upper Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Upper Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Upper Hutt"
+          },
+          "NZ_Regions:Wellington/Lower Hutt": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Lower Hutt",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Lower Hutt"
+          },
+          "NZ_Regions:Wellington/Wellington": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Wellington/Wellington",
+            "DXCC Entity Code": "170",
+            "Region": "Wellington",
+            "District": "Wellington"
+          },
+          "NZ_Regions:Nelson/Nelson": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Nelson/Nelson",
+            "DXCC Entity Code": "170",
+            "Region": "Nelson",
+            "District": "Nelson"
+          },
+          "NZ_Regions:Marlborough/Marlborough": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Marlborough/Marlborough",
+            "DXCC Entity Code": "170",
+            "Region": "Marlborough",
+            "District": "Marlborough"
+          },
+          "NZ_Regions:Tasman/Tasman": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Tasman/Tasman",
+            "DXCC Entity Code": "170",
+            "Region": "Tasman",
+            "District": "Tasman"
+          },
+          "NZ_Regions:West Coast/Buller": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Buller",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Buller"
+          },
+          "NZ_Regions:West Coast/Grey": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Grey",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Grey"
+          },
+          "NZ_Regions:West Coast/Westland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:West Coast/Westland",
+            "DXCC Entity Code": "170",
+            "Region": "West Coast",
+            "District": "Westland"
+          },
+          "NZ_Regions:Canterbury/Kaikoura": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Kaikoura",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Kaikoura"
+          },
+          "NZ_Regions:Canterbury/Hurunui": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Hurunui",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Hurunui"
+          },
+          "NZ_Regions:Canterbury/Selwyn": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Selwyn",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Selwyn"
+          },
+          "NZ_Regions:Canterbury/Waimakariri": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimakariri",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimakariri"
+          },
+          "NZ_Regions:Canterbury/Christchurch": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Christchurch",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Christchurch"
+          },
+          "NZ_Regions:Canterbury/Banks Peninsula": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Banks Peninsula",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Banks Peninsula"
+          },
+          "NZ_Regions:Canterbury/Ashburton": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Ashburton",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Ashburton"
+          },
+          "NZ_Regions:Canterbury/Mackenzie": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Mackenzie",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Mackenzie"
+          },
+          "NZ_Regions:Canterbury/Timaru": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Timaru",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Timaru"
+          },
+          "NZ_Regions:Canterbury/Waimate": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Canterbury/Waimate",
+            "DXCC Entity Code": "170",
+            "Region": "Canterbury",
+            "District": "Waimate"
+          },
+          "NZ_Regions:Otago/Waitaki": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Waitaki",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Waitaki"
+          },
+          "NZ_Regions:Otago/Queenstown-Lakes": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Queenstown-Lakes",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Queenstown-Lakes"
+          },
+          "NZ_Regions:Otago/Central Otago": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Central Otago",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Central Otago"
+          },
+          "NZ_Regions:Otago/Dunedin": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Dunedin",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Dunedin"
+          },
+          "NZ_Regions:Otago/Clutha": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Otago/Clutha",
+            "DXCC Entity Code": "170",
+            "Region": "Otago",
+            "District": "Clutha"
+          },
+          "NZ_Regions:Southland/Gore": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Gore",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Gore"
+          },
+          "NZ_Regions:Southland/Southland": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Southland",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Southland"
+          },
+          "NZ_Regions:Southland/Invercargill": {
+            "Enumeration Name": "Secondary_Administrative_Subdivision_Alt",
+            "Code": "NZ_Regions:Southland/Invercargill",
+            "DXCC Entity Code": "170",
+            "Region": "Southland",
+            "District": "Invercargill"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/enumerations_submode.json
+++ b/src/adif_mcp/resources/spec/317/enumerations_submode.json
@@ -1,0 +1,984 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:54Z",
+    "DataTypes": null,
+    "Enumerations": {
+      "Submode": {
+        "Header": [
+          "Enumeration Name",
+          "Submode",
+          "Mode",
+          "Description",
+          "Import-only",
+          "Comments"
+        ],
+        "Records": {
+          "8PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125",
+            "Mode": "PSK"
+          },
+          "8PSK125F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125F",
+            "Mode": "PSK"
+          },
+          "8PSK125FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK125FL",
+            "Mode": "PSK"
+          },
+          "8PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250",
+            "Mode": "PSK"
+          },
+          "8PSK250F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250F",
+            "Mode": "PSK"
+          },
+          "8PSK250FL": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK250FL",
+            "Mode": "PSK"
+          },
+          "8PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500",
+            "Mode": "PSK"
+          },
+          "8PSK500F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK500F",
+            "Mode": "PSK"
+          },
+          "8PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000",
+            "Mode": "PSK"
+          },
+          "8PSK1000F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1000F",
+            "Mode": "PSK"
+          },
+          "8PSK1200F": {
+            "Enumeration Name": "Submode",
+            "Submode": "8PSK1200F",
+            "Mode": "PSK"
+          },
+          "AMTORFEC": {
+            "Enumeration Name": "Submode",
+            "Submode": "AMTORFEC",
+            "Mode": "TOR"
+          },
+          "ASCI": {
+            "Enumeration Name": "Submode",
+            "Submode": "ASCI",
+            "Mode": "RTTY"
+          },
+          "C4FM": {
+            "Enumeration Name": "Submode",
+            "Submode": "C4FM",
+            "Mode": "DIGITALVOICE",
+            "Description": "C4FM 4-level FSK See the Propagation_Mode enumeration section for examples of representing C4FM voice transmissions."
+          },
+          "CHIP64": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP64",
+            "Mode": "CHIP"
+          },
+          "CHIP128": {
+            "Enumeration Name": "Submode",
+            "Submode": "CHIP128",
+            "Mode": "CHIP"
+          },
+          "DMR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DMR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Mobile Radio See the Propagation_Mode enumeration section for examples of representing DMR voice transmissions."
+          },
+          "DOM-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM-M",
+            "Mode": "DOMINO"
+          },
+          "DOM4": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM4",
+            "Mode": "DOMINO"
+          },
+          "DOM5": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM5",
+            "Mode": "DOMINO"
+          },
+          "DOM8": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM8",
+            "Mode": "DOMINO"
+          },
+          "DOM11": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM11",
+            "Mode": "DOMINO"
+          },
+          "DOM16": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM16",
+            "Mode": "DOMINO"
+          },
+          "DOM22": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM22",
+            "Mode": "DOMINO"
+          },
+          "DOM44": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM44",
+            "Mode": "DOMINO"
+          },
+          "DOM88": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOM88",
+            "Mode": "DOMINO"
+          },
+          "DOMINOEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOEX",
+            "Mode": "DOMINO"
+          },
+          "DOMINOF": {
+            "Enumeration Name": "Submode",
+            "Submode": "DOMINOF",
+            "Mode": "DOMINO"
+          },
+          "DSTAR": {
+            "Enumeration Name": "Submode",
+            "Submode": "DSTAR",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital Smart Technologies for Amateur Radio See the Propagation_Mode enumeration section for examples of representing DSTAR voice transmissions."
+          },
+          "FMHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FMHELL",
+            "Mode": "HELL"
+          },
+          "FREEDATA": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDATA",
+            "Mode": "DYNAMIC",
+            "Description": "Data communications leveraging Codec2 HF modems"
+          },
+          "FREEDV": {
+            "Enumeration Name": "Submode",
+            "Submode": "FREEDV",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital voice mode for HF radio implemented with open source"
+          },
+          "FSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSK31",
+            "Mode": "PSK"
+          },
+          "FSKH105": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH105",
+            "Mode": "HELL"
+          },
+          "FSKH245": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKH245",
+            "Mode": "HELL"
+          },
+          "FSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSKHELL",
+            "Mode": "HELL"
+          },
+          "FSQCALL": {
+            "Enumeration Name": "Submode",
+            "Submode": "FSQCALL",
+            "Mode": "MFSK",
+            "Description": "FSQCall protocol used with FSQ (Fast Simple QSO) transmission mode"
+          },
+          "FST4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software"
+          },
+          "FST4W": {
+            "Enumeration Name": "Submode",
+            "Submode": "FST4W",
+            "Mode": "MFSK",
+            "Description": "This is a digital mode supported by the WSJT-X software that is for quasi-beacon transmissions of WSPR-style messages"
+          },
+          "FT2": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT2",
+            "Mode": "MFSK"
+          },
+          "FT4": {
+            "Enumeration Name": "Submode",
+            "Submode": "FT4",
+            "Mode": "MFSK",
+            "Description": "FT4 is a digital mode designed specifically for radio contesting"
+          },
+          "GTOR": {
+            "Enumeration Name": "Submode",
+            "Submode": "GTOR",
+            "Mode": "TOR"
+          },
+          "HELL80": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELL80",
+            "Mode": "HELL"
+          },
+          "HELLX5": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX5",
+            "Mode": "HELL"
+          },
+          "HELLX9": {
+            "Enumeration Name": "Submode",
+            "Submode": "HELLX9",
+            "Mode": "HELL"
+          },
+          "HFSK": {
+            "Enumeration Name": "Submode",
+            "Submode": "HFSK",
+            "Mode": "HELL"
+          },
+          "ISCAT-A": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-A",
+            "Mode": "ISCAT"
+          },
+          "ISCAT-B": {
+            "Enumeration Name": "Submode",
+            "Submode": "ISCAT-B",
+            "Mode": "ISCAT"
+          },
+          "JS8": {
+            "Enumeration Name": "Submode",
+            "Submode": "JS8",
+            "Mode": "MFSK",
+            "Description": "Jordan Sherer designed 8-FSK modulation"
+          },
+          "JT4A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4A",
+            "Mode": "JT4"
+          },
+          "JT4B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4B",
+            "Mode": "JT4"
+          },
+          "JT4C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4C",
+            "Mode": "JT4"
+          },
+          "JT4D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4D",
+            "Mode": "JT4"
+          },
+          "JT4E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4E",
+            "Mode": "JT4"
+          },
+          "JT4F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4F",
+            "Mode": "JT4"
+          },
+          "JT4G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT4G",
+            "Mode": "JT4"
+          },
+          "JT9-1": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-1",
+            "Mode": "JT9"
+          },
+          "JT9-2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-2",
+            "Mode": "JT9"
+          },
+          "JT9-5": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-5",
+            "Mode": "JT9"
+          },
+          "JT9-10": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-10",
+            "Mode": "JT9"
+          },
+          "JT9-30": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9-30",
+            "Mode": "JT9"
+          },
+          "JT9A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9A",
+            "Mode": "JT9"
+          },
+          "JT9B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9B",
+            "Mode": "JT9"
+          },
+          "JT9C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9C",
+            "Mode": "JT9"
+          },
+          "JT9D": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9D",
+            "Mode": "JT9"
+          },
+          "JT9E": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E",
+            "Mode": "JT9"
+          },
+          "JT9E FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9E FAST",
+            "Mode": "JT9"
+          },
+          "JT9F": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F",
+            "Mode": "JT9"
+          },
+          "JT9F FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9F FAST",
+            "Mode": "JT9"
+          },
+          "JT9G": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G",
+            "Mode": "JT9"
+          },
+          "JT9G FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9G FAST",
+            "Mode": "JT9"
+          },
+          "JT9H": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H",
+            "Mode": "JT9"
+          },
+          "JT9H FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT9H FAST",
+            "Mode": "JT9"
+          },
+          "JT65A": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65A",
+            "Mode": "JT65"
+          },
+          "JT65B": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B",
+            "Mode": "JT65"
+          },
+          "JT65B2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65B2",
+            "Mode": "JT65"
+          },
+          "JT65C": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C",
+            "Mode": "JT65"
+          },
+          "JT65C2": {
+            "Enumeration Name": "Submode",
+            "Submode": "JT65C2",
+            "Mode": "JT65"
+          },
+          "JTMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "JTMS",
+            "Mode": "MFSK"
+          },
+          "LSB": {
+            "Enumeration Name": "Submode",
+            "Submode": "LSB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, lower-sideband, suppressed-carrier"
+          },
+          "M17": {
+            "Enumeration Name": "Submode",
+            "Submode": "M17",
+            "Mode": "DIGITALVOICE",
+            "Description": "Digital radio protocol using the Codec 2 voice encoder"
+          },
+          "MFSK4": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK4",
+            "Mode": "MFSK"
+          },
+          "MFSK8": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK8",
+            "Mode": "MFSK"
+          },
+          "MFSK11": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK11",
+            "Mode": "MFSK"
+          },
+          "MFSK16": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK16",
+            "Mode": "MFSK"
+          },
+          "MFSK22": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK22",
+            "Mode": "MFSK"
+          },
+          "MFSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK31",
+            "Mode": "MFSK"
+          },
+          "MFSK32": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK32",
+            "Mode": "MFSK"
+          },
+          "MFSK64": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64",
+            "Mode": "MFSK"
+          },
+          "MFSK64L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK64L",
+            "Mode": "MFSK"
+          },
+          "MFSK128": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128",
+            "Mode": "MFSK"
+          },
+          "MFSK128L": {
+            "Enumeration Name": "Submode",
+            "Submode": "MFSK128L",
+            "Mode": "MFSK"
+          },
+          "NAVTEX": {
+            "Enumeration Name": "Submode",
+            "Submode": "NAVTEX",
+            "Mode": "TOR"
+          },
+          "OLIVIA 4/125": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/125",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 4/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 4/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/250": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/250",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 8/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 8/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/500": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/500",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 16/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 16/1000",
+            "Mode": "OLIVIA"
+          },
+          "OLIVIA 32/1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "OLIVIA 32/1000",
+            "Mode": "OLIVIA"
+          },
+          "OPERA-BEACON": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-BEACON",
+            "Mode": "OPERA"
+          },
+          "OPERA-QSO": {
+            "Enumeration Name": "Submode",
+            "Submode": "OPERA-QSO",
+            "Mode": "OPERA"
+          },
+          "PAC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC2",
+            "Mode": "PAC"
+          },
+          "PAC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC3",
+            "Mode": "PAC"
+          },
+          "PAC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAC4",
+            "Mode": "PAC"
+          },
+          "PAX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PAX2",
+            "Mode": "PAX"
+          },
+          "PCW": {
+            "Enumeration Name": "Submode",
+            "Submode": "PCW",
+            "Mode": "CW",
+            "Description": "Coherent CW"
+          },
+          "PSK10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK10",
+            "Mode": "PSK"
+          },
+          "PSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK31",
+            "Mode": "PSK"
+          },
+          "PSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63",
+            "Mode": "PSK"
+          },
+          "PSK63F": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63F",
+            "Mode": "PSK"
+          },
+          "PSK63RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC10",
+            "Mode": "PSK"
+          },
+          "PSK63RC20": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC20",
+            "Mode": "PSK"
+          },
+          "PSK63RC32": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC32",
+            "Mode": "PSK"
+          },
+          "PSK63RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC4",
+            "Mode": "PSK"
+          },
+          "PSK63RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK63RC5",
+            "Mode": "PSK"
+          },
+          "PSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125",
+            "Mode": "PSK"
+          },
+          "PSK125RC10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC10",
+            "Mode": "PSK"
+          },
+          "PSK125RC12": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC12",
+            "Mode": "PSK"
+          },
+          "PSK125RC16": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC16",
+            "Mode": "PSK"
+          },
+          "PSK125RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC4",
+            "Mode": "PSK"
+          },
+          "PSK125RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK125RC5",
+            "Mode": "PSK"
+          },
+          "PSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250",
+            "Mode": "PSK"
+          },
+          "PSK250RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC2",
+            "Mode": "PSK"
+          },
+          "PSK250RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC3",
+            "Mode": "PSK"
+          },
+          "PSK250RC5": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC5",
+            "Mode": "PSK"
+          },
+          "PSK250RC6": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC6",
+            "Mode": "PSK"
+          },
+          "PSK250RC7": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK250RC7",
+            "Mode": "PSK"
+          },
+          "PSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500",
+            "Mode": "PSK"
+          },
+          "PSK500RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC2",
+            "Mode": "PSK"
+          },
+          "PSK500RC3": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC3",
+            "Mode": "PSK"
+          },
+          "PSK500RC4": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK500RC4",
+            "Mode": "PSK"
+          },
+          "PSK800RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK800RC2",
+            "Mode": "PSK"
+          },
+          "PSK1000": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000",
+            "Mode": "PSK"
+          },
+          "PSK1000RC2": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSK1000RC2",
+            "Mode": "PSK"
+          },
+          "PSKAM10": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM10",
+            "Mode": "PSK"
+          },
+          "PSKAM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM31",
+            "Mode": "PSK"
+          },
+          "PSKAM50": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKAM50",
+            "Mode": "PSK"
+          },
+          "PSKFEC31": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKFEC31",
+            "Mode": "PSK"
+          },
+          "PSKHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "PSKHELL",
+            "Mode": "HELL"
+          },
+          "QPSK31": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK31",
+            "Mode": "PSK"
+          },
+          "Q65": {
+            "Enumeration Name": "Submode",
+            "Submode": "Q65",
+            "Mode": "MFSK"
+          },
+          "QPSK63": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK63",
+            "Mode": "PSK"
+          },
+          "QPSK125": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK125",
+            "Mode": "PSK"
+          },
+          "QPSK250": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK250",
+            "Mode": "PSK"
+          },
+          "QPSK500": {
+            "Enumeration Name": "Submode",
+            "Submode": "QPSK500",
+            "Mode": "PSK"
+          },
+          "QRA64A": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64A",
+            "Mode": "QRA64"
+          },
+          "QRA64B": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64B",
+            "Mode": "QRA64"
+          },
+          "QRA64C": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64C",
+            "Mode": "QRA64"
+          },
+          "QRA64D": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64D",
+            "Mode": "QRA64"
+          },
+          "QRA64E": {
+            "Enumeration Name": "Submode",
+            "Submode": "QRA64E",
+            "Mode": "QRA64"
+          },
+          "RIBBIT_PIX": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_PIX",
+            "Mode": "OFDM",
+            "Description": "Images transmitted using Ribbit"
+          },
+          "RIBBIT_SMS": {
+            "Enumeration Name": "Submode",
+            "Submode": "RIBBIT_SMS",
+            "Mode": "OFDM",
+            "Description": "Short text messages transmitted using Ribbit"
+          },
+          "ROS-EME": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-EME",
+            "Mode": "ROS"
+          },
+          "ROS-HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-HF",
+            "Mode": "ROS"
+          },
+          "ROS-MF": {
+            "Enumeration Name": "Submode",
+            "Submode": "ROS-MF",
+            "Mode": "ROS"
+          },
+          "SCAMP_FAST": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_FAST",
+            "Mode": "FSK",
+            "Description": "SCAMP fast FSK"
+          },
+          "SCAMP_OO": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off keying"
+          },
+          "SCAMP_OO_SLW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_OO_SLW",
+            "Mode": "MTONE",
+            "Description": "SCAMP single modulated tone on/off slow keying"
+          },
+          "SCAMP_SLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_SLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP slow FSK"
+          },
+          "SCAMP_VSLOW": {
+            "Enumeration Name": "Submode",
+            "Submode": "SCAMP_VSLOW",
+            "Mode": "FSK",
+            "Description": "SCAMP very slow FSK"
+          },
+          "SIM31": {
+            "Enumeration Name": "Submode",
+            "Submode": "SIM31",
+            "Mode": "PSK"
+          },
+          "SITORB": {
+            "Enumeration Name": "Submode",
+            "Submode": "SITORB",
+            "Mode": "TOR"
+          },
+          "SLOWHELL": {
+            "Enumeration Name": "Submode",
+            "Submode": "SLOWHELL",
+            "Mode": "HELL"
+          },
+          "THOR-M": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR-M",
+            "Mode": "THOR"
+          },
+          "THOR4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR4",
+            "Mode": "THOR"
+          },
+          "THOR5": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR5",
+            "Mode": "THOR"
+          },
+          "THOR8": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR8",
+            "Mode": "THOR"
+          },
+          "THOR11": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR11",
+            "Mode": "THOR"
+          },
+          "THOR16": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR16",
+            "Mode": "THOR"
+          },
+          "THOR22": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR22",
+            "Mode": "THOR"
+          },
+          "THOR25X4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR25X4",
+            "Mode": "THOR"
+          },
+          "THOR50X1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X1",
+            "Mode": "THOR"
+          },
+          "THOR50X2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR50X2",
+            "Mode": "THOR"
+          },
+          "THOR100": {
+            "Enumeration Name": "Submode",
+            "Submode": "THOR100",
+            "Mode": "THOR"
+          },
+          "THRBX": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX",
+            "Mode": "THRB"
+          },
+          "THRBX1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX1",
+            "Mode": "THRB"
+          },
+          "THRBX2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX2",
+            "Mode": "THRB"
+          },
+          "THRBX4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THRBX4",
+            "Mode": "THRB"
+          },
+          "THROB1": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB1",
+            "Mode": "THRB"
+          },
+          "THROB2": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB2",
+            "Mode": "THRB"
+          },
+          "THROB4": {
+            "Enumeration Name": "Submode",
+            "Submode": "THROB4",
+            "Mode": "THRB"
+          },
+          "USB": {
+            "Enumeration Name": "Submode",
+            "Submode": "USB",
+            "Mode": "SSB",
+            "Description": "Amplitude modulated voice telephony, upper-sideband, suppressed-carrier"
+          },
+          "VARA HF": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA HF",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for HF"
+          },
+          "VARA SATELLITE": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA SATELLITE",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for satellite operations"
+          },
+          "VARA FM 1200": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 1200",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          },
+          "VARA FM 9600": {
+            "Enumeration Name": "Submode",
+            "Submode": "VARA FM 9600",
+            "Mode": "DYNAMIC",
+            "Description": "Channel adaptive high-speed modem for FM transceivers"
+          }
+        }
+      }
+    },
+    "Fields": null
+  }
+}

--- a/src/adif_mcp/resources/spec/317/fields.json
+++ b/src/adif_mcp/resources/spec/317/fields.json
@@ -1,0 +1,1042 @@
+{
+  "Adif": {
+    "Version": "3.1.7",
+    "Status": "Released",
+    "Date": "2026-03-22T00:00:00Z",
+    "Created": "2026-03-22T12:41:55Z",
+    "DataTypes": null,
+    "Enumerations": null,
+    "Fields": {
+      "Header": [
+        "Field Name",
+        "Data Type",
+        "Enumeration",
+        "Description",
+        "Header Field",
+        "Minimum Value",
+        "Maximum Value",
+        "Import-only",
+        "Comments"
+      ],
+      "Records": {
+        "ADIF_VER": {
+          "Field Name": "ADIF_VER",
+          "Data Type": "String",
+          "Description": "Identifies the version of ADIF used in this file in the format X.Y.Z where ● X is an integer designating the ADIF epoch. ● Y is an integer between 0 and 9 designating the major version. ● Z is an integer between 0 and 9 designating the minor version.",
+          "Header Field": "true"
+        },
+        "CREATED_TIMESTAMP": {
+          "Field Name": "CREATED_TIMESTAMP",
+          "Data Type": "String",
+          "Description": "Identifies the UTC date and time that the file was created in the format of 15 characters YYYYMMDD HHMMSS where YYYYMMDD is a Date data type. HHMMSS is a 6 character Time data type.",
+          "Header Field": "true"
+        },
+        "PROGRAMID": {
+          "Field Name": "PROGRAMID",
+          "Data Type": "String",
+          "Description": "Identifies the name of the logger, converter, or utility that created or processed this ADIF content. To help avoid name clashes, the ADIF PROGRAMID Register provides a voluntary list of PROGRAMID values.",
+          "Header Field": "true"
+        },
+        "PROGRAMVERSION": {
+          "Field Name": "PROGRAMVERSION",
+          "Data Type": "String",
+          "Description": "Identifies the version of the logger, converter, or utility that created or processed this ADIF file.",
+          "Header Field": "true"
+        },
+        "USERDEFn": {
+          "Field Name": "USERDEFn",
+          "Data Type": "String",
+          "Description": "Specifies the name and optional enumeration or range of the nth user-defined field, where n is a positive integer. The name of a user-defined field may not ● be an ADIF Field name. ● contain ○ a comma. ○ a colon. ○ an open-angle-bracket or close-angle-bracket character. ○ an open-curly-bracket or close-curly-bracket character. ● begin or end with a space character.",
+          "Header Field": "true"
+        },
+        "ADDRESS": {
+          "Field Name": "ADDRESS",
+          "Data Type": "MultilineString",
+          "Description": "the contacted station\u0027s complete mailing address: full name, street address, city, postal code, and country"
+        },
+        "ADDRESS_INTL": {
+          "Field Name": "ADDRESS_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "the contacted station\u0027s complete mailing address: full name, street address, city, postal code, and country"
+        },
+        "AGE": {
+          "Field Name": "AGE",
+          "Data Type": "Number",
+          "Description": "the contacted station\u0027s operator\u0027s age in years in the range 0 to 120 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "120"
+        },
+        "ALTITUDE": {
+          "Field Name": "ALTITUDE",
+          "Data Type": "Number",
+          "Description": "the height of the contacted station in meters relative to Mean Sea Level (MSL). For example 1.5 km is \u003CALTITUDE:4\u003E1500 and 10.5 m is \u003CALTITUDE:4\u003E10.5"
+        },
+        "ANT_AZ": {
+          "Field Name": "ANT_AZ",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s antenna azimuth, in degrees with a value between 0 to 360 (inclusive). Values outside this range are import-only and must be normalized for export (e.g. 370 is exported as 10). True north is 0 degrees with values increasing in a clockwise direction.",
+          "Minimum Value": "0",
+          "Maximum Value": "360"
+        },
+        "ANT_EL": {
+          "Field Name": "ANT_EL",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s antenna elevation, in degrees with a value between -90 to 90 (inclusive). Values outside this range are import-only and must be normalized for export (e.g. 100 is exported as 80). The horizon is 0 degrees with values increasing as the angle moves in an upward direction.",
+          "Minimum Value": "-90",
+          "Maximum Value": "90"
+        },
+        "ANT_PATH": {
+          "Field Name": "ANT_PATH",
+          "Data Type": "Enumeration",
+          "Enumeration": "Ant_Path",
+          "Description": "the signal path"
+        },
+        "ARRL_SECT": {
+          "Field Name": "ARRL_SECT",
+          "Data Type": "Enumeration",
+          "Enumeration": "ARRL_Section",
+          "Description": "the contacted station\u0027s ARRL section"
+        },
+        "AWARD_SUBMITTED": {
+          "Field Name": "AWARD_SUBMITTED",
+          "Data Type": "SponsoredAwardList",
+          "Enumeration": "Sponsored_Award",
+          "Description": "the list of awards submitted to a sponsor. note that this field might not be used in a QSO record. It might be used to convey information about a user\u0027s \u0022Award Account\u0022 between an award sponsor and the user. For example, AA6YQ might submit a request for awards by sending the following: \u003CCALL:5\u003EAA6YQ \u003CAWARD_SUBMITTED:64\u003EADIF_CENTURY_BASIC,ADIF_CENTURY_SILVER,ADIF_SPECTRUM_100-160m"
+        },
+        "AWARD_GRANTED": {
+          "Field Name": "AWARD_GRANTED",
+          "Data Type": "SponsoredAwardList",
+          "Enumeration": "Sponsored_Award",
+          "Description": "the list of awards granted by a sponsor. note that this field might not be used in a QSO record. It might be used to convey information about a user\u0027s \u0022Award Account\u0022 between an award sponsor and the user. For example, in response to a request \u0022send me a list of the awards granted to AA6YQ\u0022, this might be received: \u003CCALL:5\u003EAA6YQ \u003CAWARD_GRANTED:64\u003EADIF_CENTURY_BASIC,ADIF_CENTURY_SILVER,ADIF_SPECTRUM_100-160m"
+        },
+        "A_INDEX": {
+          "Field Name": "A_INDEX",
+          "Data Type": "Number",
+          "Description": "the geomagnetic A index at the time of the QSO in the range 0 to 400 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "400"
+        },
+        "BAND": {
+          "Field Name": "BAND",
+          "Data Type": "Enumeration",
+          "Enumeration": "Band",
+          "Description": "QSO Band"
+        },
+        "BAND_RX": {
+          "Field Name": "BAND_RX",
+          "Data Type": "Enumeration",
+          "Enumeration": "Band",
+          "Description": "in a split frequency QSO, the logging station\u0027s receiving band"
+        },
+        "CALL": {
+          "Field Name": "CALL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s callsign"
+        },
+        "CHECK": {
+          "Field Name": "CHECK",
+          "Data Type": "String",
+          "Description": "contest check (e.g. for ARRL Sweepstakes)"
+        },
+        "CLASS": {
+          "Field Name": "CLASS",
+          "Data Type": "String",
+          "Description": "contest class (e.g. for ARRL Field Day)"
+        },
+        "CLUBLOG_QSO_UPLOAD_DATE": {
+          "Field Name": "CLUBLOG_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the Club Log online service"
+        },
+        "CLUBLOG_QSO_UPLOAD_STATUS": {
+          "Field Name": "CLUBLOG_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the Club Log online service"
+        },
+        "CNTY": {
+          "Field Name": "CNTY",
+          "Data Type": "Enumeration",
+          "Enumeration": "Secondary_Administrative_Subdivision[DXCC]",
+          "Description": "the contacted station\u0027s Secondary Administrative Subdivision (e.g. US county, JA Gun), in the specified format"
+        },
+        "CNTY_ALT": {
+          "Field Name": "CNTY_ALT",
+          "Data Type": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of Secondary Administrative Subdivision Alt codes for the contacted station See the Data Type for details."
+        },
+        "COMMENT": {
+          "Field Name": "COMMENT",
+          "Data Type": "String",
+          "Description": "comment field for QSO for a message to be incorporated in a paper or electronic QSL for the contacted station\u0027s operator, use the QSLMSG field recommended use: information of interest to the contacted station\u0027s operator"
+        },
+        "COMMENT_INTL": {
+          "Field Name": "COMMENT_INTL",
+          "Data Type": "IntlString",
+          "Description": "comment field for QSO for a message to be incorporated in a paper or electronic QSL for the contacted station\u0027s operator, use the QSLMSG_INTL field recommended use: information of interest to the contacted station\u0027s operator"
+        },
+        "CONT": {
+          "Field Name": "CONT",
+          "Data Type": "Enumeration",
+          "Enumeration": "Continent",
+          "Description": "the contacted station\u0027s Continent"
+        },
+        "CONTACTED_OP": {
+          "Field Name": "CONTACTED_OP",
+          "Data Type": "String",
+          "Description": "the callsign of the individual operating the contacted station"
+        },
+        "CONTEST_ID": {
+          "Field Name": "CONTEST_ID",
+          "Data Type": "String",
+          "Enumeration": "Contest_ID",
+          "Description": "QSO Contest Identifier use enumeration values for interoperability"
+        },
+        "COUNTRY": {
+          "Field Name": "COUNTRY",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s DXCC entity name"
+        },
+        "COUNTRY_INTL": {
+          "Field Name": "COUNTRY_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s DXCC entity name"
+        },
+        "CQZ": {
+          "Field Name": "CQZ",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s CQ Zone in the range 1 to 40 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "40"
+        },
+        "CREDIT_SUBMITTED": {
+          "Field Name": "CREDIT_SUBMITTED",
+          "Data Type": "CreditList,AwardList",
+          "Enumeration": "Credit,Award",
+          "Description": "the list of credits sought for this QSO Use of data type AwardList and enumeration Award are import-only"
+        },
+        "CREDIT_GRANTED": {
+          "Field Name": "CREDIT_GRANTED",
+          "Data Type": "CreditList,AwardList",
+          "Enumeration": "Credit,Award",
+          "Description": "the list of credits granted to this QSO Use of data type AwardList and enumeration Award are import-only"
+        },
+        "DARC_DOK": {
+          "Field Name": "DARC_DOK",
+          "Data Type": "Enumeration",
+          "Description": "the contacted station\u0027s DARC DOK (District Location Code) A DOK comprises letters and numbers, e.g. \u003CDARC_DOK:3\u003EA01 Note that DARC provides two different lists - one for DOKs and one for Special DOKs."
+        },
+        "DCL_QSLRDATE": {
+          "Field Name": "DCL_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from DCL (only valid if DCL_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "DCL_QSLSDATE": {
+          "Field Name": "DCL_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to DCL (only valid if DCL_QSL_SENT is Y, Q, or I)"
+        },
+        "DCL_QSL_RCVD": {
+          "Field Name": "DCL_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "DCL QSL received status Default Value: N"
+        },
+        "DCL_QSL_SENT": {
+          "Field Name": "DCL_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "DCL QSL sent status Default Value: N"
+        },
+        "DISTANCE": {
+          "Field Name": "DISTANCE",
+          "Data Type": "Number",
+          "Description": "the distance between the logging station and the contacted station in kilometers via the specified signal path with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "DXCC": {
+          "Field Name": "DXCC",
+          "Data Type": "Enumeration",
+          "Enumeration": "DXCC_Entity_Code",
+          "Description": "the contacted station\u0027s DXCC Entity Code \u003CDXCC:1\u003E0 means that the contacted station is known not to be within a DXCC entity."
+        },
+        "EMAIL": {
+          "Field Name": "EMAIL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s email address"
+        },
+        "EQ_CALL": {
+          "Field Name": "EQ_CALL",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s owner\u0027s callsign"
+        },
+        "EQSL_AG": {
+          "Field Name": "EQSL_AG",
+          "Data Type": "Enumeration",
+          "Enumeration": "EQSL_AG",
+          "Description": "indicates whether the QSO is known to be \u0022Authenticity Guaranteed\u0022 by eQSL Default value: U"
+        },
+        "EQSL_QSLRDATE": {
+          "Field Name": "EQSL_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from eQSL.cc (only valid if EQSL_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "EQSL_QSLSDATE": {
+          "Field Name": "EQSL_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to eQSL.cc (only valid if EQSL_QSL_SENT is Y, Q, or I)"
+        },
+        "EQSL_QSL_RCVD": {
+          "Field Name": "EQSL_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "eQSL.cc QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:42\u003ECQWAZ:eqsl,CQWAZ_BAND:eqsl,CQWAZ_MODE:eqsl Default Value: N"
+        },
+        "EQSL_QSL_SENT": {
+          "Field Name": "EQSL_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "eQSL.cc QSL sent status Default Value: N"
+        },
+        "FISTS": {
+          "Field Name": "FISTS",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s FISTS CW Club member number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "FISTS_CC": {
+          "Field Name": "FISTS_CC",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s FISTS CW Club Century Certificate (CC) number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "FORCE_INIT": {
+          "Field Name": "FORCE_INIT",
+          "Data Type": "Boolean",
+          "Description": "new EME \u0022initial\u0022"
+        },
+        "FREQ": {
+          "Field Name": "FREQ",
+          "Data Type": "Number",
+          "Description": "QSO frequency in Megahertz"
+        },
+        "FREQ_RX": {
+          "Field Name": "FREQ_RX",
+          "Data Type": "Number",
+          "Description": "in a split frequency QSO, the logging station\u0027s receiving frequency in Megahertz"
+        },
+        "GRIDSQUARE": {
+          "Field Name": "GRIDSQUARE",
+          "Data Type": "GridSquare",
+          "Description": "the contacted station\u0027s 2-character, 4-character, 6-character, or 8-character Maidenhead Grid Square For 10 or 12 character locators, store the first 8 characters in GRIDSQUARE and the additional 2 or 4 characters in the GRIDSQUARE_EXT field"
+        },
+        "GRIDSQUARE_EXT": {
+          "Field Name": "GRIDSQUARE_EXT",
+          "Data Type": "GridSquareExt",
+          "Description": "for a contacted station\u0027s 10-character Maidenhead locator, supplements the GRIDSQUARE field by containing characters 9 and 10. For a contacted station\u0027s 12-character Maidenhead locator, supplements the GRIDSQUARE field by containing characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0 to 9. On export, the field length must be 2 or 4. On import, if the field length is greater than 4, the additional characters must be ignored. Example of exporting the 10-character locator FN01MH42BQ: \u003CGRIDSQUARE:8\u003EFN01MH42 \u003CGRIDSQUARE_EXT:2\u003EBQ"
+        },
+        "GUEST_OP": {
+          "Field Name": "GUEST_OP",
+          "Data Type": "String",
+          "Description": "import-only: use OPERATOR instead",
+          "Import-only": "true"
+        },
+        "HAMLOGEU_QSO_UPLOAD_DATE": {
+          "Field Name": "HAMLOGEU_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HAMLOG.EU online service"
+        },
+        "HAMLOGEU_QSO_UPLOAD_STATUS": {
+          "Field Name": "HAMLOGEU_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HAMLOG.EU online service"
+        },
+        "HAMQTH_QSO_UPLOAD_DATE": {
+          "Field Name": "HAMQTH_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HamQTH.com online service"
+        },
+        "HAMQTH_QSO_UPLOAD_STATUS": {
+          "Field Name": "HAMQTH_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HamQTH.com online service"
+        },
+        "HRDLOG_QSO_UPLOAD_DATE": {
+          "Field Name": "HRDLOG_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the HRDLog.net online service"
+        },
+        "HRDLOG_QSO_UPLOAD_STATUS": {
+          "Field Name": "HRDLOG_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the HRDLog.net online service"
+        },
+        "IOTA": {
+          "Field Name": "IOTA",
+          "Data Type": "IOTARefNo",
+          "Description": "the contacted station\u0027s IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "IOTA_ISLAND_ID": {
+          "Field Name": "IOTA_ISLAND_ID",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s IOTA Island Identifier, an 8-digit integer in the range 1 to 99999999 [leading zeroes optional]",
+          "Minimum Value": "1",
+          "Maximum Value": "99999999"
+        },
+        "ITUZ": {
+          "Field Name": "ITUZ",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s ITU zone in the range 1 to 90 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "90"
+        },
+        "K_INDEX": {
+          "Field Name": "K_INDEX",
+          "Data Type": "Integer",
+          "Description": "the geomagnetic K index at the time of the QSO in the range 0 to 9 (inclusive)",
+          "Minimum Value": "0",
+          "Maximum Value": "9"
+        },
+        "LAT": {
+          "Field Name": "LAT",
+          "Data Type": "Location",
+          "Description": "the contacted station\u0027s latitude"
+        },
+        "LON": {
+          "Field Name": "LON",
+          "Data Type": "Location",
+          "Description": "the contacted station\u0027s longitude"
+        },
+        "LOTW_QSLRDATE": {
+          "Field Name": "LOTW_QSLRDATE",
+          "Data Type": "Date",
+          "Description": "date QSL received from ARRL Logbook of the World (only valid if LOTW_QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "LOTW_QSLSDATE": {
+          "Field Name": "LOTW_QSLSDATE",
+          "Data Type": "Date",
+          "Description": "date QSL sent to ARRL Logbook of the World (only valid if LOTW_QSL_SENT is Y, Q, or I)"
+        },
+        "LOTW_QSL_RCVD": {
+          "Field Name": "LOTW_QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "ARRL Logbook of the World QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:39\u003EDXCC:lotw,DXCC_BAND:lotw,DXCC_MODE:lotw Default Value: N"
+        },
+        "LOTW_QSL_SENT": {
+          "Field Name": "LOTW_QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "ARRL Logbook of the World QSL sent status Default Value: N"
+        },
+        "MAX_BURSTS": {
+          "Field Name": "MAX_BURSTS",
+          "Data Type": "Number",
+          "Description": "maximum length of meteor scatter bursts heard by the logging station, in seconds with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "MODE": {
+          "Field Name": "MODE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Mode",
+          "Description": "QSO Mode"
+        },
+        "MORSE_KEY_INFO": {
+          "Field Name": "MORSE_KEY_INFO",
+          "Data Type": "String",
+          "Description": "details of the contacted station\u0027s Morse key (e.g. make, model, etc). Example: \u003CMORSE_KEY_INFO:16\u003EBegali Sculpture"
+        },
+        "MORSE_KEY_TYPE": {
+          "Field Name": "MORSE_KEY_TYPE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Morse_Key_Type",
+          "Description": "the contacted station\u0027s Morse key type (e.g. straight key, bug, etc). Example for a dual-lever paddle: \u003CMORSE_KEY_TYPE:2\u003EDP"
+        },
+        "MS_SHOWER": {
+          "Field Name": "MS_SHOWER",
+          "Data Type": "String",
+          "Description": "For Meteor Scatter QSOs, the name of the meteor shower in progress"
+        },
+        "MY_ALTITUDE": {
+          "Field Name": "MY_ALTITUDE",
+          "Data Type": "Number",
+          "Description": "the height of the logging station in meters relative to Mean Sea Level (MSL). For example 1.5 km is \u003CMY_ALTITUDE:4\u003E1500 and 10.5 m is \u003CMY_ALTITUDE:4\u003E10.5"
+        },
+        "MY_ANTENNA": {
+          "Field Name": "MY_ANTENNA",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s antenna"
+        },
+        "MY_ANTENNA_INTL": {
+          "Field Name": "MY_ANTENNA_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s antenna"
+        },
+        "MY_ARRL_SECT": {
+          "Field Name": "MY_ARRL_SECT",
+          "Data Type": "Enumeration",
+          "Enumeration": "ARRL_Section",
+          "Description": "the logging station\u0027s ARRL section"
+        },
+        "MY_CITY": {
+          "Field Name": "MY_CITY",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s city"
+        },
+        "MY_CITY_INTL": {
+          "Field Name": "MY_CITY_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s city"
+        },
+        "MY_CNTY": {
+          "Field Name": "MY_CNTY",
+          "Data Type": "Enumeration",
+          "Enumeration": "Secondary_Administrative_Subdivision[MY_DXCC]",
+          "Description": "the logging station\u0027s Secondary Administrative Subdivision (e.g. US county, JA Gun), in the specified format"
+        },
+        "MY_CNTY_ALT": {
+          "Field Name": "MY_CNTY_ALT",
+          "Data Type": "SecondaryAdministrativeSubdivisionListAlt",
+          "Description": "a semicolon (;) delimited, unordered list of Secondary Administrative Subdivision Alt codes for the logging station See the Data Type for details."
+        },
+        "MY_COUNTRY": {
+          "Field Name": "MY_COUNTRY",
+          "Data Type": "String",
+          "Enumeration": "Country",
+          "Description": "the logging station\u0027s DXCC entity name"
+        },
+        "MY_COUNTRY_INTL": {
+          "Field Name": "MY_COUNTRY_INTL",
+          "Data Type": "IntlString",
+          "Enumeration": "Country",
+          "Description": "the logging station\u0027s DXCC entity name"
+        },
+        "MY_CQ_ZONE": {
+          "Field Name": "MY_CQ_ZONE",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s CQ Zone in the range 1 to 40 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "40"
+        },
+        "MY_DARC_DOK": {
+          "Field Name": "MY_DARC_DOK",
+          "Data Type": "Enumeration",
+          "Description": "the logging station\u0027s DARC DOK (District Location Code) A DOK comprises letters and numbers, e.g. \u003CMY_DARC_DOK:3\u003EA01 Note that DARC provides two different lists - one for DOKs and one for Special DOKs."
+        },
+        "MY_DXCC": {
+          "Field Name": "MY_DXCC",
+          "Data Type": "Enumeration",
+          "Enumeration": "DXCC_Entity_Code",
+          "Description": "the logging station\u0027s DXCC Entity Code \u003CMY_DXCC:1\u003E0 means that the logging station is known not to be within a DXCC entity."
+        },
+        "MY_FISTS": {
+          "Field Name": "MY_FISTS",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s FISTS CW Club member number with a value greater than 0.",
+          "Minimum Value": "1"
+        },
+        "MY_GRIDSQUARE": {
+          "Field Name": "MY_GRIDSQUARE",
+          "Data Type": "GridSquare",
+          "Description": "the logging station\u0027s 2-character, 4-character, 6-character, or 8-character Maidenhead Grid Square For 10 or 12 character locators, store the first 8 characters in MY_GRIDSQUARE and the additional 2 or 4 characters in the MY_GRIDSQUARE_EXT field"
+        },
+        "MY_GRIDSQUARE_EXT": {
+          "Field Name": "MY_GRIDSQUARE_EXT",
+          "Data Type": "GridSquareExt",
+          "Description": "for a logging station\u0027s 10-character Maidenhead locator, supplements the MY_GRIDSQUARE field by containing characters 9 and 10. For a logging station\u0027s 12-character Maidenhead locator, supplements the MY_GRIDSQUARE field by containing characters 9, 10, 11 and 12. Characters 9 and 10 are case-insensitive ASCII letters in the range A-X. Characters 11 and 12 are Digits in the range 0 to 9. On export, the field length must be 2 or 4. On import, if the field length is greater than 4, the additional characters must be ignored. Example of exporting the 10-character locator FN01MH42BQ: \u003CMY_GRIDSQUARE:8\u003EFN01MH42 \u003CMY_GRIDSQUARE_EXT:2\u003EBQ"
+        },
+        "MY_IOTA": {
+          "Field Name": "MY_IOTA",
+          "Data Type": "IOTARefNo",
+          "Description": "the logging station\u0027s IOTA designator, in format CC-XXX, where CC is a member of the Continent enumeration XXX is the island group designator, where 1 \u003C= XXX \u003C= 999 [use leading zeroes]"
+        },
+        "MY_IOTA_ISLAND_ID": {
+          "Field Name": "MY_IOTA_ISLAND_ID",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s IOTA Island Identifier, an 8-digit integer in the range 1 to 99999999 [leading zeroes optional]",
+          "Minimum Value": "1",
+          "Maximum Value": "99999999"
+        },
+        "MY_ITU_ZONE": {
+          "Field Name": "MY_ITU_ZONE",
+          "Data Type": "PositiveInteger",
+          "Description": "the logging station\u0027s ITU zone in the range 1 to 90 (inclusive)",
+          "Minimum Value": "1",
+          "Maximum Value": "90"
+        },
+        "MY_LAT": {
+          "Field Name": "MY_LAT",
+          "Data Type": "Location",
+          "Description": "the logging station\u0027s latitude"
+        },
+        "MY_LON": {
+          "Field Name": "MY_LON",
+          "Data Type": "Location",
+          "Description": "the logging station\u0027s longitude"
+        },
+        "MY_MORSE_KEY_INFO": {
+          "Field Name": "MY_MORSE_KEY_INFO",
+          "Data Type": "String",
+          "Description": "details of the logging station\u0027s Morse key (e.g. make, model, etc). Example: \u003CMY_MORSE_KEY_INFO:16\u003EBegali Sculpture"
+        },
+        "MY_MORSE_KEY_TYPE": {
+          "Field Name": "MY_MORSE_KEY_TYPE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Morse_Key_Type",
+          "Description": "the logging station\u0027s Morse key type (e.g. straight key, bug, etc). Example for a dual-lever paddle: \u003CMORSE_KEY_TYPE:2\u003EDP"
+        },
+        "MY_NAME": {
+          "Field Name": "MY_NAME",
+          "Data Type": "String",
+          "Description": "the logging operator\u0027s name"
+        },
+        "MY_NAME_INTL": {
+          "Field Name": "MY_NAME_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging operator\u0027s name"
+        },
+        "MY_POSTAL_CODE": {
+          "Field Name": "MY_POSTAL_CODE",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s postal code"
+        },
+        "MY_POSTAL_CODE_INTL": {
+          "Field Name": "MY_POSTAL_CODE_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s postal code"
+        },
+        "MY_POTA_REF": {
+          "Field Name": "MY_POTA_REF",
+          "Data Type": "POTARefList",
+          "Description": "a comma-delimited list of one or more of the logging station\u0027s POTA (Parks on the Air) reference(s). Examples: \u003CMY_POTA_REF:6\u003EK-0059 \u003CMY_POTA_REF:7\u003EK-10000 \u003CMY_POTA_REF:40\u003EK-0817,K-4566,K-4576,K-4573,K-4578@US-WY"
+        },
+        "MY_RIG": {
+          "Field Name": "MY_RIG",
+          "Data Type": "String",
+          "Description": "description of the logging station\u0027s equipment"
+        },
+        "MY_RIG_INTL": {
+          "Field Name": "MY_RIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "description of the logging station\u0027s equipment"
+        },
+        "MY_SIG": {
+          "Field Name": "MY_SIG",
+          "Data Type": "String",
+          "Description": "special interest activity or event"
+        },
+        "MY_SIG_INTL": {
+          "Field Name": "MY_SIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "special interest activity or event"
+        },
+        "MY_SIG_INFO": {
+          "Field Name": "MY_SIG_INFO",
+          "Data Type": "String",
+          "Description": "special interest activity or event information"
+        },
+        "MY_SIG_INFO_INTL": {
+          "Field Name": "MY_SIG_INFO_INTL",
+          "Data Type": "IntlString",
+          "Description": "special interest activity or event information"
+        },
+        "MY_SOTA_REF": {
+          "Field Name": "MY_SOTA_REF",
+          "Data Type": "SOTARef",
+          "Description": "the logging station\u0027s International SOTA Reference."
+        },
+        "MY_STATE": {
+          "Field Name": "MY_STATE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Primary_Administrative_Subdivision[MY_DXCC]",
+          "Description": "the code for the logging station\u0027s Primary Administrative Subdivision (e.g. US State, JA Island, VE Province)"
+        },
+        "MY_STREET": {
+          "Field Name": "MY_STREET",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s street"
+        },
+        "MY_STREET_INTL": {
+          "Field Name": "MY_STREET_INTL",
+          "Data Type": "IntlString",
+          "Description": "the logging station\u0027s street"
+        },
+        "MY_USACA_COUNTIES": {
+          "Field Name": "MY_USACA_COUNTIES",
+          "Data Type": "SecondarySubdivisionList",
+          "Description": "two US counties in the case where the logging station is located on a border between two counties, representing counties that the contacted station may claim for the CQ Magazine USA-CA award program. E.g. MA,Franklin:MA,Hampshire"
+        },
+        "MY_VUCC_GRIDS": {
+          "Field Name": "MY_VUCC_GRIDS",
+          "Data Type": "GridSquareList",
+          "Description": "two or four adjacent Maidenhead grid locators, each four or six characters long, representing the logging station\u0027s grid squares that the contacted station may claim for the ARRL VUCC award program. E.g. EM98,FM08,EM97,FM07"
+        },
+        "MY_WWFF_REF": {
+          "Field Name": "MY_WWFF_REF",
+          "Data Type": "WWFFRef",
+          "Description": "the logging station\u0027s WWFF (World Wildlife Flora \u0026 Fauna) reference"
+        },
+        "NAME": {
+          "Field Name": "NAME",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s operator\u0027s name"
+        },
+        "NAME_INTL": {
+          "Field Name": "NAME_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s operator\u0027s name"
+        },
+        "NOTES": {
+          "Field Name": "NOTES",
+          "Data Type": "MultilineString",
+          "Description": "QSO notes recommended use: information of interest to the logging station\u0027s operator"
+        },
+        "NOTES_INTL": {
+          "Field Name": "NOTES_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "QSO notes recommended use: information of interest to the logging station\u0027s operator"
+        },
+        "NR_BURSTS": {
+          "Field Name": "NR_BURSTS",
+          "Data Type": "Integer",
+          "Description": "the number of meteor scatter bursts heard by the logging station with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "NR_PINGS": {
+          "Field Name": "NR_PINGS",
+          "Data Type": "Integer",
+          "Description": "the number of meteor scatter pings heard by the logging station with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "OPERATOR": {
+          "Field Name": "OPERATOR",
+          "Data Type": "String",
+          "Description": "the logging operator\u0027s callsign if STATION_CALLSIGN is absent, OPERATOR shall be treated as both the logging station\u0027s callsign and the logging operator\u0027s callsign"
+        },
+        "OWNER_CALLSIGN": {
+          "Field Name": "OWNER_CALLSIGN",
+          "Data Type": "String",
+          "Description": "the callsign of the owner of the station used to log the contact (the callsign of the OPERATOR\u0027s host) if OWNER_CALLSIGN is absent, STATION_CALLSIGN shall be treated as both the logging station\u0027s callsign and the callsign of the owner of the station"
+        },
+        "PFX": {
+          "Field Name": "PFX",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s WPX prefix"
+        },
+        "POTA_REF": {
+          "Field Name": "POTA_REF",
+          "Data Type": "POTARefList",
+          "Description": "a comma-delimited list of one or more of the contacted station\u0027s POTA (Parks on the Air) reference(s). Examples: \u003CPOTA_REF:6\u003EK-5033 \u003CPOTA_REF:13\u003EVE-5082@CA-AB \u003CPOTA_REF:40\u003EK-0817,K-4566,K-4576,K-4573,K-4578@US-WY"
+        },
+        "PRECEDENCE": {
+          "Field Name": "PRECEDENCE",
+          "Data Type": "String",
+          "Description": "contest precedence (e.g. for ARRL Sweepstakes)"
+        },
+        "PROP_MODE": {
+          "Field Name": "PROP_MODE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Propagation_Mode",
+          "Description": "QSO propagation mode"
+        },
+        "PUBLIC_KEY": {
+          "Field Name": "PUBLIC_KEY",
+          "Data Type": "String",
+          "Description": "public encryption key"
+        },
+        "QRZCOM_QSO_DOWNLOAD_DATE": {
+          "Field Name": "QRZCOM_QSO_DOWNLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "date QSO downloaded from QRZ.COM logbook"
+        },
+        "QRZCOM_QSO_DOWNLOAD_STATUS": {
+          "Field Name": "QRZCOM_QSO_DOWNLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Download_Status",
+          "Description": "QRZ.COM logbook QSO download status"
+        },
+        "QRZCOM_QSO_UPLOAD_DATE": {
+          "Field Name": "QRZCOM_QSO_UPLOAD_DATE",
+          "Data Type": "Date",
+          "Description": "the date the QSO was last uploaded to the QRZ.COM online service"
+        },
+        "QRZCOM_QSO_UPLOAD_STATUS": {
+          "Field Name": "QRZCOM_QSO_UPLOAD_STATUS",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Upload_Status",
+          "Description": "the upload status of the QSO on the QRZ.COM online service"
+        },
+        "QSLMSG": {
+          "Field Name": "QSLMSG",
+          "Data Type": "MultilineString",
+          "Description": "a message for the contacted station\u0027s operator to be incorporated in a paper or electronic QSL"
+        },
+        "QSLMSG_INTL": {
+          "Field Name": "QSLMSG_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "a message for the contacted station\u0027s operator to be incorporated in a paper or electronic QSL"
+        },
+        "QSLMSG_RCVD": {
+          "Field Name": "QSLMSG_RCVD",
+          "Data Type": "MultilineString",
+          "Description": "a message addressed to the logging station\u0027s operator incorporated in a paper or electronic QSL"
+        },
+        "QSLRDATE": {
+          "Field Name": "QSLRDATE",
+          "Data Type": "Date",
+          "Description": "QSL received date (only valid if QSL_RCVD is Y, I, or V)(V import-only)"
+        },
+        "QSLSDATE": {
+          "Field Name": "QSLSDATE",
+          "Data Type": "Date",
+          "Description": "QSL sent date (only valid if QSL_SENT is Y, Q, or I)"
+        },
+        "QSL_RCVD": {
+          "Field Name": "QSL_RCVD",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Rcvd",
+          "Description": "QSL received status instead of V (import-only) use \u003CCREDIT_GRANTED:39\u003EDXCC:card,DXCC_BAND:card,DXCC_MODE:card Default Value: N"
+        },
+        "QSL_RCVD_VIA": {
+          "Field Name": "QSL_RCVD_VIA",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Via",
+          "Description": "if QSL_RCVD is set to \u0027Y\u0027 or \u0027V\u0027, the means by which the QSL was received by the logging station; otherwise, the means by which the logging station requested or intends to request that the QSL be conveyed. (Note: \u0027V\u0027 is import-only) use of M (manager) is import-only"
+        },
+        "QSL_SENT": {
+          "Field Name": "QSL_SENT",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Sent",
+          "Description": "QSL sent status Default Value: N"
+        },
+        "QSL_SENT_VIA": {
+          "Field Name": "QSL_SENT_VIA",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSL_Via",
+          "Description": "if QSL_SENT is set to \u0027Y\u0027, the means by which the QSL was sent by the logging station; otherwise, the means by which the logging station intends to convey the QSL use of M (manager) is import-only"
+        },
+        "QSL_VIA": {
+          "Field Name": "QSL_VIA",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s QSL route"
+        },
+        "QSO_COMPLETE": {
+          "Field Name": "QSO_COMPLETE",
+          "Data Type": "Enumeration",
+          "Enumeration": "QSO_Complete",
+          "Description": "indicates whether the QSO was complete from the perspective of the logging station Y - yes N - no NIL - not heard ? - uncertain"
+        },
+        "QSO_DATE": {
+          "Field Name": "QSO_DATE",
+          "Data Type": "Date",
+          "Description": "date on which the QSO started"
+        },
+        "QSO_DATE_OFF": {
+          "Field Name": "QSO_DATE_OFF",
+          "Data Type": "Date",
+          "Description": "date on which the QSO ended"
+        },
+        "QSO_RANDOM": {
+          "Field Name": "QSO_RANDOM",
+          "Data Type": "Boolean",
+          "Description": "indicates whether the QSO was random or scheduled"
+        },
+        "QTH": {
+          "Field Name": "QTH",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s city"
+        },
+        "QTH_INTL": {
+          "Field Name": "QTH_INTL",
+          "Data Type": "IntlString",
+          "Description": "the contacted station\u0027s city"
+        },
+        "REGION": {
+          "Field Name": "REGION",
+          "Data Type": "Enumeration",
+          "Enumeration": "Region",
+          "Description": "the contacted station\u0027s WAE or CQ entity contained within a DXCC entity. the value None indicates that the WAE or CQ entity is the DXCC entity in the DXCC field. nothing can be inferred from the absence of the REGION field"
+        },
+        "RIG": {
+          "Field Name": "RIG",
+          "Data Type": "MultilineString",
+          "Description": "description of the contacted station\u0027s equipment"
+        },
+        "RIG_INTL": {
+          "Field Name": "RIG_INTL",
+          "Data Type": "IntlMultilineString",
+          "Description": "description of the contacted station\u0027s equipment"
+        },
+        "RST_RCVD": {
+          "Field Name": "RST_RCVD",
+          "Data Type": "String",
+          "Description": "signal report from the contacted station"
+        },
+        "RST_SENT": {
+          "Field Name": "RST_SENT",
+          "Data Type": "String",
+          "Description": "signal report sent to the contacted station"
+        },
+        "RX_PWR": {
+          "Field Name": "RX_PWR",
+          "Data Type": "Number",
+          "Description": "the contacted station\u0027s transmitter power in Watts with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "SAT_MODE": {
+          "Field Name": "SAT_MODE",
+          "Data Type": "String",
+          "Description": "satellite mode - a code representing the satellite\u0027s uplink band and downlink band"
+        },
+        "SAT_NAME": {
+          "Field Name": "SAT_NAME",
+          "Data Type": "String",
+          "Description": "name of satellite"
+        },
+        "SFI": {
+          "Field Name": "SFI",
+          "Data Type": "Integer",
+          "Description": "the solar flux at the time of the QSO in the range 0 to 300 (inclusive).",
+          "Minimum Value": "0",
+          "Maximum Value": "300"
+        },
+        "SIG": {
+          "Field Name": "SIG",
+          "Data Type": "String",
+          "Description": "the name of the contacted station\u0027s special activity or interest group"
+        },
+        "SIG_INTL": {
+          "Field Name": "SIG_INTL",
+          "Data Type": "IntlString",
+          "Description": "the name of the contacted station\u0027s special activity or interest group"
+        },
+        "SIG_INFO": {
+          "Field Name": "SIG_INFO",
+          "Data Type": "String",
+          "Description": "information associated with the contacted station\u0027s activity or interest group"
+        },
+        "SIG_INFO_INTL": {
+          "Field Name": "SIG_INFO_INTL",
+          "Data Type": "IntlString",
+          "Description": "information associated with the contacted station\u0027s activity or interest group"
+        },
+        "SILENT_KEY": {
+          "Field Name": "SILENT_KEY",
+          "Data Type": "Boolean",
+          "Description": "\u0027Y\u0027 indicates that the contacted station\u0027s operator is now a Silent Key."
+        },
+        "SKCC": {
+          "Field Name": "SKCC",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s Straight Key Century Club (SKCC) member information"
+        },
+        "SOTA_REF": {
+          "Field Name": "SOTA_REF",
+          "Data Type": "SOTARef",
+          "Description": "the contacted station\u0027s International SOTA Reference."
+        },
+        "SRX": {
+          "Field Name": "SRX",
+          "Data Type": "Integer",
+          "Description": "contest QSO received serial number with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "SRX_STRING": {
+          "Field Name": "SRX_STRING",
+          "Data Type": "String",
+          "Description": "contest QSO received information use Cabrillo format to convey contest information for which ADIF fields are not specified in the event of a conflict between information in a dedicated contest field and this field, information in the dedicated contest field shall prevail"
+        },
+        "STATE": {
+          "Field Name": "STATE",
+          "Data Type": "Enumeration",
+          "Enumeration": "Primary_Administrative_Subdivision[DXCC]",
+          "Description": "the code for the contacted station\u0027s Primary Administrative Subdivision (e.g. US State, JA Island, VE Province)"
+        },
+        "STATION_CALLSIGN": {
+          "Field Name": "STATION_CALLSIGN",
+          "Data Type": "String",
+          "Description": "the logging station\u0027s callsign (the callsign used over the air) if STATION_CALLSIGN is absent, OPERATOR shall be treated as both the logging station\u0027s callsign and the logging operator\u0027s callsign"
+        },
+        "STX": {
+          "Field Name": "STX",
+          "Data Type": "Integer",
+          "Description": "contest QSO transmitted serial number with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "STX_STRING": {
+          "Field Name": "STX_STRING",
+          "Data Type": "String",
+          "Description": "contest QSO transmitted information use Cabrillo format to convey contest information for which ADIF fields are not specified in the event of a conflict between information in a dedicated contest field and this field, information in the dedicated contest field shall prevail"
+        },
+        "SUBMODE": {
+          "Field Name": "SUBMODE",
+          "Data Type": "String",
+          "Enumeration": "Submode[MODE]",
+          "Description": "QSO Submode use enumeration values for interoperability"
+        },
+        "SWL": {
+          "Field Name": "SWL",
+          "Data Type": "Boolean",
+          "Description": "indicates that the QSO information pertains to an SWL report"
+        },
+        "TEN_TEN": {
+          "Field Name": "TEN_TEN",
+          "Data Type": "PositiveInteger",
+          "Description": "Ten-Ten number with a value greater than 0",
+          "Minimum Value": "1"
+        },
+        "TIME_OFF": {
+          "Field Name": "TIME_OFF",
+          "Data Type": "Time",
+          "Description": "HHMM or HHMMSS in UTC in the absence of \u003CQSO_DATE_OFF\u003E, the QSO duration is less than 24 hours. For example, the following is a QSO starting at 14 July 2020 23:55 and finishing at 15 July 2020 01:00: \u003CQSO_DATE:8\u003E20200714 \u003CTIME_ON:4\u003E2355 \u003CTIME_OFF:4\u003E0100"
+        },
+        "TIME_ON": {
+          "Field Name": "TIME_ON",
+          "Data Type": "Time",
+          "Description": "HHMM or HHMMSS in UTC"
+        },
+        "TX_PWR": {
+          "Field Name": "TX_PWR",
+          "Data Type": "Number",
+          "Description": "the logging station\u0027s power in Watts with a value greater than or equal to 0",
+          "Minimum Value": "0"
+        },
+        "UKSMG": {
+          "Field Name": "UKSMG",
+          "Data Type": "PositiveInteger",
+          "Description": "the contacted station\u0027s UKSMG member number with a value greater than 0",
+          "Minimum Value": "1"
+        },
+        "USACA_COUNTIES": {
+          "Field Name": "USACA_COUNTIES",
+          "Data Type": "SecondarySubdivisionList",
+          "Description": "two US counties in the case where the contacted station is located on a border between two counties, representing counties credited to the QSO for the CQ Magazine USA-CA award program. E.g. MA,Franklin:MA,Hampshire"
+        },
+        "VE_PROV": {
+          "Field Name": "VE_PROV",
+          "Data Type": "String",
+          "Description": "import-only: use STATE instead",
+          "Import-only": "true"
+        },
+        "VUCC_GRIDS": {
+          "Field Name": "VUCC_GRIDS",
+          "Data Type": "GridSquareList",
+          "Description": "two or four adjacent Maidenhead grid locators, each four or six characters long, representing the contacted station\u0027s grid squares credited to the QSO for the ARRL VUCC award program. E.g. EM98,FM08,EM97,FM07"
+        },
+        "WEB": {
+          "Field Name": "WEB",
+          "Data Type": "String",
+          "Description": "the contacted station\u0027s URL"
+        },
+        "WWFF_REF": {
+          "Field Name": "WWFF_REF",
+          "Data Type": "WWFFRef",
+          "Description": "the contacted station\u0027s WWFF (World Wildlife Flora \u0026 Fauna) reference"
+        }
+      }
+    }
+  }
+}

--- a/src/adif_mcp/resources/spec/adif_catalog.json
+++ b/src/adif_mcp/resources/spec/adif_catalog.json
@@ -1,5 +1,5 @@
 {
-  "spec_version": "3.1.6",
+  "spec_version": "3.1.7",
   "fields": [
     "call",
     "station_call",

--- a/src/adif_mcp/resources/spec/adif_meta.json
+++ b/src/adif_mcp/resources/spec/adif_meta.json
@@ -1,11 +1,11 @@
 {
-  "spec_version": "3.1.6",
+  "spec_version": "3.1.7",
   "status": "Authoritative/Sovereign",
   "maintainer": "G7BEB",
   "build_flavor": "editable",
   "features": [
     "core QSO model",
     "geography utils",
-    "3.1.6 resources"
+    "3.1.7 resources"
   ]
 }

--- a/test/TEST-CASE-REGISTER.md
+++ b/test/TEST-CASE-REGISTER.md
@@ -1,7 +1,7 @@
 # ADIF-MCP Test Case Register
 
 **Version**: v0.7.0
-**Spec**: ADIF 3.1.6 (2025-09-15)
+**Spec**: ADIF 3.1.7 (2026-03-22)
 **Official Test Corpus**: G3ZOD `CreateADIFTestFiles` (https://adif.org.uk/316/resources)
 **Reference Validators**: K1MU Validator (web), adif-multitool (CLI, G3ZOD/flwyd)
 
@@ -15,7 +15,7 @@
 | Enum Validation — Compound (ADIF-EVC) | 3 | 3/3 PASS |
 | Enum Validation — Conditional (ADIF-EVX) | 2 | 2/2 PASS |
 | Enum Validation — Regression (ADIF-EVR) | 1 | 1/1 PASS |
-| Official ADIF 3.1.6 Test Corpus (ADIF-TCR) | 2 | 2/2 PASS |
+| Official ADIF 3.1.7 Test Corpus (ADIF-TCR) | 2 | 2/2 PASS |
 | Enum JSON Parity vs Official Export | 1 | 1/1 PASS (manual) |
 | KI7MT Forensic Hard Tests (KI7MT-FRN) | 12 | 12/12 PASS |
 | **Total** | **40** | **40/40 PASS** |
@@ -36,9 +36,9 @@ cd adif-mcp
 | Field | Value |
 |-------|-------|
 | **ID** | ADIF-ENL-001 |
-| **Name** | Enumeration count matches ADIF 3.1.6 spec |
+| **Name** | Enumeration count matches ADIF 3.1.7 spec |
 | **Tool** | `list_enumerations` |
-| **Purpose** | Verify all 25 ADIF 3.1.6 enumerations are loaded and exposed |
+| **Purpose** | Verify all 25 ADIF 3.1.7 enumerations are loaded and exposed |
 | **Input** | None |
 | **Expected** | `enumeration_count` = 25, `enumerations` dict has 25 keys |
 | **Pass Criteria** | Both assertions hold |
@@ -328,22 +328,22 @@ cd adif-mcp
 
 ---
 
-## ADIF-TCR: Official ADIF 3.1.6 Test Corpus
+## ADIF-TCR: Official ADIF 3.1.7 Test Corpus
 
 ### ADIF-TCR-001: Zero False Errors
 
 | Field | Value |
 |-------|-------|
 | **ID** | ADIF-TCR-001 |
-| **Name** | Zero false errors on official ADIF 3.1.6 test QSOs |
-| **Tool** | `validate_adif_record` (iterated over 6,191 records) |
+| **Name** | Zero false errors on official ADIF 3.1.7 test QSOs |
+| **Tool** | `validate_adif_record` (iterated over 6,197 records) |
 | **Purpose** | The official test file from adif.org.uk exercises every enumeration value in the spec. If our validator rejects any official record, **our validator is wrong**. |
-| **Source** | `https://adif.org.uk/316/resources` — `ADIF_316_test_QSOs_2025_08_27.adi` |
-| **Generator** | G3ZOD `CreateADIFTestFiles` v3.1.6.1 |
-| **Records** | 6,191 QSOs covering all 25 enumerations, all field types, user-defined fields, app-defined fields |
-| **Expected** | Zero errors across all 6,191 records |
+| **Source** | `https://adif.org.uk/317/` — `ADIF_317_test_QSOs_2026_03_22.adi` |
+| **Generator** | G3ZOD `CreateADIFTestFiles` (3.1.7 corpus) |
+| **Records** | 6,197 QSOs covering all 25 enumerations, all field types, user-defined fields, app-defined fields |
+| **Expected** | Zero errors across all 6,197 records |
 | **Pass Criteria** | `len(all_errors) == 0` |
-| **Result** | **PASS — 0 errors on 6,191 records** |
+| **Result** | **PASS — 0 errors on 6,197 records** |
 
 ### ADIF-TCR-002: Warning Categories Are Legitimate
 
@@ -351,7 +351,7 @@ cd adif-mcp
 |-------|-------|
 | **ID** | ADIF-TCR-002 |
 | **Name** | All warnings on official test file are correct behavior |
-| **Tool** | `validate_adif_record` (iterated over 6,191 records) |
+| **Tool** | `validate_adif_record` (iterated over 6,197 records) |
 | **Purpose** | Verify warnings are real (not misclassified errors). The test file deliberately uses user-defined fields and import-only values. |
 | **Expected** | ~39 warnings total, all in categories: "not in spec" (user/app-defined fields), "import-only" (deprecated enum values), or "submode" (parent mode mismatch) |
 | **Pass Criteria** | 30-50 warnings, every warning matches a known category |
@@ -363,7 +363,7 @@ cd adif-mcp
 | Field | Value |
 |-------|-------|
 | **ID** | ADIF-TCR-003 |
-| **Name** | Our 25 enum JSON files match official ADIF 3.1.6 exports exactly |
+| **Name** | Our 25 enum JSON files match official ADIF 3.1.7 exports exactly |
 | **Purpose** | Verify we ship the authoritative data, not a stale or modified copy |
 | **Method** | Compare record counts and keys between `src/adif_mcp/resources/spec/316/enumerations_*.json` and official `316/exports/json/enumerations_*.json` from the ZIP archive |
 | **Expected** | Identical record counts and identical record keys for all 25 enumerations |
@@ -395,10 +395,10 @@ cd adif-mcp
 | Field | Value |
 |-------|-------|
 | **ID** | KI7MT-FRN-002 |
-| **Name** | MODE=FT4 correctly errors per ADIF 3.1.6 spec |
+| **Name** | MODE=FT4 correctly errors per ADIF 3.1.7 spec |
 | **Tool** | `validate_adif_record` |
 | **Source** | QRZ export — 2 of 49,233 records have MODE=FT4 |
-| **Purpose** | FT4 must be `MODE=MFSK + SUBMODE=FT4` per ADIF 3.1.6 policy. Unlike FT8 (grandfathered as a MODE before the policy), FT4 was added after MODE/SUBMODE standardization. WSJT-X exports FT4 correctly; the 2 errors came from a non-compliant logger. |
+| **Purpose** | FT4 must be `MODE=MFSK + SUBMODE=FT4` per ADIF 3.1.7 policy. Unlike FT8 (grandfathered as a MODE before the policy), FT4 was added after MODE/SUBMODE standardization. WSJT-X exports FT4 correctly; the 2 errors came from a non-compliant logger. |
 | **Input** | `<MODE:3>FT4<BAND:3>20m<EOR>` |
 | **Expected** | status="invalid", error mentions MODE + FT4 |
 | **Rationale** | Ref: https://wsjtx.groups.io/g/main/topic/85236332 — FT8 was rushed through before ADIF 3 policy; FT4 follows the rules. This is a TRUE data error, not a false positive. |
@@ -438,7 +438,7 @@ cd adif-mcp
 | **Name** | QSL_SENT_VIA=M warns as import-only, not error |
 | **Tool** | `validate_adif_record` |
 | **Source** | QRZ export — pre-internet QSOs used QSL managers extensively |
-| **Purpose** | QSL_Via "M" (manager) is import-only in 3.1.6. Common in logs predating eQSL/LoTW. Must preserve these QSOs on import, not reject. |
+| **Purpose** | QSL_Via "M" (manager) is import-only in 3.1.7. Common in logs predating eQSL/LoTW. Must preserve these QSOs on import, not reject. |
 | **Input** | `<QSL_SENT_VIA:1>M<QSL_SENT:1>Y<EOR>` |
 | **Expected** | status="success", warning contains "import-only", zero errors |
 | **Result** | PASS |
@@ -574,8 +574,8 @@ FT8 was rushed into the ADIF spec as its own MODE before the MODE/SUBMODE policy
 
 | Resource | URL |
 |----------|-----|
-| ADIF 3.1.6 Specification | https://adif.org/316/ADIF_316.htm |
-| ADIF 3.1.6 Resources (ZIP) | https://adif.org.uk/316/resources |
+| ADIF 3.1.7 Specification | https://adif.org/316/ADIF_316.htm |
+| ADIF 3.1.7 Resources (ZIP) | https://adif.org.uk/316/resources |
 | ADIF Resources Page | https://adif.org/316/ADIF_316_Resources.htm |
 | CreateADIFTestFiles (G3ZOD) | https://github.com/g3zod/CreateADIFTestFiles |
 | CreateADIFExportFiles (G3ZOD) | https://github.com/g3zod/CreateADIFExportFiles |

--- a/test/test_enumerations.py
+++ b/test/test_enumerations.py
@@ -22,10 +22,15 @@ def test_list_enumerations_count() -> None:
 
 
 def test_list_enumerations_has_mode() -> None:
-    """Mode enumeration present with correct record count."""
+    """Mode enumeration present with correct record count.
+
+    ADIF 3.1.7 adds OFDM (Orthogonal Frequency-Division Multiplexing),
+    bringing the Mode count from 90 (3.1.6) to 91. OFDM is not
+    Import-only, so the import_only_count stays at 42.
+    """
     result = list_enumerations()
     mode = result["enumerations"]["Mode"]
-    assert mode["record_count"] == 90
+    assert mode["record_count"] == 91
     assert mode["import_only_count"] == 42
     assert "Mode" in mode["searchable_fields"]
 
@@ -257,19 +262,21 @@ def test_validate_whitespace_band_errors() -> None:
     assert any("BAND" in e and "empty" in e for e in result["errors"])
 
 
-# --- Official ADIF 3.1.6 Test File (G3ZOD / adif.org.uk) ---
+# --- Official ADIF 3.1.7 Test File (G3ZOD / adif.org.uk) ---
 
 
 def test_official_adif_test_file_zero_errors() -> None:
-    """ADIF-TCR-001: Zero false errors on official 3.1.6 test corpus.
+    """ADIF-TCR-001: Zero false errors on official 3.1.7 test corpus.
 
-    Source: https://adif.org.uk/316/resources
+    Source: https://adif.org.uk/317/resources
     Generator: CreateADIFTestFiles (G3ZOD)
-    Records: 6,191 QSOs exercising every enumeration value
+    Records: 6,197 QSOs exercising every enumeration value (3.1.7 adds
+    +6 over 3.1.6: covers OFDM mode + FT2, FREEDATA, RIBBIT_PIX,
+    RIBBIT_SMS submodes).
     Gate: If our validator rejects an official record, our validator is wrong.
     """
     test_file = os.path.join(
-        _TEST_DATA, "ADIF_316_test_QSOs_2025_08_27.adi"
+        _TEST_DATA, "ADIF_317_test_QSOs_2026_03_22.adi"
     )
     if not os.path.exists(test_file):
         return  # Skip if test file not present (CI without data)
@@ -281,7 +288,7 @@ def test_official_adif_test_file_zero_errors() -> None:
     body = parts[1]
     records = re.findall(r"(.*?<EOR>)", body, re.IGNORECASE | re.DOTALL)
 
-    assert len(records) == 6191, f"Expected 6191 records, got {len(records)}"
+    assert len(records) == 6197, f"Expected 6197 records, got {len(records)}"
 
     all_errors = []
     for i, rec_text in enumerate(records):
@@ -359,6 +366,60 @@ def test_country_invalid() -> None:
     result = validate_adif_record(adif)
     assert result["status"] == "invalid"
     assert any("FAKELAND" in e for e in result["errors"])
+
+
+# --- ADIF 3.1.7 new enum entries ---
+
+
+def test_317_new_mode_ofdm() -> None:
+    """ADIF 3.1.7: OFDM is a new Mode (Orthogonal Frequency-Division Multiplexing)."""
+    adif = "<MODE:4>OFDM<EOR>"
+    result = validate_adif_record(adif)
+    assert result["status"] == "success", result
+    assert not result["errors"], result["errors"]
+
+
+def test_317_new_submode_ft2() -> None:
+    """ADIF 3.1.7: FT2 is a new Submode under Mode MFSK."""
+    adif = "<MODE:4>MFSK<SUBMODE:3>FT2<EOR>"
+    result = validate_adif_record(adif)
+    assert result["status"] == "success", result
+    submode_warns = [w for w in result["warnings"] if "submode" in w.lower()]
+    assert not submode_warns, submode_warns
+
+
+def test_317_new_submode_freedata() -> None:
+    """ADIF 3.1.7: FREEDATA is a new Submode under Mode DYNAMIC."""
+    adif = "<MODE:7>DYNAMIC<SUBMODE:8>FREEDATA<EOR>"
+    result = validate_adif_record(adif)
+    assert result["status"] == "success", result
+    submode_warns = [w for w in result["warnings"] if "submode" in w.lower()]
+    assert not submode_warns, submode_warns
+
+
+def test_317_new_submode_ribbit_pix() -> None:
+    """ADIF 3.1.7: RIBBIT_PIX is a new Submode under Mode OFDM."""
+    adif = "<MODE:4>OFDM<SUBMODE:10>RIBBIT_PIX<EOR>"
+    result = validate_adif_record(adif)
+    assert result["status"] == "success", result
+    submode_warns = [w for w in result["warnings"] if "submode" in w.lower()]
+    assert not submode_warns, submode_warns
+
+
+def test_317_new_submode_ribbit_sms() -> None:
+    """ADIF 3.1.7: RIBBIT_SMS is a new Submode under Mode OFDM."""
+    adif = "<MODE:4>OFDM<SUBMODE:10>RIBBIT_SMS<EOR>"
+    result = validate_adif_record(adif)
+    assert result["status"] == "success", result
+    submode_warns = [w for w in result["warnings"] if "submode" in w.lower()]
+    assert not submode_warns, submode_warns
+
+
+def test_317_submode_count() -> None:
+    """ADIF 3.1.7: Submode count is 187 (3.1.6 had 183, +4 new in 3.1.7)."""
+    result = list_enumerations()
+    sub = result["enumerations"]["Submode"]
+    assert sub["record_count"] == 187
 
 
 def test_country_case_insensitive() -> None:

--- a/test/test_pkg_meta.py
+++ b/test/test_pkg_meta.py
@@ -8,4 +8,4 @@ def test_pkg_meta_exposed() -> None:
     assert hasattr(adif_mcp, "__version__")
     assert isinstance(adif_mcp.__version__, str) and len(adif_mcp.__version__) > 0
     assert hasattr(adif_mcp, "__adif_spec__")
-    assert adif_mcp.__adif_spec__ in {"3.1.5", "3.1.6", "3.2.0"}  # keep in sync as needed
+    assert adif_mcp.__adif_spec__ in {"3.1.5", "3.1.6", "3.1.7", "3.2.0"}  # keep in sync as needed

--- a/test/test_pkg_meta.py
+++ b/test/test_pkg_meta.py
@@ -8,4 +8,5 @@ def test_pkg_meta_exposed() -> None:
     assert hasattr(adif_mcp, "__version__")
     assert isinstance(adif_mcp.__version__, str) and len(adif_mcp.__version__) > 0
     assert hasattr(adif_mcp, "__adif_spec__")
-    assert adif_mcp.__adif_spec__ in {"3.1.5", "3.1.6", "3.1.7", "3.2.0"}  # keep in sync as needed
+    # Allowed set kept in sync as new ADIF spec revisions are added.
+    assert adif_mcp.__adif_spec__ in {"3.1.5", "3.1.6", "3.1.7", "3.2.0"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,17 +1,21 @@
 version = 1
 revision = 3
-requires-python = ">=3.11"
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "adif-mcp"
-version = "0.4.4"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "click" },
     { name = "fastmcp" },
-    { name = "keyring" },
     { name = "requests" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 
@@ -19,7 +23,6 @@ dependencies = [
 all = [
     { name = "cli-test-helpers" },
     { name = "interrogate" },
-    { name = "keyring" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -28,9 +31,6 @@ dev = [
     { name = "interrogate" },
     { name = "mypy" },
     { name = "ruff" },
-]
-keyring = [
-    { name = "keyring" },
 ]
 test = [
     { name = "cli-test-helpers" },
@@ -63,21 +63,19 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "adif-mcp", extras = ["dev", "test"], marker = "extra == 'all'" },
-    { name = "adif-mcp", extras = ["keyring"], marker = "extra == 'all'" },
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "cli-test-helpers", marker = "extra == 'test'", specifier = ">=0.3.0" },
     { name = "click", specifier = ">=8.1.7" },
-    { name = "fastmcp", specifier = ">=2.14.1" },
+    { name = "fastmcp", specifier = ">=3.0" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "keyring", specifier = ">=25.6.0" },
-    { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.3" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.8" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
-provides-extras = ["dev", "test", "keyring", "all"]
+provides-extras = ["dev", "test", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -104,6 +102,36 @@ dev = [
 ]
 
 [[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "caio", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
+
+[[package]]
+name = "aiofile"
+version = "3.11.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+dependencies = [
+    { name = "caio", marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/cd/0d76dfc5de72bde52f55f53e925c7d152d9c7906634ec1e0cbc7e8d4ad93/aiofile-3.11.1-py3-none-any.whl", hash = "sha256:ce77d14ac07f77bc2b757834a5c129321f3f705c474593deed5ab209079a52c9", size = 20446, upload-time = "2026-05-16T08:18:32.051Z" },
+]
+
+[[package]]
 name = "aiofiles"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -126,6 +154,7 @@ name = "anyio"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -144,15 +173,6 @@ wheels = [
 ]
 
 [[package]]
-name = "async-timeout"
-version = "5.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -163,14 +183,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -180,6 +201,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
@@ -237,6 +267,35 @@ wheels = [
 ]
 
 [[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/80/ea4ead0c5d52a9828692e7df20f0eafe8d26e671ce4883a0a146bb91049e/caio-0.9.25-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ca6c8ecda611478b6016cb94d23fd3eb7124852b985bdec7ecaad9f3116b9619", size = 36836, upload-time = "2025-12-26T15:22:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/36715c97c873649d1029001578f901b50250916295e3dddf20c865438865/caio-0.9.25-cp310-cp310-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db9b5681e4af8176159f0d6598e73b2279bb661e718c7ac23342c550bd78c241", size = 79695, upload-time = "2025-12-26T15:22:18.818Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/07080ecb1adb55a02cbd8ec0126aa8e43af343ffabb6a71125b42670e9a1/caio-0.9.25-cp310-cp310-manylinux_2_34_aarch64.whl", hash = "sha256:bf61d7d0c4fd10ffdd98ca47f7e8db4d7408e74649ffaf4bef40b029ada3c21b", size = 79457, upload-time = "2026-03-04T22:08:16.024Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/dd55757bb671eb4c376e006c04e83beb413486821f517792ea603ef216e9/caio-0.9.25-cp310-cp310-manylinux_2_34_x86_64.whl", hash = "sha256:ab52e5b643f8bbd64a0605d9412796cd3464cb8ca88593b13e95a0f0b10508ae", size = 77705, upload-time = "2026-03-04T22:08:17.202Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/90/543f556fcfcfa270713eef906b6352ab048e1e557afec12925c991dc93c2/caio-0.9.25-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d6956d9e4a27021c8bd6c9677f3a59eb1d820cc32d0343cea7961a03b1371965", size = 36839, upload-time = "2025-12-26T15:21:40.267Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3b/36f3e8ec38dafe8de4831decd2e44c69303d2a3892d16ceda42afed44e1b/caio-0.9.25-cp311-cp311-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf84bfa039f25ad91f4f52944452a5f6f405e8afab4d445450978cd6241d1478", size = 80255, upload-time = "2025-12-26T15:22:20.271Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ce/65e64867d928e6aff1b4f0e12dba0ef6d5bf412c240dc1df9d421ac10573/caio-0.9.25-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:ae3d62587332bce600f861a8de6256b1014d6485cfd25d68c15caf1611dd1f7c", size = 80052, upload-time = "2026-03-04T22:08:20.402Z" },
+    { url = "https://files.pythonhosted.org/packages/46/90/e278863c47e14ec58309aa2e38a45882fbe67b4cc29ec9bc8f65852d3e45/caio-0.9.25-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:fc220b8533dcf0f238a6b1a4a937f92024c71e7b10b5a2dfc1c73604a25709bc", size = 78273, upload-time = "2026-03-04T22:08:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -254,6 +313,18 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/07/f44ca684db4e4f08a3fdc6eeb9a0d15dc6883efc7b8c90357fdbf74e186c/cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14", size = 182191, upload-time = "2024-09-04T20:43:30.027Z" },
+    { url = "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67", size = 178592, upload-time = "2024-09-04T20:43:32.108Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382", size = 426024, upload-time = "2024-09-04T20:43:34.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702", size = 448188, upload-time = "2024-09-04T20:43:36.286Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3", size = 455571, upload-time = "2024-09-04T20:43:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6", size = 436687, upload-time = "2024-09-04T20:43:40.084Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17", size = 446211, upload-time = "2024-09-04T20:43:41.526Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8", size = 461325, upload-time = "2024-09-04T20:43:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e", size = 438784, upload-time = "2024-09-04T20:43:45.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be", size = 461564, upload-time = "2024-09-04T20:43:46.779Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/fe/4d41c2f200c4a457933dbd98d3cf4e911870877bd94d9656cc0fcb390681/cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c", size = 171804, upload-time = "2024-09-04T20:43:48.186Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b6/0b0f5ab93b0df4acc49cae758c81fe4e5ef26c3ae2e10cc69249dfd8b3ab/cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15", size = 181299, upload-time = "2024-09-04T20:43:49.812Z" },
     { url = "https://files.pythonhosted.org/packages/6b/f4/927e3a8899e52a27fa57a48607ff7dc91a9ebe97399b357b85a0c7892e00/cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401", size = 182264, upload-time = "2024-09-04T20:43:51.124Z" },
     { url = "https://files.pythonhosted.org/packages/6c/f5/6c3a8efe5f503175aaddcbea6ad0d2c96dad6f5abb205750d1b3df44ef29/cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf", size = 178651, upload-time = "2024-09-04T20:43:52.872Z" },
     { url = "https://files.pythonhosted.org/packages/94/dd/a3f0118e688d1b1a57553da23b16bdade96d2f9bcda4d32e7d2838047ff7/cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4", size = 445259, upload-time = "2024-09-04T20:43:56.123Z" },
@@ -296,6 +367,17 @@ version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/2d/5fd176ceb9b2fc619e63405525573493ca23441330fcdaee6bef9460e924/charset_normalizer-3.4.3.tar.gz", hash = "sha256:6fce4b8500244f6fcb71465d4a4930d132ba9ab8e71a7859e6a5d59851068d14", size = 122371, upload-time = "2025-08-09T07:57:28.46Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/98/f3b8013223728a99b908c9344da3aa04ee6e3fa235f19409033eda92fb78/charset_normalizer-3.4.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:fb7f67a1bfa6e40b438170ebdc8158b78dc465a5a67b6dde178a46987b244a72", size = 207695, upload-time = "2025-08-09T07:55:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/21/40/5188be1e3118c82dcb7c2a5ba101b783822cfb413a0268ed3be0468532de/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc9370a2da1ac13f0153780040f465839e6cccb4a1e44810124b4e22483c93fe", size = 147153, upload-time = "2025-08-09T07:55:38.467Z" },
+    { url = "https://files.pythonhosted.org/packages/37/60/5d0d74bc1e1380f0b72c327948d9c2aca14b46a9efd87604e724260f384c/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:07a0eae9e2787b586e129fdcbe1af6997f8d0e5abaa0bc98c0e20e124d67e601", size = 160428, upload-time = "2025-08-09T07:55:40.072Z" },
+    { url = "https://files.pythonhosted.org/packages/85/9a/d891f63722d9158688de58d050c59dc3da560ea7f04f4c53e769de5140f5/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:74d77e25adda8581ffc1c720f1c81ca082921329452eba58b16233ab1842141c", size = 157627, upload-time = "2025-08-09T07:55:41.706Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1a/7425c952944a6521a9cfa7e675343f83fd82085b8af2b1373a2409c683dc/charset_normalizer-3.4.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0e909868420b7049dafd3a31d45125b31143eec59235311fc4c57ea26a4acd2", size = 152388, upload-time = "2025-08-09T07:55:43.262Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c9/a2c9c2a355a8594ce2446085e2ec97fd44d323c684ff32042e2a6b718e1d/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c6f162aabe9a91a309510d74eeb6507fab5fff92337a15acbe77753d88d9dcf0", size = 150077, upload-time = "2025-08-09T07:55:44.903Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/38/20a1f44e4851aa1c9105d6e7110c9d020e093dfa5836d712a5f074a12bf7/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4ca4c094de7771a98d7fbd67d9e5dbf1eb73efa4f744a730437d8a3a5cf994f0", size = 161631, upload-time = "2025-08-09T07:55:46.346Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/fa/384d2c0f57edad03d7bec3ebefb462090d8905b4ff5a2d2525f3bb711fac/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:02425242e96bcf29a49711b0ca9f37e451da7c70562bc10e8ed992a5a7a25cc0", size = 159210, upload-time = "2025-08-09T07:55:47.539Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9e/eca49d35867ca2db336b6ca27617deed4653b97ebf45dfc21311ce473c37/charset_normalizer-3.4.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:78deba4d8f9590fe4dae384aeff04082510a709957e968753ff3c48399f6f92a", size = 153739, upload-time = "2025-08-09T07:55:48.744Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/26c3036e62dfe8de8061182d33be5025e2424002125c9500faff74a6735e/charset_normalizer-3.4.3-cp310-cp310-win32.whl", hash = "sha256:d79c198e27580c8e958906f803e63cddb77653731be08851c7df0b1a14a8fc0f", size = 99825, upload-time = "2025-08-09T07:55:50.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/f05db471f81af1fa01839d44ae2a8bfeec8d2a8b4590f16c4e7393afd323/charset_normalizer-3.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:c6e490913a46fa054e03699c70019ab869e990270597018cef1d8562132c2669", size = 107452, upload-time = "2025-08-09T07:55:51.461Z" },
     { url = "https://files.pythonhosted.org/packages/7f/b5/991245018615474a60965a7c9cd2b4efbaabd16d582a5547c47ee1c7730b/charset_normalizer-3.4.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b256ee2e749283ef3ddcff51a675ff43798d92d746d1a6e4631bf8c707d22d0b", size = 204483, upload-time = "2025-08-09T07:55:53.12Z" },
     { url = "https://files.pythonhosted.org/packages/c7/2a/ae245c41c06299ec18262825c1569c5d3298fc920e4ddf56ab011b417efd/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13faeacfe61784e2559e690fc53fa4c5ae97c6fcedb8eb6fb8d0a15b475d2c64", size = 145520, upload-time = "2025-08-09T07:55:54.712Z" },
     { url = "https://files.pythonhosted.org/packages/3a/a4/b3b6c76e7a635748c4421d2b92c7b8f90a432f98bda5082049af37ffc8e3/charset_normalizer-3.4.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:00237675befef519d9af72169d8604a067d92755e84fe76492fef5441db05b91", size = 158876, upload-time = "2025-08-09T07:55:56.024Z" },
@@ -365,15 +447,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -398,6 +471,7 @@ dependencies = [
     { name = "questionary" },
     { name = "termcolor" },
     { name = "tomlkit" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ee/c0/fe5ba5555f2891bcb0b3e7dc1c57fcfd206ab7133a3094d70b81fd5a4a10/commitizen-4.8.3.tar.gz", hash = "sha256:303ebdc271217aadbb6a73a015612121291d180c8cdd05b5251c7923d4a14195", size = 56225, upload-time = "2025-06-09T14:18:51.472Z" }
 wheels = [
@@ -437,6 +511,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/82/27/092d311af22095d288f4db89fcaebadfb2f28944f3d790a4cf51fe5ddaeb/cryptography-45.0.6-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b64e668fc3528e77efa51ca70fadcd6610e8ab231e3e06ae2bab3b31c2b8ed9", size = 4554815, upload-time = "2025-08-05T23:59:00.283Z" },
     { url = "https://files.pythonhosted.org/packages/7e/01/aa2f4940262d588a8fdf4edabe4cda45854d00ebc6eaac12568b3a491a16/cryptography-45.0.6-cp37-abi3-win32.whl", hash = "sha256:780c40fb751c7d2b0c6786ceee6b6f871e86e8718a8ff4bc35073ac353c7cd02", size = 2912147, upload-time = "2025-08-05T23:59:01.716Z" },
     { url = "https://files.pythonhosted.org/packages/0a/bc/16e0276078c2de3ceef6b5a34b965f4436215efac45313df90d55f0ba2d2/cryptography-45.0.6-cp37-abi3-win_amd64.whl", hash = "sha256:20d15aed3ee522faac1a39fbfdfee25d17b1284bafd808e1640a74846d7c4d1b", size = 3390459, upload-time = "2025-08-05T23:59:03.358Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d2/4482d97c948c029be08cb29854a91bd2ae8da7eb9c4152461f1244dcea70/cryptography-45.0.6-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:705bb7c7ecc3d79a50f236adda12ca331c8e7ecfbea51edd931ce5a7a7c4f012", size = 3576812, upload-time = "2025-08-05T23:59:04.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/24/55fc238fcaa122855442604b8badb2d442367dfbd5a7ca4bb0bd346e263a/cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:826b46dae41a1155a0c0e66fafba43d0ede1dc16570b95e40c4d83bfcf0a451d", size = 4141694, upload-time = "2025-08-05T23:59:06.66Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/7e/3ea4fa6fbe51baf3903806a0241c666b04c73d2358a3ecce09ebee8b9622/cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:cc4d66f5dc4dc37b89cfef1bd5044387f7a1f6f0abb490815628501909332d5d", size = 4375010, upload-time = "2025-08-05T23:59:08.14Z" },
+    { url = "https://files.pythonhosted.org/packages/50/42/ec5a892d82d2a2c29f80fc19ced4ba669bca29f032faf6989609cff1f8dc/cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f68f833a9d445cc49f01097d95c83a850795921b3f7cc6488731e69bde3288da", size = 4141377, upload-time = "2025-08-05T23:59:09.584Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d7/246c4c973a22b9c2931999da953a2c19cae7c66b9154c2d62ffed811225e/cryptography-45.0.6-pp310-pypy310_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3b5bf5267e98661b9b888a9250d05b063220dfa917a8203744454573c7eb79db", size = 4374609, upload-time = "2025-08-05T23:59:11.923Z" },
+    { url = "https://files.pythonhosted.org/packages/78/6d/c49ccf243f0a1b0781c2a8de8123ee552f0c8a417c6367a24d2ecb7c11b3/cryptography-45.0.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2384f2ab18d9be88a6e4f8972923405e2dbb8d3e16c6b43f15ca491d7831bd18", size = 3322156, upload-time = "2025-08-05T23:59:13.597Z" },
     { url = "https://files.pythonhosted.org/packages/61/69/c252de4ec047ba2f567ecb53149410219577d408c2aea9c989acae7eafce/cryptography-45.0.6-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fc022c1fa5acff6def2fc6d7819bbbd31ccddfe67d075331a65d9cfb28a20983", size = 3584669, upload-time = "2025-08-05T23:59:15.431Z" },
     { url = "https://files.pythonhosted.org/packages/e3/fe/deea71e9f310a31fe0a6bfee670955152128d309ea2d1c79e2a5ae0f0401/cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:3de77e4df42ac8d4e4d6cdb342d989803ad37707cf8f3fbf7b088c9cbdd46427", size = 4153022, upload-time = "2025-08-05T23:59:16.954Z" },
     { url = "https://files.pythonhosted.org/packages/60/45/a77452f5e49cb580feedba6606d66ae7b82c128947aa754533b3d1bd44b0/cryptography-45.0.6-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:599c8d7df950aa68baa7e98f7b73f4f414c9f02d0e8104a30c0182a07732638b", size = 4386802, upload-time = "2025-08-05T23:59:18.55Z" },
@@ -454,6 +534,8 @@ dependencies = [
     { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/99/e1b75193ee23bd10a05a3b90c065d419b1c8c18f61cae6b8218c7158f792/cyclopts-4.4.1.tar.gz", hash = "sha256:368a404926b46a49dc328a33ccd7e55ba879296a28e64a42afe2f6667704cecf", size = 159245, upload-time = "2025-12-21T13:59:02.266Z" }
 wheels = [
@@ -467,15 +549,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0c/59/d4ffff1dee2c8f6f2dd8f87010962e60f7b7847504d765c91ede5a466730/decli-0.6.3.tar.gz", hash = "sha256:87f9d39361adf7f16b9ca6e3b614badf7519da13092f2db3c80ca223c53c7656", size = 7564, upload-time = "2025-06-01T15:23:41.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/fa/ec878c28bc7f65b77e7e17af3522c9948a9711b9fa7fc4c5e3140a7e3578/decli-0.6.3-py3-none-any.whl", hash = "sha256:5152347c7bb8e3114ad65db719e5709b28d7f7f45bdb709f70167925e55640f3", size = 7989, upload-time = "2025-06-01T15:23:40.228Z" },
-]
-
-[[package]]
-name = "diskcache"
-version = "5.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload-time = "2023-08-31T06:12:00.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload-time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
@@ -540,48 +613,63 @@ wheels = [
 ]
 
 [[package]]
-name = "fakeredis"
-version = "2.33.0"
+name = "fastmcp"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "redis" },
-    { name = "sortedcontainers" },
+    { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/f9/57464119936414d60697fcbd32f38909bb5688b616ae13de6e98384433e0/fakeredis-2.33.0.tar.gz", hash = "sha256:d7bc9a69d21df108a6451bbffee23b3eba432c21a654afc7ff2d295428ec5770", size = 175187, upload-time = "2025-12-16T19:45:52.269Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/a9/5c5a01b6abd5346bf60b97cfd29e4a86661940c27dd562bfcda07fd03519/fastmcp-3.3.1.tar.gz", hash = "sha256:979362ea557de42a5f40342563c7e4b236bcc8e7cd192715f50030695d1a71cd", size = 28681699, upload-time = "2026-05-15T15:50:39.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/78/a850fed8aeef96d4a99043c90b818b2ed5419cd5b24a4049fd7cfb9f1471/fakeredis-2.33.0-py3-none-any.whl", hash = "sha256:de535f3f9ccde1c56672ab2fdd6a8efbc4f2619fc2f1acc87b8737177d71c965", size = 119605, upload-time = "2025-12-16T19:45:51.08Z" },
-]
-
-[package.optional-dependencies]
-lua = [
-    { name = "lupa" },
+    { url = "https://files.pythonhosted.org/packages/9f/11/6b1bdada6ccfe647d615ae63f9106f8136aec17971e9361546af01c7d38e/fastmcp-3.3.1-py3-none-any.whl", hash = "sha256:862440c5c4d281363a5995eee59d77f0f7cac1f18869038729cecf03b02fc522", size = 7903, upload-time = "2026-05-15T15:50:36.424Z" },
 ]
 
 [[package]]
-name = "fastmcp"
-version = "2.14.1"
+name = "fastmcp-slim"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a0/627103e517e1d0d6f1eec633d5662d13e776f01b45ad188e4f5f7478b438/fastmcp_slim-3.3.1.tar.gz", hash = "sha256:0957835fc59452e143ab2f4b7836d2d2df9b2d9958408edc79ba8b56232b2a88", size = 567007, upload-time = "2026-05-15T15:50:10.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ee/97047f4cc2d7b1d46670d08d8ad01a96e7a748cc01c0b4b351ad8eddbc7a/fastmcp_slim-3.3.1-py3-none-any.whl", hash = "sha256:6cf1c2d77e3adb0d409d6825ed6b0b2a999062973e00b8eea03bd48bf9b4c043", size = 738644, upload-time = "2026-05-15T15:50:08.336Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
+    { name = "jsonref" },
     { name = "jsonschema-path" },
     { name = "mcp" },
     { name = "openapi-pydantic" },
-    { name = "platformdirs" },
-    { name = "py-key-value-aio", extra = ["disk", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
-    { name = "pydocket" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
-    { name = "rich" },
+    { name = "python-multipart" },
+    { name = "pyyaml" },
+    { name = "uncalled-for" },
     { name = "uvicorn" },
+    { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/50/d38e4371bdc34e709f4731b1e882cb7bc50e51c1a224859d4cd381b3a79b/fastmcp-2.14.1.tar.gz", hash = "sha256:132725cbf77b68fa3c3d165eff0cfa47e40c1479457419e6a2cfda65bd84c8d6", size = 8263331, upload-time = "2025-12-15T02:26:27.102Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/82/72401d09dc27c27fdf72ad6c2fe331e553e3c3646e01b5ff16473191033d/fastmcp-2.14.1-py3-none-any.whl", hash = "sha256:fb3e365cc1d52573ab89caeba9944dd4b056149097be169bce428e011f0a57e5", size = 412176, upload-time = "2025-12-15T02:26:25.356Z" },
 ]
 
 [[package]]
@@ -630,6 +718,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/b5/23b91f22b7b3a7f8f62223f6664946271c0f5cb4179605a3e6bbae863920/griffe-1.13.0.tar.gz", hash = "sha256:246ea436a5e78f7fbf5f24ca8a727bb4d2a4b442a2959052eea3d0bfe9a076e0", size = 412759, upload-time = "2025-08-26T13:27:11.422Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/8c/b7cfdd8dfe48f6b09f7353323732e1a290c388bd14f216947928dc85f904/griffe-1.13.0-py3-none-any.whl", hash = "sha256:470fde5b735625ac0a36296cd194617f039e9e83e301fcbd493e2b58382d0559", size = 139365, upload-time = "2025-08-26T13:27:09.882Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -718,6 +815,7 @@ dependencies = [
     { name = "colorama" },
     { name = "py" },
     { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/22/74f7fcc96280eea46cf2bcbfa1354ac31de0e60a4be6f7966f12cef20893/interrogate-1.7.0.tar.gz", hash = "sha256:a320d6ec644dfd887cc58247a345054fc4d9f981100c45184470068f4b3719b0", size = 159636, upload-time = "2024-04-07T22:30:46.217Z" }
 wheels = [
@@ -782,6 +880,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
 name = "jsbeautifier"
 version = "1.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -792,6 +902,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
+]
+
+[[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]
@@ -855,69 +974,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lupa"
-version = "2.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b8/1c/191c3e6ec6502e3dbe25a53e27f69a5daeac3e56de1f73c0138224171ead/lupa-2.6.tar.gz", hash = "sha256:9a770a6e89576be3447668d7ced312cd6fd41d3c13c2462c9dc2c2ab570e45d9", size = 7240282, upload-time = "2025-10-24T07:20:29.738Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/29/1f66907c1ebf1881735afa695e646762c674f00738ebf66d795d59fc0665/lupa-2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6d988c0f9331b9f2a5a55186701a25444ab10a1432a1021ee58011499ecbbdd5", size = 962875, upload-time = "2025-10-24T07:17:39.107Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/67/4a748604be360eb9c1c215f6a0da921cd1a2b44b2c5951aae6fb83019d3a/lupa-2.6-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:ebe1bbf48259382c72a6fe363dea61a0fd6fe19eab95e2ae881e20f3654587bf", size = 1935390, upload-time = "2025-10-24T07:17:41.427Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/0c/8ef9ee933a350428b7bdb8335a37ef170ab0bb008bbf9ca8f4f4310116b6/lupa-2.6-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:a8fcee258487cf77cdd41560046843bb38c2e18989cd19671dd1e2596f798306", size = 992193, upload-time = "2025-10-24T07:17:43.231Z" },
-    { url = "https://files.pythonhosted.org/packages/65/46/e6c7facebdb438db8a65ed247e56908818389c1a5abbf6a36aab14f1057d/lupa-2.6-cp311-cp311-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:561a8e3be800827884e767a694727ed8482d066e0d6edfcbf423b05e63b05535", size = 1165844, upload-time = "2025-10-24T07:17:45.437Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/26/9f1154c6c95f175ccbf96aa96c8f569c87f64f463b32473e839137601a8b/lupa-2.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af880a62d47991cae78b8e9905c008cbfdc4a3a9723a66310c2634fc7644578c", size = 1048069, upload-time = "2025-10-24T07:17:47.181Z" },
-    { url = "https://files.pythonhosted.org/packages/68/67/2cc52ab73d6af81612b2ea24c870d3fa398443af8e2875e5befe142398b1/lupa-2.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80b22923aa4023c86c0097b235615f89d469a0c4eee0489699c494d3367c4c85", size = 2079079, upload-time = "2025-10-24T07:17:49.755Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/dc/f843f09bbf325f6e5ee61730cf6c3409fc78c010d968c7c78acba3019ca7/lupa-2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:153d2cc6b643f7efb9cfc0c6bb55ec784d5bac1a3660cfc5b958a7b8f38f4a75", size = 1071428, upload-time = "2025-10-24T07:17:51.991Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/60/37533a8d85bf004697449acb97ecdacea851acad28f2ad3803662487dd2a/lupa-2.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:3fa8777e16f3ded50b72967dc17e23f5a08e4f1e2c9456aff2ebdb57f5b2869f", size = 1181756, upload-time = "2025-10-24T07:17:53.752Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/f2/cf29b20dbb4927b6a3d27c339ac5d73e74306ecc28c8e2c900b2794142ba/lupa-2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8dbdcbe818c02a2f56f5ab5ce2de374dab03e84b25266cfbaef237829bc09b3f", size = 2175687, upload-time = "2025-10-24T07:17:56.228Z" },
-    { url = "https://files.pythonhosted.org/packages/94/7c/050e02f80c7131b63db1474bff511e63c545b5a8636a24cbef3fc4da20b6/lupa-2.6-cp311-cp311-win32.whl", hash = "sha256:defaf188fde8f7a1e5ce3a5e6d945e533b8b8d547c11e43b96c9b7fe527f56dc", size = 1412592, upload-time = "2025-10-24T07:17:59.062Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/9a/6f2af98aa5d771cea661f66c8eb8f53772ec1ab1dfbce24126cfcd189436/lupa-2.6-cp311-cp311-win_amd64.whl", hash = "sha256:9505ae600b5c14f3e17e70f87f88d333717f60411faca1ddc6f3e61dce85fa9e", size = 1669194, upload-time = "2025-10-24T07:18:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/94/86/ce243390535c39d53ea17ccf0240815e6e457e413e40428a658ea4ee4b8d/lupa-2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47ce718817ef1cc0c40d87c3d5ae56a800d61af00fbc0fad1ca9be12df2f3b56", size = 951707, upload-time = "2025-10-24T07:18:03.884Z" },
-    { url = "https://files.pythonhosted.org/packages/86/85/cedea5e6cbeb54396fdcc55f6b741696f3f036d23cfaf986d50d680446da/lupa-2.6-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:7aba985b15b101495aa4b07112cdc08baa0c545390d560ad5cfde2e9e34f4d58", size = 1916703, upload-time = "2025-10-24T07:18:05.6Z" },
-    { url = "https://files.pythonhosted.org/packages/24/be/3d6b5f9a8588c01a4d88129284c726017b2089f3a3fd3ba8bd977292fea0/lupa-2.6-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:b766f62f95b2739f2248977d29b0722e589dcf4f0ccfa827ccbd29f0148bd2e5", size = 985152, upload-time = "2025-10-24T07:18:08.561Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/23/9f9a05beee5d5dce9deca4cb07c91c40a90541fc0a8e09db4ee670da550f/lupa-2.6-cp312-cp312-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:00a934c23331f94cb51760097ebfab14b005d55a6b30a2b480e3c53dd2fa290d", size = 1159599, upload-time = "2025-10-24T07:18:10.346Z" },
-    { url = "https://files.pythonhosted.org/packages/40/4e/e7c0583083db9d7f1fd023800a9767d8e4391e8330d56c2373d890ac971b/lupa-2.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21de9f38bd475303e34a042b7081aabdf50bd9bafd36ce4faea2f90fd9f15c31", size = 1038686, upload-time = "2025-10-24T07:18:12.112Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/9f/5a4f7d959d4feba5e203ff0c31889e74d1ca3153122be4a46dca7d92bf7c/lupa-2.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf3bda96d3fc41237e964a69c23647d50d4e28421111360274d4799832c560e9", size = 2071956, upload-time = "2025-10-24T07:18:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/92/34/2f4f13ca65d01169b1720176aedc4af17bc19ee834598c7292db232cb6dc/lupa-2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5a76ead245da54801a81053794aa3975f213221f6542d14ec4b859ee2e7e0323", size = 1057199, upload-time = "2025-10-24T07:18:16.379Z" },
-    { url = "https://files.pythonhosted.org/packages/35/2a/5f7d2eebec6993b0dcd428e0184ad71afb06a45ba13e717f6501bfed1da3/lupa-2.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8dd0861741caa20886ddbda0a121d8e52fb9b5bb153d82fa9bba796962bf30e8", size = 1173693, upload-time = "2025-10-24T07:18:18.153Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/29/089b4d2f8e34417349af3904bb40bec40b65c8731f45e3fd8d497ca573e5/lupa-2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:239e63948b0b23023f81d9a19a395e768ed3da6a299f84e7963b8f813f6e3f9c", size = 2164394, upload-time = "2025-10-24T07:18:20.403Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/1b/79c17b23c921f81468a111cad843b076a17ef4b684c4a8dff32a7969c3f0/lupa-2.6-cp312-cp312-win32.whl", hash = "sha256:325894e1099499e7a6f9c351147661a2011887603c71086d36fe0f964d52d1ce", size = 1420647, upload-time = "2025-10-24T07:18:23.368Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/15/5121e68aad3584e26e1425a5c9a79cd898f8a152292059e128c206ee817c/lupa-2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c735a1ce8ee60edb0fe71d665f1e6b7c55c6021f1d340eb8c865952c602cd36f", size = 1688529, upload-time = "2025-10-24T07:18:25.523Z" },
-    { url = "https://files.pythonhosted.org/packages/28/1d/21176b682ca5469001199d8b95fa1737e29957a3d185186e7a8b55345f2e/lupa-2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:663a6e58a0f60e7d212017d6678639ac8df0119bc13c2145029dcba084391310", size = 947232, upload-time = "2025-10-24T07:18:27.878Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4c/d327befb684660ca13cf79cd1f1d604331808f9f1b6fb6bf57832f8edf80/lupa-2.6-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:d1f5afda5c20b1f3217a80e9bc1b77037f8a6eb11612fd3ada19065303c8f380", size = 1908625, upload-time = "2025-10-24T07:18:29.944Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8e/ad22b0a19454dfd08662237a84c792d6d420d36b061f239e084f29d1a4f3/lupa-2.6-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:26f2b3c085fe76e9119e48c1013c1cccdc1f51585d456858290475aa38e7089e", size = 981057, upload-time = "2025-10-24T07:18:31.553Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/48/74859073ab276bd0566c719f9ca0108b0cfc1956ca0d68678d117d47d155/lupa-2.6-cp313-cp313-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:60d2f902c7b96fb8ab98493dcff315e7bb4d0b44dc9dd76eb37de575025d5685", size = 1156227, upload-time = "2025-10-24T07:18:33.981Z" },
-    { url = "https://files.pythonhosted.org/packages/09/6c/0e9ded061916877253c2266074060eb71ed99fb21d73c8c114a76725bce2/lupa-2.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a02d25dee3a3250967c36590128d9220ae02f2eda166a24279da0b481519cbff", size = 1035752, upload-time = "2025-10-24T07:18:36.32Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ef/f8c32e454ef9f3fe909f6c7d57a39f950996c37a3deb7b391fec7903dab7/lupa-2.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eae1ee16b886b8914ff292dbefbf2f48abfbdee94b33a88d1d5475e02423203", size = 2069009, upload-time = "2025-10-24T07:18:38.072Z" },
-    { url = "https://files.pythonhosted.org/packages/53/dc/15b80c226a5225815a890ee1c11f07968e0aba7a852df41e8ae6fe285063/lupa-2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0edd5073a4ee74ab36f74fe61450148e6044f3952b8d21248581f3c5d1a58be", size = 1056301, upload-time = "2025-10-24T07:18:40.165Z" },
-    { url = "https://files.pythonhosted.org/packages/31/14/2086c1425c985acfb30997a67e90c39457122df41324d3c179d6ee2292c6/lupa-2.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0c53ee9f22a8a17e7d4266ad48e86f43771951797042dd51d1494aaa4f5f3f0a", size = 1170673, upload-time = "2025-10-24T07:18:42.426Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e5/b216c054cf86576c0191bf9a9f05de6f7e8e07164897d95eea0078dca9b2/lupa-2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:de7c0f157a9064a400d828789191a96da7f4ce889969a588b87ec80de9b14772", size = 2162227, upload-time = "2025-10-24T07:18:46.112Z" },
-    { url = "https://files.pythonhosted.org/packages/59/2f/33ecb5bedf4f3bc297ceacb7f016ff951331d352f58e7e791589609ea306/lupa-2.6-cp313-cp313-win32.whl", hash = "sha256:ee9523941ae0a87b5b703417720c5d78f72d2f5bc23883a2ea80a949a3ed9e75", size = 1419558, upload-time = "2025-10-24T07:18:48.371Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/b4/55e885834c847ea610e111d87b9ed4768f0afdaeebc00cd46810f25029f6/lupa-2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b1335a5835b0a25ebdbc75cf0bda195e54d133e4d994877ef025e218c2e59db9", size = 1683424, upload-time = "2025-10-24T07:18:50.976Z" },
-    { url = "https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcb6d0a3264873e1653bc188499f48c1fb4b41a779e315eba45256cfe7bc33c1", size = 953818, upload-time = "2025-10-24T07:18:53.378Z" },
-    { url = "https://files.pythonhosted.org/packages/10/41/27bbe81953fb2f9ecfced5d9c99f85b37964cfaf6aa8453bb11283983721/lupa-2.6-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:a37e01f2128f8c36106726cb9d360bac087d58c54b4522b033cc5691c584db18", size = 1915850, upload-time = "2025-10-24T07:18:55.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/98/f9ff60db84a75ba8725506bbf448fb085bc77868a021998ed2a66d920568/lupa-2.6-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:458bd7e9ff3c150b245b0fcfbb9bd2593d1152ea7f0a7b91c1d185846da033fe", size = 982344, upload-time = "2025-10-24T07:18:57.05Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f7/f39e0f1c055c3b887d86b404aaf0ca197b5edfd235a8b81b45b25bac7fc3/lupa-2.6-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:052ee82cac5206a02df77119c325339acbc09f5ce66967f66a2e12a0f3211cad", size = 1156543, upload-time = "2025-10-24T07:18:59.251Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/9c/59e6cffa0d672d662ae17bd7ac8ecd2c89c9449dee499e3eb13ca9cd10d9/lupa-2.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96594eca3c87dd07938009e95e591e43d554c1dbd0385be03c100367141db5a8", size = 1047974, upload-time = "2025-10-24T07:19:01.449Z" },
-    { url = "https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8faddd9d198688c8884091173a088a8e920ecc96cda2ffed576a23574c4b3f6", size = 2073458, upload-time = "2025-10-24T07:19:03.369Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/10/824173d10f38b51fc77785228f01411b6ca28826ce27404c7c912e0e442c/lupa-2.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:daebb3a6b58095c917e76ba727ab37b27477fb926957c825205fbda431552134", size = 1067683, upload-time = "2025-10-24T07:19:06.2Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/dc/9692fbcf3c924d9c4ece2d8d2f724451ac2e09af0bd2a782db1cef34e799/lupa-2.6-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f3154e68972befe0f81564e37d8142b5d5d79931a18309226a04ec92487d4ea3", size = 1171892, upload-time = "2025-10-24T07:19:08.544Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ff/e318b628d4643c278c96ab3ddea07fc36b075a57383c837f5b11e537ba9d/lupa-2.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e4dadf77b9fedc0bfa53417cc28dc2278a26d4cbd95c29f8927ad4d8fe0a7ef9", size = 2166641, upload-time = "2025-10-24T07:19:10.485Z" },
-    { url = "https://files.pythonhosted.org/packages/12/f7/a6f9ec2806cf2d50826980cdb4b3cffc7691dc6f95e13cc728846d5cb793/lupa-2.6-cp314-cp314-win32.whl", hash = "sha256:cb34169c6fa3bab3e8ac58ca21b8a7102f6a94b6a5d08d3636312f3f02fafd8f", size = 1456857, upload-time = "2025-10-24T07:19:37.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/de/df71896f25bdc18360fdfa3b802cd7d57d7fede41a0e9724a4625b412c85/lupa-2.6-cp314-cp314-win_amd64.whl", hash = "sha256:b74f944fe46c421e25d0f8692aef1e842192f6f7f68034201382ac440ef9ea67", size = 1731191, upload-time = "2025-10-24T07:19:40.281Z" },
-    { url = "https://files.pythonhosted.org/packages/47/3c/a1f23b01c54669465f5f4c4083107d496fbe6fb45998771420e9aadcf145/lupa-2.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0e21b716408a21ab65723f8841cf7f2f37a844b7a965eeabb785e27fca4099cf", size = 999343, upload-time = "2025-10-24T07:19:12.519Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/501994291cb640bfa2ccf7f554be4e6914afa21c4026bd01bff9ca8aac57/lupa-2.6-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:589db872a141bfff828340079bbdf3e9a31f2689f4ca0d88f97d9e8c2eae6142", size = 2000730, upload-time = "2025-10-24T07:19:14.869Z" },
-    { url = "https://files.pythonhosted.org/packages/53/a5/457ffb4f3f20469956c2d4c4842a7675e884efc895b2f23d126d23e126cc/lupa-2.6-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:cd852a91a4a9d4dcbb9a58100f820a75a425703ec3e3f049055f60b8533b7953", size = 1021553, upload-time = "2025-10-24T07:19:17.123Z" },
-    { url = "https://files.pythonhosted.org/packages/51/6b/36bb5a5d0960f2a5c7c700e0819abb76fd9bf9c1d8a66e5106416d6e9b14/lupa-2.6-cp314-cp314t-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:0334753be028358922415ca97a64a3048e4ed155413fc4eaf87dd0a7e2752983", size = 1133275, upload-time = "2025-10-24T07:19:20.51Z" },
-    { url = "https://files.pythonhosted.org/packages/19/86/202ff4429f663013f37d2229f6176ca9f83678a50257d70f61a0a97281bf/lupa-2.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:661d895cd38c87658a34780fac54a690ec036ead743e41b74c3fb81a9e65a6aa", size = 1038441, upload-time = "2025-10-24T07:19:22.509Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/42/d8125f8e420714e5b52e9c08d88b5329dfb02dcca731b4f21faaee6cc5b5/lupa-2.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aa58454ccc13878cc177c62529a2056be734da16369e451987ff92784994ca7", size = 2058324, upload-time = "2025-10-24T07:19:24.979Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/2c/47bf8b84059876e877a339717ddb595a4a7b0e8740bacae78ba527562e1c/lupa-2.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1425017264e470c98022bba8cff5bd46d054a827f5df6b80274f9cc71dafd24f", size = 1060250, upload-time = "2025-10-24T07:19:27.262Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/06/d88add2b6406ca1bdec99d11a429222837ca6d03bea42ca75afa169a78cb/lupa-2.6-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:224af0532d216e3105f0a127410f12320f7c5f1aa0300bdf9646b8d9afb0048c", size = 1151126, upload-time = "2025-10-24T07:19:29.522Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a0/89e6a024c3b4485b89ef86881c9d55e097e7cb0bdb74efb746f2fa6a9a76/lupa-2.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9abb98d5a8fd27c8285302e82199f0e56e463066f88f619d6594a450bf269d80", size = 2153693, upload-time = "2025-10-24T07:19:31.379Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/36/a0f007dc58fc1bbf51fb85dcc82fcb1f21b8c4261361de7dab0e3d8521ef/lupa-2.6-cp314-cp314t-win32.whl", hash = "sha256:1849efeba7a8f6fb8aa2c13790bee988fd242ae404bd459509640eeea3d1e291", size = 1590104, upload-time = "2025-10-24T07:19:33.514Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/5e/db903ce9cf82c48d6b91bf6d63ae4c8d0d17958939a4e04ba6b9f38b8643/lupa-2.6-cp314-cp314t-win_amd64.whl", hash = "sha256:fc1498d1a4fc028bc521c26d0fad4ca00ed63b952e32fb95949bda76a04bad52", size = 1913818, upload-time = "2025-10-24T07:19:36.039Z" },
-]
-
-[[package]]
 name = "markdown"
 version = "3.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -944,6 +1000,16 @@ version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393, upload-time = "2024-10-18T15:20:52.426Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732, upload-time = "2024-10-18T15:20:53.578Z" },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866, upload-time = "2024-10-18T15:20:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964, upload-time = "2024-10-18T15:20:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977, upload-time = "2024-10-18T15:20:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366, upload-time = "2024-10-18T15:20:58.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091, upload-time = "2024-10-18T15:20:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065, upload-time = "2024-10-18T15:21:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514, upload-time = "2024-10-18T15:21:01.122Z" },
     { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
     { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
     { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
@@ -1187,6 +1253,7 @@ dependencies = [
     { name = "griffe" },
     { name = "mkdocs-autorefs" },
     { name = "mkdocstrings" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/ae/58ab2bfbee2792e92a98b97e872f7c003deb903071f75d8d83aa55db28fa/mkdocstrings_python-1.18.2.tar.gz", hash = "sha256:4ad536920a07b6336f50d4c6d5603316fafb1172c5c882370cbbc954770ad323", size = 207972, upload-time = "2025-08-28T16:11:19.847Z" }
 wheels = [
@@ -1209,10 +1276,17 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "pathspec" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01", size = 3352570, upload-time = "2025-07-31T07:54:19.204Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/a9/3d7aa83955617cdf02f94e50aab5c830d205cfa4320cf124ff64acce3a8e/mypy-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3fbe6d5555bf608c47203baa3e72dbc6ec9965b3d7c318aa9a4ca76f465bd972", size = 11003299, upload-time = "2025-07-31T07:54:06.425Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e8/72e62ff837dd5caaac2b4a5c07ce769c8e808a00a65e5d8f94ea9c6f20ab/mypy-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:80ef5c058b7bce08c83cac668158cb7edea692e458d21098c7d3bce35a5d43e7", size = 10125451, upload-time = "2025-07-31T07:53:52.974Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/10/f3f3543f6448db11881776f26a0ed079865926b0c841818ee22de2c6bbab/mypy-1.17.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4a580f8a70c69e4a75587bd925d298434057fe2a428faaf927ffe6e4b9a98df", size = 11916211, upload-time = "2025-07-31T07:53:18.879Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bf/63e83ed551282d67bb3f7fea2cd5561b08d2bb6eb287c096539feb5ddbc5/mypy-1.17.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd86bb649299f09d987a2eebb4d52d10603224500792e1bee18303bbcc1ce390", size = 12652687, upload-time = "2025-07-31T07:53:30.544Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/68f2eeef11facf597143e85b694a161868b3b006a5fbad50e09ea117ef24/mypy-1.17.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a76906f26bd8d51ea9504966a9c25419f2e668f012e0bdf3da4ea1526c534d94", size = 12896322, upload-time = "2025-07-31T07:53:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/87/8e3e9c2c8bd0d7e071a89c71be28ad088aaecbadf0454f46a540bda7bca6/mypy-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:e79311f2d904ccb59787477b7bd5d26f3347789c06fcd7656fa500875290264b", size = 9507962, upload-time = "2025-07-31T07:53:08.431Z" },
     { url = "https://files.pythonhosted.org/packages/46/cf/eadc80c4e0a70db1c08921dcc220357ba8ab2faecb4392e3cebeb10edbfa/mypy-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ad37544be07c5d7fba814eb370e006df58fed8ad1ef33ed1649cb1889ba6ff58", size = 10921009, upload-time = "2025-07-31T07:53:23.037Z" },
     { url = "https://files.pythonhosted.org/packages/5d/c1/c869d8c067829ad30d9bdae051046561552516cfb3a14f7f0347b7d973ee/mypy-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:064e2ff508e5464b4bd807a7c1625bc5047c5022b85c70f030680e18f37273a5", size = 10047482, upload-time = "2025-07-31T07:53:26.151Z" },
     { url = "https://files.pythonhosted.org/packages/98/b9/803672bab3fe03cee2e14786ca056efda4bb511ea02dadcedde6176d06d0/mypy-1.17.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70401bbabd2fa1aa7c43bb358f54037baf0586f41e83b0ae67dd0534fc64edfd", size = 11832883, upload-time = "2025-07-31T07:53:47.948Z" },
@@ -1275,62 +1349,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-exporter-prometheus"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/14/39/7dafa6fff210737267bed35a8855b6ac7399b9e582b8cf1f25f842517012/opentelemetry_exporter_prometheus-0.60b1.tar.gz", hash = "sha256:a4011b46906323f71724649d301b4dc188aaa068852e814f4df38cc76eac616b", size = 14976, upload-time = "2025-12-11T13:32:42.944Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/0d/4be6bf5477a3eb3d917d2f17d3c0b6720cd6cb97898444a61d43cc983f5c/opentelemetry_exporter_prometheus-0.60b1-py3-none-any.whl", hash = "sha256:49f59178de4f4590e3cef0b8b95cf6e071aae70e1f060566df5546fad773b8fd", size = 13019, upload-time = "2025-12-11T13:32:23.974Z" },
-]
-
-[[package]]
-name = "opentelemetry-instrumentation"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/41/0f/7e6b713ac117c1f5e4e3300748af699b9902a2e5e34c9cf443dde25a01fa/opentelemetry_instrumentation-0.60b1.tar.gz", hash = "sha256:57ddc7974c6eb35865af0426d1a17132b88b2ed8586897fee187fd5b8944bd6a", size = 31706, upload-time = "2025-12-11T13:36:42.515Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/d2/6788e83c5c86a2690101681aeef27eeb2a6bf22df52d3f263a22cee20915/opentelemetry_instrumentation-0.60b1-py3-none-any.whl", hash = "sha256:04480db952b48fb1ed0073f822f0ee26012b7be7c3eac1a3793122737c78632d", size = 33096, upload-time = "2025-12-11T13:35:33.067Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.39.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/c76080c9ba07e1e8235d24cdcc4d125ef7aa3edf23eb4e497c2e50889adc/opentelemetry_sdk-1.39.1.tar.gz", hash = "sha256:cf4d4563caf7bff906c9f7967e2be22d0d6b349b908be0d90fb21c8e9c995cc6", size = 171460, upload-time = "2025-12-11T13:32:49.369Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/98/e91cf858f203d86f4eccdf763dcf01cf03f1dae80c3750f7e635bfa206b6/opentelemetry_sdk-1.39.1-py3-none-any.whl", hash = "sha256:4d5482c478513ecb0a5d938dcc61394e647066e0cc2676bee9f3af3f3f45f01c", size = 132565, upload-time = "2025-12-11T13:32:35.069Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.60b1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/df/553f93ed38bf22f4b999d9be9c185adb558982214f33eae539d3b5cd0858/opentelemetry_semantic_conventions-0.60b1.tar.gz", hash = "sha256:87c228b5a0669b748c76d76df6c364c369c28f1c465e50f661e39737e84bc953", size = 137935, upload-time = "2025-12-11T13:32:50.487Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/5e/5958555e09635d09b75de3c4f8b9cae7335ca545d77392ffe7331534c402/opentelemetry_semantic_conventions-0.60b1-py3-none-any.whl", hash = "sha256:9fa8c8b0c110da289809292b0591220d3a7b53c1526a23021e977d68597893fb", size = 219982, upload-time = "2025-12-11T13:32:36.955Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1367,15 +1385,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathvalidate"
-version = "3.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fa/2a/52a8da6fe965dea6192eb716b357558e103aea0a1e9a8352ad575a8406ca/pathvalidate-3.3.1.tar.gz", hash = "sha256:b18c07212bfead624345bb8e1d6141cdcf15a39736994ea0b94035ad2b1ba177", size = 63262, upload-time = "2025-06-15T09:07:20.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/70/875f4a23bfc4731703a5835487d0d2fb999031bd415e7d17c0ae615c18b7/pathvalidate-3.3.1-py3-none-any.whl", hash = "sha256:5263baab691f8e1af96092fa5137ee17df5bdfbd6cff1fcac4d6ef4bc2e1735f", size = 24305, upload-time = "2025-06-15T09:07:19.117Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1391,15 +1400,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.23.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/53/3edb5d68ecf6b38fcbcc1ad28391117d2a322d9a1a3eff04bfdb184d8c3b/prometheus_client-0.23.1.tar.gz", hash = "sha256:6ae8f9081eaaaf153a2e959d2e6c4f4fb57b12ef76c8c7980202f1e57b48b2ce", size = 80481, upload-time = "2025-09-18T20:47:25.043Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/db/14bafcb4af2139e046d03fd00dea7873e48eafe18b7d2797e73d6681f210/prometheus_client-0.23.1-py3-none-any.whl", hash = "sha256:dd1913e6e76b59cfe44e7a4b83e01afc9873c1bdfd2ed8739f1e76aeca115f99", size = 61145, upload-time = "2025-09-18T20:47:23.875Z" },
 ]
 
 [[package]]
@@ -1425,43 +1425,28 @@ wheels = [
 
 [[package]]
 name = "py-key-value-aio"
-version = "0.3.0"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beartype" },
-    { name = "py-key-value-shared" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/93/ce/3136b771dddf5ac905cc193b461eb67967cf3979688c6696e1f2cdcde7ea/py_key_value_aio-0.3.0.tar.gz", hash = "sha256:858e852fcf6d696d231266da66042d3355a7f9871650415feef9fca7a6cd4155", size = 50801, upload-time = "2025-11-17T16:50:04.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/10/72f6f213b8f0bce36eff21fda0a13271834e9eeff7f9609b01afdc253c79/py_key_value_aio-0.3.0-py3-none-any.whl", hash = "sha256:1c781915766078bfd608daa769fefb97e65d1d73746a3dfb640460e322071b64", size = 96342, upload-time = "2025-11-17T16:50:03.801Z" },
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
 ]
 
 [package.optional-dependencies]
-disk = [
-    { name = "diskcache" },
-    { name = "pathvalidate" },
+filetree = [
+    { name = "aiofile", version = "3.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "aiofile", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "anyio" },
 ]
 keyring = [
     { name = "keyring" },
 ]
 memory = [
     { name = "cachetools" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[[package]]
-name = "py-key-value-shared"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "beartype" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/e4/1971dfc4620a3a15b4579fe99e024f5edd6e0967a71154771a059daff4db/py_key_value_shared-0.3.0.tar.gz", hash = "sha256:8fdd786cf96c3e900102945f92aa1473138ebe960ef49da1c833790160c28a4b", size = 11666, upload-time = "2025-11-17T16:50:06.849Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e4/b8b0a03ece72f47dce2307d36e1c34725b7223d209fc679315ffe6a4e2c3/py_key_value_shared-0.3.0-py3-none-any.whl", hash = "sha256:5b0efba7ebca08bb158b1e93afc2f07d30b8f40c2fc12ce24a4c0d84f42f9298", size = 19560, upload-time = "2025-11-17T16:50:05.954Z" },
 ]
 
 [[package]]
@@ -1502,6 +1487,19 @@ dependencies = [
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
     { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
     { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
     { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
@@ -1580,6 +1578,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
     { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
     { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
     { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
     { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
@@ -1602,29 +1608,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/4b/ac7e0aae12027748076d72a8764ff1c9d82ca75a7a52622e67ed3f765c54/pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0", size = 194184, upload-time = "2025-11-10T14:25:47.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/60/5d4751ba3f4a40a6891f24eec885f51afd78d208498268c734e256fb13c4/pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809", size = 51880, upload-time = "2025-11-10T14:25:45.546Z" },
-]
-
-[[package]]
-name = "pydocket"
-version = "0.16.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cloudpickle" },
-    { name = "fakeredis", extra = ["lua"] },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "prometheus-client" },
-    { name = "py-key-value-aio", extra = ["memory", "redis"] },
-    { name = "python-json-logger" },
-    { name = "redis" },
-    { name = "rich" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e0/c5/61dcfce4d50b66a3f09743294d37fab598b81bb0975054b7f732da9243ec/pydocket-0.16.3.tar.gz", hash = "sha256:78e9da576de09e9f3f410d2471ef1c679b7741ddd21b586c97a13872b69bd265", size = 297080, upload-time = "2025-12-23T23:37:33.32Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/94/93b7f5981aa04f922e0d9ce7326a4587866ec7e39f7c180ffcf408e66ee8/pydocket-0.16.3-py3-none-any.whl", hash = "sha256:e2b50925356e7cd535286255195458ac7bba15f25293356651b36d223db5dd7c", size = 67087, upload-time = "2025-12-23T23:37:31.829Z" },
 ]
 
 [[package]]
@@ -1683,10 +1666,12 @@ version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
     { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714, upload-time = "2025-06-18T05:48:06.109Z" }
 wheels = [
@@ -1698,6 +1683,7 @@ name = "pytest-asyncio"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
@@ -1728,21 +1714,12 @@ wheels = [
 ]
 
 [[package]]
-name = "python-json-logger"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
-]
-
-[[package]]
 name = "python-multipart"
-version = "0.0.21"
+version = "0.0.28"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/96/804520d0850c7db98e5ccb70282e29208723f0964e88ffd9d0da2f52ea09/python_multipart-0.0.21.tar.gz", hash = "sha256:7137ebd4d3bbf70ea1622998f902b97a29434a9e8dc40eb203bbcf7c2a2cba92", size = 37196, upload-time = "2025-12-17T09:24:22.446Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/76/03af049af4dcee5d27442f71b6924f01f3efb5d2bd34f23fcd563f2cc5f5/python_multipart-0.0.21-py3-none-any.whl", hash = "sha256:cf7a6713e01c87aa35387f4774e812c4361150938d20d232800f75ffcf266090", size = 24541, upload-time = "2025-12-17T09:24:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
@@ -1759,6 +1736,9 @@ name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
     { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
     { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
     { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
@@ -1788,6 +1768,15 @@ version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz", hash = "sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e", size = 130631, upload-time = "2024-08-06T20:33:50.674Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086", size = 184199, upload-time = "2024-08-06T20:31:40.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf", size = 171758, upload-time = "2024-08-06T20:31:42.173Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237", size = 718463, upload-time = "2024-08-06T20:31:44.263Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b", size = 719280, upload-time = "2024-08-06T20:31:50.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed", size = 751239, upload-time = "2024-08-06T20:31:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180", size = 695802, upload-time = "2024-08-06T20:31:53.836Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68", size = 720527, upload-time = "2024-08-06T20:31:55.565Z" },
+    { url = "https://files.pythonhosted.org/packages/be/aa/5afe99233fb360d0ff37377145a949ae258aaab831bde4792b32650a4378/PyYAML-6.0.2-cp310-cp310-win32.whl", hash = "sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99", size = 144052, upload-time = "2024-08-06T20:31:56.914Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/84/0fa4b06f6d6c958d207620fc60005e241ecedceee58931bb20138e1e5776/PyYAML-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e", size = 161774, upload-time = "2024-08-06T20:31:58.304Z" },
     { url = "https://files.pythonhosted.org/packages/f8/aa/7af4e81f7acba21a4c6be026da38fd2b872ca46226673c89a758ebdc4fd2/PyYAML-6.0.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774", size = 184612, upload-time = "2024-08-06T20:32:03.408Z" },
     { url = "https://files.pythonhosted.org/packages/8b/62/b9faa998fd185f65c1371643678e4d58254add437edb764a08c5a98fb986/PyYAML-6.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee", size = 172040, upload-time = "2024-08-06T20:32:04.926Z" },
     { url = "https://files.pythonhosted.org/packages/ad/0c/c804f5f922a9a6563bab712d8dcc70251e8af811fce4524d57c2c0fd49a4/PyYAML-6.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c", size = 736829, upload-time = "2024-08-06T20:32:06.459Z" },
@@ -1839,18 +1828,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
-]
-
-[[package]]
-name = "redis"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/43/c8/983d5c6579a411d8a99bc5823cc5712768859b5ce2c8afe1a65b37832c81/redis-7.1.0.tar.gz", hash = "sha256:b1cc3cfa5a2cb9c2ab3ba700864fb0ad75617b41f01352ce5779dabf6d5f9c3c", size = 4796669, upload-time = "2025-11-19T15:54:39.961Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/f0/8956f8a86b20d7bb9d6ac0187cf4cd54d8065bc9a1a09eb8011d4d326596/redis-7.1.0-py3-none-any.whl", hash = "sha256:23c52b208f92b56103e17c5d06bdc1a6c2c0b3106583985a76a18f83b265de2b", size = 354159, upload-time = "2025-11-19T15:54:38.064Z" },
 ]
 
 [[package]]
@@ -1914,6 +1891,20 @@ version = "0.27.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz", hash = "sha256:26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8", size = 27479, upload-time = "2025-08-27T12:16:36.024Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/ed/3aef893e2dd30e77e35d20d4ddb45ca459db59cead748cad9796ad479411/rpds_py-0.27.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:68afeec26d42ab3b47e541b272166a0b4400313946871cba3ed3a4fc0cab1cef", size = 371606, upload-time = "2025-08-27T12:12:25.189Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/82/9818b443e5d3eb4c83c3994561387f116aae9833b35c484474769c4a8faf/rpds_py-0.27.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74e5b2f7bb6fa38b1b10546d27acbacf2a022a8b5543efb06cfebc72a59c85be", size = 353452, upload-time = "2025-08-27T12:12:27.433Z" },
+    { url = "https://files.pythonhosted.org/packages/99/c7/d2a110ffaaa397fc6793a83c7bd3545d9ab22658b7cdff05a24a4535cc45/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9024de74731df54546fab0bfbcdb49fae19159ecaecfc8f37c18d2c7e2c0bd61", size = 381519, upload-time = "2025-08-27T12:12:28.719Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bc/e89581d1f9d1be7d0247eaef602566869fdc0d084008ba139e27e775366c/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:31d3ebadefcd73b73928ed0b2fd696f7fefda8629229f81929ac9c1854d0cffb", size = 394424, upload-time = "2025-08-27T12:12:30.207Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/2e/36a6861f797530e74bb6ed53495f8741f1ef95939eed01d761e73d559067/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b2e7f8f169d775dd9092a1743768d771f1d1300453ddfe6325ae3ab5332b4657", size = 523467, upload-time = "2025-08-27T12:12:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/c1bc2be32564fa499f988f0a5c6505c2f4746ef96e58e4d7de5cf923d77e/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d905d16f77eb6ab2e324e09bfa277b4c8e5e6b8a78a3e7ff8f3cdf773b4c013", size = 402660, upload-time = "2025-08-27T12:12:33.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ec/ef8bf895f0628dd0a59e54d81caed6891663cb9c54a0f4bb7da918cb88cf/rpds_py-0.27.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:50c946f048209e6362e22576baea09193809f87687a95a8db24e5fbdb307b93a", size = 384062, upload-time = "2025-08-27T12:12:34.857Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f7/f47ff154be8d9a5e691c083a920bba89cef88d5247c241c10b9898f595a1/rpds_py-0.27.1-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:3deab27804d65cd8289eb814c2c0e807c4b9d9916c9225e363cb0cf875eb67c1", size = 401289, upload-time = "2025-08-27T12:12:36.085Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d9/ca410363efd0615814ae579f6829cafb39225cd63e5ea5ed1404cb345293/rpds_py-0.27.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b61097f7488de4be8244c89915da8ed212832ccf1e7c7753a25a394bf9b1f10", size = 417718, upload-time = "2025-08-27T12:12:37.401Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a0/8cb5c2ff38340f221cc067cc093d1270e10658ba4e8d263df923daa18e86/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8a3f29aba6e2d7d90528d3c792555a93497fe6538aa65eb675b44505be747808", size = 558333, upload-time = "2025-08-27T12:12:38.672Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8c/1b0de79177c5d5103843774ce12b84caa7164dfc6cd66378768d37db11bf/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:dd6cd0485b7d347304067153a6dc1d73f7d4fd995a396ef32a24d24b8ac63ac8", size = 589127, upload-time = "2025-08-27T12:12:41.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/5e/26abb098d5e01266b0f3a2488d299d19ccc26849735d9d2b95c39397e945/rpds_py-0.27.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6f4461bf931108c9fa226ffb0e257c1b18dc2d44cd72b125bec50ee0ab1248a9", size = 554899, upload-time = "2025-08-27T12:12:42.925Z" },
+    { url = "https://files.pythonhosted.org/packages/de/41/905cc90ced13550db017f8f20c6d8e8470066c5738ba480d7ba63e3d136b/rpds_py-0.27.1-cp310-cp310-win32.whl", hash = "sha256:ee5422d7fb21f6a00c1901bf6559c49fee13a5159d0288320737bbf6585bd3e4", size = 217450, upload-time = "2025-08-27T12:12:44.813Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3d/6bef47b0e253616ccdf67c283e25f2d16e18ccddd38f92af81d5a3420206/rpds_py-0.27.1-cp310-cp310-win_amd64.whl", hash = "sha256:3e039aabf6d5f83c745d5f9a0a381d031e9ed871967c0a5c38d201aca41f3ba1", size = 228447, upload-time = "2025-08-27T12:12:46.204Z" },
     { url = "https://files.pythonhosted.org/packages/b5/c1/7907329fbef97cbd49db6f7303893bd1dd5a4a3eae415839ffdfb0762cae/rpds_py-0.27.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:be898f271f851f68b318872ce6ebebbc62f303b654e43bf72683dbdc25b7c881", size = 371063, upload-time = "2025-08-27T12:12:47.856Z" },
     { url = "https://files.pythonhosted.org/packages/11/94/2aab4bc86228bcf7c48760990273653a4900de89c7537ffe1b0d6097ed39/rpds_py-0.27.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:62ac3d4e3e07b58ee0ddecd71d6ce3b1637de2d373501412df395a0ec5f9beb5", size = 353210, upload-time = "2025-08-27T12:12:49.187Z" },
     { url = "https://files.pythonhosted.org/packages/3a/57/f5eb3ecf434342f4f1a46009530e93fd201a0b5b83379034ebdb1d7c1a58/rpds_py-0.27.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4708c5c0ceb2d034f9991623631d3d23cb16e65c83736ea020cdbe28d57c0a0e", size = 381636, upload-time = "2025-08-27T12:12:50.492Z" },
@@ -2002,6 +1993,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/10/6b283707780a81919f71625351182b4f98932ac89a09023cb61865136244/rpds_py-0.27.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f39f58a27cc6e59f432b568ed8429c7e1641324fbe38131de852cd77b2d534b0", size = 555813, upload-time = "2025-08-27T12:15:00.334Z" },
     { url = "https://files.pythonhosted.org/packages/04/2e/30b5ea18c01379da6272a92825dd7e53dc9d15c88a19e97932d35d430ef7/rpds_py-0.27.1-cp314-cp314t-win32.whl", hash = "sha256:d5fa0ee122dc09e23607a28e6d7b150da16c662e66409bbe85230e4c85bb528a", size = 217385, upload-time = "2025-08-27T12:15:01.937Z" },
     { url = "https://files.pythonhosted.org/packages/32/7d/97119da51cb1dd3f2f3c0805f155a3aa4a95fa44fe7d78ae15e69edf4f34/rpds_py-0.27.1-cp314-cp314t-win_amd64.whl", hash = "sha256:6567d2bb951e21232c2f660c24cf3470bb96de56cdcb3f071a83feeaff8a2772", size = 230097, upload-time = "2025-08-27T12:15:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/63/b7cc415c345625d5e62f694ea356c58fb964861409008118f1245f8c3347/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7ba22cb9693df986033b91ae1d7a979bc399237d45fccf875b76f62bb9e52ddf", size = 371360, upload-time = "2025-08-27T12:15:29.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/12e1b24b560cf378b8ffbdb9dc73abd529e1adcfcf82727dfd29c4a7b88d/rpds_py-0.27.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5b640501be9288c77738b5492b3fd3abc4ba95c50c2e41273c8a1459f08298d3", size = 353933, upload-time = "2025-08-27T12:15:30.837Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/85/1bb2210c1f7a1b99e91fea486b9f0f894aa5da3a5ec7097cbad7dec6d40f/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb08b65b93e0c6dd70aac7f7890a9c0938d5ec71d5cb32d45cf844fb8ae47636", size = 382962, upload-time = "2025-08-27T12:15:32.348Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c9/a839b9f219cf80ed65f27a7f5ddbb2809c1b85c966020ae2dff490e0b18e/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7ff07d696a7a38152ebdb8212ca9e5baab56656749f3d6004b34ab726b550b8", size = 394412, upload-time = "2025-08-27T12:15:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2d/b1d7f928b0b1f4fc2e0133e8051d199b01d7384875adc63b6ddadf3de7e5/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fb7c72262deae25366e3b6c0c0ba46007967aea15d1eea746e44ddba8ec58dcc", size = 523972, upload-time = "2025-08-27T12:15:35.377Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/af/2cbf56edd2d07716df1aec8a726b3159deb47cb5c27e1e42b71d705a7c2f/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7b002cab05d6339716b03a4a3a2ce26737f6231d7b523f339fa061d53368c9d8", size = 403273, upload-time = "2025-08-27T12:15:37.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/93/425e32200158d44ff01da5d9612c3b6711fe69f606f06e3895511f17473b/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:23f6b69d1c26c4704fec01311963a41d7de3ee0570a84ebde4d544e5a1859ffc", size = 385278, upload-time = "2025-08-27T12:15:38.571Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1a/1a04a915ecd0551bfa9e77b7672d1937b4b72a0fc204a17deef76001cfb2/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:530064db9146b247351f2a0250b8f00b289accea4596a033e94be2389977de71", size = 402084, upload-time = "2025-08-27T12:15:40.529Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f7/66585c0fe5714368b62951d2513b684e5215beaceab2c6629549ddb15036/rpds_py-0.27.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b90b0496570bd6b0321724a330d8b545827c4df2034b6ddfc5f5275f55da2ad", size = 419041, upload-time = "2025-08-27T12:15:42.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7e/83a508f6b8e219bba2d4af077c35ba0e0cdd35a751a3be6a7cba5a55ad71/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:879b0e14a2da6a1102a3fc8af580fc1ead37e6d6692a781bd8c83da37429b5ab", size = 560084, upload-time = "2025-08-27T12:15:43.839Z" },
+    { url = "https://files.pythonhosted.org/packages/66/66/bb945683b958a1b19eb0fe715594630d0f36396ebdef4d9b89c2fa09aa56/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:0d807710df3b5faa66c731afa162ea29717ab3be17bdc15f90f2d9f183da4059", size = 590115, upload-time = "2025-08-27T12:15:46.647Z" },
+    { url = "https://files.pythonhosted.org/packages/12/00/ccfaafaf7db7e7adace915e5c2f2c2410e16402561801e9c7f96683002d3/rpds_py-0.27.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:3adc388fc3afb6540aec081fa59e6e0d3908722771aa1e37ffe22b220a436f0b", size = 556561, upload-time = "2025-08-27T12:15:48.219Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/b7/92b6ed9aad103bfe1c45df98453dfae40969eef2cb6c6239c58d7e96f1b3/rpds_py-0.27.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c796c0c1cc68cb08b0284db4229f5af76168172670c74908fdbd4b7d7f515819", size = 229125, upload-time = "2025-08-27T12:15:49.956Z" },
     { url = "https://files.pythonhosted.org/packages/0c/ed/e1fba02de17f4f76318b834425257c8ea297e415e12c68b4361f63e8ae92/rpds_py-0.27.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cdfe4bb2f9fe7458b7453ad3c33e726d6d1c7c0a72960bcc23800d77384e42df", size = 371402, upload-time = "2025-08-27T12:15:51.561Z" },
     { url = "https://files.pythonhosted.org/packages/af/7c/e16b959b316048b55585a697e94add55a4ae0d984434d279ea83442e460d/rpds_py-0.27.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:8fabb8fd848a5f75a2324e4a84501ee3a5e3c78d8603f83475441866e60b94a3", size = 354084, upload-time = "2025-08-27T12:15:53.219Z" },
     { url = "https://files.pythonhosted.org/packages/de/c1/ade645f55de76799fdd08682d51ae6724cb46f318573f18be49b1e040428/rpds_py-0.27.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eda8719d598f2f7f3e0f885cba8646644b55a187762bec091fa14a2b819746a9", size = 383090, upload-time = "2025-08-27T12:15:55.158Z" },
@@ -2065,15 +2069,6 @@ wheels = [
 ]
 
 [[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2089,15 +2084,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5", size = 22329, upload-time = "2025-01-02T07:14:40.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e", size = 24303, upload-time = "2025-01-02T07:14:38.724Z" },
-]
-
-[[package]]
-name = "sortedcontainers"
-version = "2.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]
@@ -2154,27 +2140,66 @@ wheels = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
 name = "tomlkit"
 version = "0.13.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
-]
-
-[[package]]
-name = "typer"
-version = "0.20.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/c1/933d30fd7a123ed981e2a1eedafceab63cb379db0402e438a13bc51bbb15/typer-0.20.1.tar.gz", hash = "sha256:68585eb1b01203689c4199bc440d6be616f0851e9f0eb41e4a778845c5a0fd5b", size = 105968, upload-time = "2025-12-19T16:48:56.302Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/52/1f2df7e7d1be3d65ddc2936d820d4a3d9777a54f4204f5ca46b8513eff77/typer-0.20.1-py3-none-any.whl", hash = "sha256:4b3bde918a67c8e03d861aa02deca90a95bbac572e71b1b9be56ff49affdb5a8", size = 47381, upload-time = "2025-12-19T16:48:53.679Z" },
 ]
 
 [[package]]
@@ -2229,6 +2254,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2244,6 +2278,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
@@ -2256,6 +2291,9 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/56/90994d789c61df619bfc5ce2ecdabd5eeff564e1eb47512bd01b5e019569/watchdog-6.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d1cdb490583ebd691c012b3d6dae011000fe42edb7a82ece80965b42abd61f26", size = 96390, upload-time = "2024-11-01T14:06:24.793Z" },
+    { url = "https://files.pythonhosted.org/packages/55/46/9a67ee697342ddf3c6daa97e3a587a56d6c4052f881ed926a849fcf7371c/watchdog-6.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bc64ab3bdb6a04d69d4023b29422170b74681784ffb9463ed4870cf2f3e66112", size = 88389, upload-time = "2024-11-01T14:06:27.112Z" },
+    { url = "https://files.pythonhosted.org/packages/44/65/91b0985747c52064d8701e1075eb96f8c40a79df889e59a399453adfb882/watchdog-6.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c897ac1b55c5a1461e16dae288d22bb2e412ba9807df8397a635d88f671d36c3", size = 89020, upload-time = "2024-11-01T14:06:29.876Z" },
     { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
     { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
     { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
@@ -2265,6 +2303,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
     { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
     { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ad/d17b5d42e28a8b91f8ed01cb949da092827afb9995d4559fd448d0472763/watchdog-6.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:c7ac31a19f4545dd92fc25d200694098f42c9a8e391bc00bdd362c5736dbf881", size = 87902, upload-time = "2024-11-01T14:06:53.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ca/c3649991d140ff6ab67bfc85ab42b165ead119c9e12211e08089d763ece5/watchdog-6.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:9513f27a1a582d9808cf21a07dae516f0fab1cf2d7683a742c498b93eedabb11", size = 88380, upload-time = "2024-11-01T14:06:55.19Z" },
     { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
     { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
     { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
@@ -2275,6 +2315,109 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
 ]
 
 [[package]]
@@ -2292,6 +2435,17 @@ version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/da/6462a9f510c0c49837bbc9345aca92d767a56c1fb2939e1579df1e1cdcf7/websockets-15.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d63efaa0cd96cf0c5fe4d581521d9fa87744540d4bc999ae6e08595a1014b45b", size = 175423, upload-time = "2025-03-05T20:01:35.363Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/9f/9d11c1a4eb046a9e106483b9ff69bce7ac880443f00e5ce64261b47b07e7/websockets-15.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac60e3b188ec7574cb761b08d50fcedf9d77f1530352db4eef1707fe9dee7205", size = 173080, upload-time = "2025-03-05T20:01:37.304Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4f/b462242432d93ea45f297b6179c7333dd0402b855a912a04e7fc61c0d71f/websockets-15.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5756779642579d902eed757b21b0164cd6fe338506a8083eb58af5c372e39d9a", size = 173329, upload-time = "2025-03-05T20:01:39.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0c/6afa1f4644d7ed50284ac59cc70ef8abd44ccf7d45850d989ea7310538d0/websockets-15.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdfe3e2a29e4db3659dbd5bbf04560cea53dd9610273917799f1cde46aa725e", size = 182312, upload-time = "2025-03-05T20:01:41.815Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d4/ffc8bd1350b229ca7a4db2a3e1c482cf87cea1baccd0ef3e72bc720caeec/websockets-15.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c2529b320eb9e35af0fa3016c187dffb84a3ecc572bcee7c3ce302bfeba52bf", size = 181319, upload-time = "2025-03-05T20:01:43.967Z" },
+    { url = "https://files.pythonhosted.org/packages/97/3a/5323a6bb94917af13bbb34009fac01e55c51dfde354f63692bf2533ffbc2/websockets-15.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac1e5c9054fe23226fb11e05a6e630837f074174c4c2f0fe442996112a6de4fb", size = 181631, upload-time = "2025-03-05T20:01:46.104Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/cc/1aeb0f7cee59ef065724041bb7ed667b6ab1eeffe5141696cccec2687b66/websockets-15.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5df592cd503496351d6dc14f7cdad49f268d8e618f80dce0cd5a36b93c3fc08d", size = 182016, upload-time = "2025-03-05T20:01:47.603Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f9/c86f8f7af208e4161a7f7e02774e9d0a81c632ae76db2ff22549e1718a51/websockets-15.0.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:0a34631031a8f05657e8e90903e656959234f3a04552259458aac0b0f9ae6fd9", size = 181426, upload-time = "2025-03-05T20:01:48.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/b9/828b0bc6753db905b91df6ae477c0b14a141090df64fb17f8a9d7e3516cf/websockets-15.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3d00075aa65772e7ce9e990cab3ff1de702aa09be3940d1dc88d5abf1ab8a09c", size = 181360, upload-time = "2025-03-05T20:01:50.938Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/250f5533ec468ba6327055b7d98b9df056fb1ce623b8b6aaafb30b55d02e/websockets-15.0.1-cp310-cp310-win32.whl", hash = "sha256:1234d4ef35db82f5446dca8e35a7da7964d02c127b095e172e54397fb6a6c256", size = 176388, upload-time = "2025-03-05T20:01:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/46/aca7082012768bb98e5608f01658ff3ac8437e563eca41cf068bd5849a5e/websockets-15.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:39c1fec2c11dc8d89bba6b2bf1556af381611a173ac2b511cf7231622058af41", size = 176830, upload-time = "2025-03-05T20:01:53.922Z" },
     { url = "https://files.pythonhosted.org/packages/9f/32/18fcd5919c293a398db67443acd33fde142f283853076049824fc58e6f75/websockets-15.0.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:823c248b690b2fd9303ba00c4f66cd5e2d8c3ba4aa968b2779be9532a4dad431", size = 175423, upload-time = "2025-03-05T20:01:56.276Z" },
     { url = "https://files.pythonhosted.org/packages/76/70/ba1ad96b07869275ef42e2ce21f07a5b0148936688c2baf7e4a1f60d5058/websockets-15.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678999709e68425ae2593acf2e3ebcbcf2e69885a5ee78f9eb80e6e371f1bf57", size = 173082, upload-time = "2025-03-05T20:01:57.563Z" },
     { url = "https://files.pythonhosted.org/packages/86/f2/10b55821dd40eb696ce4704a87d57774696f9451108cff0d2824c97e0f97/websockets-15.0.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d50fd1ee42388dcfb2b3676132c78116490976f1300da28eb629272d5d93e905", size = 173330, upload-time = "2025-03-05T20:01:59.063Z" },
@@ -2325,66 +2479,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/d40f779fa16f74d3468357197af8d6ad07e7c5a27ea1ca74ceb38986f77a/websockets-15.0.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0c9e74d766f2818bb95f84c25be4dea09841ac0f734d1966f415e4edfc4ef1c3", size = 173109, upload-time = "2025-03-05T20:03:17.769Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/cd/5b887b8585a593073fd92f7c23ecd3985cd2c3175025a91b0d69b0551372/websockets-15.0.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:1009ee0c7739c08a0cd59de430d6de452a55e42d6b522de7aa15e6f67db0b8e1", size = 173343, upload-time = "2025-03-05T20:03:19.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/d34f7556890341e900a95acf4886833646306269f899d58ad62f588bf410/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76d1f20b1c7a2fa82367e04982e708723ba0e7b8d43aa643d3dcd404d74f1475", size = 174599, upload-time = "2025-03-05T20:03:21.1Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e6/5fd43993a87db364ec60fc1d608273a1a465c0caba69176dd160e197ce42/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f29d80eb9a9263b8d109135351caf568cc3f80b9928bccde535c235de55c22d9", size = 174207, upload-time = "2025-03-05T20:03:23.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "1.17.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
-    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
-    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
-    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
-    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
-    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
-    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
-    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
-    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
-    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
-    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
-    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
-    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
-    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
-    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
-    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds official ADIF 3.1.7 spec resources alongside the sealed 3.1.6 set. Pure additive — no breaking changes, no clients have to change anything.

**Tracks** the natural follow-on from the fleet [`get_version_info` rollout](https://github.com/IONIS-AI/ionis-devel/issues/49) (closed). `get_version_info` now reports `{service_version: "1.1.0", adif_spec_version: "3.1.7"}`.

## New enum entries (from upstream `ADIF_317_resources_2026_03_22.zip`)

| Type | Value | Parent | Description |
|---|---|---|---|
| Mode | OFDM | — | Orthogonal Frequency-Division Multiplexing, including COFDM |
| Submode | FT2 | MFSK | (no spec description) |
| Submode | FREEDATA | DYNAMIC | (no spec description) |
| Submode | RIBBIT_PIX | OFDM | Images transmitted using Ribbit |
| Submode | RIBBIT_SMS | OFDM | (no spec description) |

## Resource set

- `src/adif_mcp/resources/spec/317/` — full 30-file canonical 3.1.7 JSON (29 official from upstream ZIP + project-internal `enumerations_country.json` carried forward unchanged)
- `test/data/ADIF_317_test_QSOs_2026_03_22.adi` — official G3ZOD test corpus (6,197 records, +6 over 3.1.6, exercises new enum values)

## Default spec switched to 3.1.7

- `__adif_spec__ = "3.1.7"` (was `"3.1.6"`)
- `[tool.adif] spec_version = "3.1.7"`
- `[tool.adif_mcp] spec = "ADIF_317"`
- `get_spec_text(version=...)` default = `"317"`
- `adif_catalog.json` + `adif_meta.json` bumped

## Sealed for backward compatibility

- `src/adif_mcp/resources/spec/316/` — untouched
- `test/data/ADIF_316_test_QSOs_2025_09_15.adi` — untouched
- Callers explicitly pinning `version="316"` continue to work

## Tests

- 6 new tests covering each new enum entry + total submode count (`test_317_new_mode_ofdm`, `test_317_new_submode_ft2`, `test_317_new_submode_freedata`, `test_317_new_submode_ribbit_pix`, `test_317_new_submode_ribbit_sms`, `test_317_submode_count`)
- `test_list_enumerations_has_mode`: Mode record_count expectation 90 → 91 (OFDM is not import-only, so `import_only_count` stays 42)
- `test_official_adif_test_file_zero_errors`: corpus filename + record count 6191 → 6197
- `test_pkg_meta_exposed`: allowed `__adif_spec__` set extended to include `"3.1.7"`

**Full suite: 108/108 pass.**

## Architecture note

Package version (1.0.5 → 1.1.0) and ADIF spec version (3.1.6 → 3.1.7) intentionally bumped independently per the fleet `{service_version, spec_version}` convention. Coupling the two numbers would force fake spec bumps for bug fixes and prevent independent rev of the package.

## References

- Upstream changes: https://adif.org.uk/317/ADIF_317_annotated.htm
- Upstream resources ZIP: https://adif.org.uk/317/ADIF_317_resources_2026_03_22.zip