### PR TITLE
fix: list_enumerations docstring '25' vs actual 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- Docstring in `list_enumerations` said "25 ADIF 3.1.7 enumerations" but actual count is 26 (per live tool and spec resources). Updated to remove hardcoded count for accuracy.
+
 ## [1.1.0] - 2026-05-16
 
 ### Added

--- a/src/adif_mcp/mcp/server.py
+++ b/src/adif_mcp/mcp/server.py
@@ -545,7 +545,7 @@ def read_specification_resource(resource_name: str) -> str:
 
 @mcp.tool()
 def list_enumerations() -> Dict[str, Any]:
-    """Lists all 25 ADIF 3.1.7 enumerations with record counts and fields."""
+    """Lists all ADIF 3.1.7 enumerations with record counts and fields."""
     result: Dict[str, Any] = {}
     for enum_name, fields in ENUMERATION_FIELDS.items():
         records = _load_enum_records(enum_name)


### PR DESCRIPTION
Fixes minor docstring drift for enumeration count (now 26 per 3.1.7).

Closes #5

Co-Authored-By: Grok (xAI)