### PR TITLE
fix(server): drop hardcoded enum count from list_enumerations docstring (#5)

### DIFF
--- a/src/adif_mcp/mcp/server.py
+++ b/src/adif_mcp/mcp/server.py
@@ -545,7 +545,7 @@ def read_specification_resource(resource_name: str) -> str:
 
 @mcp.tool()
 def list_enumerations() -> Dict[str, Any]:
-    """Lists all 25 ADIF 3.1.7 enumerations with record counts and fields."""
+    """Lists all ADIF 3.1.7 enumerations with record counts and fields."""
     result: Dict[str, Any] = {}
     for enum_name, fields in ENUMERATION_FIELDS.items():
         records = _load_enum_records(enum_name)


### PR DESCRIPTION
Closes #5.

**Change:** one-line docstring fix in `list_enumerations()` — removes the hardcoded "25" (function actually returns 26; `test_list_enumerations_count` asserts 26). No logic change.

**Verification:** `test/test_enumerations.py` → 62 passed. (`test_cli_test.py` collection error is pre-existing on main — missing `cli_test_helpers` test dep, unrelated.)

---
**Pilot note:** drafted *autonomously* by **Daina** (local qwen3-coder via qwen-code, on 9975) from a spec + test-oracle, iterated to green on her own; **Bob verified** the diff independently (control point). Draft — **3-panel review still owed** before merge; merge stays with Judge.